### PR TITLE
browser tests updated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "juice-shop",
   "description": "An intentionally insecure Javascript Web Application",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "private": true,
   "dependencies": {
     "angular": "~1.4.8",

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -7,13 +7,19 @@ module.exports = function (config) {
             base: 'SauceLabs',
             browserName: 'chrome',
             platform : 'Linux',
-            version: '37'
+            version: '46'
         },
         sl_firefox: {
             base: 'SauceLabs',
             browserName: 'firefox',
             platform: 'Linux',
-            version: '33'
+            version: '42'
+        },
+        sl_edge_20: {
+            base: 'SauceLabs',
+            browserName: 'MicrosoftEdge',
+            platform: 'Windows 10',
+            version: '20'
         },
         sl_ie_11: {
             base: 'SauceLabs',
@@ -21,23 +27,17 @@ module.exports = function (config) {
             platform: 'Windows 8.1',
             version: '11'
         },
-        sl_ie_10: {
-            base: 'SauceLabs',
-            browserName: 'internet explorer',
-            platform: 'Windows 8',
-            version: '10'
-        },
         sl_ie_9: {
             base: 'SauceLabs',
             browserName: 'internet explorer',
             platform: 'Windows 7',
-            version: '9'
+            version: '10'
         },
         sl_safari: {
             base: 'SauceLabs',
             browserName: 'safari',
-            platform: 'OS X 10.9',
-            version: '7'
+            platform: 'OS X 10.11',
+            version: '9'
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "juice-shop",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "description": "An intentionally insecure Javascript Web Application",
     "homepage": "http://bkimminich.github.io/juice-shop/",
     "author": "Bjoern Kimminich",


### PR DESCRIPTION
now unit testing on
- Chrome 46 and Firefox 42 on Linux
- Edge 20 on Win 10
- IE 11 on Win 8.1
- IE 10 on Win 7
- Safari 9 on OS X 10.11

removed unit testing on
- Win 8.0
- IE 9

still e2e testing on
- Latest Chrome on Win 7

Note: Due to limitations of @saucelabs for OSS projects to 5 concurrent VMs, build frequency on @travis-ci had to be reduced to 2 concurrent jobs to avoid timeouts.
