### PR TITLE
Fix for ratings not appearing on Administration page

### DIFF
--- a/app/views/Administration.html
+++ b/app/views/Administration.html
@@ -34,7 +34,7 @@
                 <td>{{feedback.UserId}}</td>
                 <td><div ng-bind-html="feedback.comment"></div></td>
                 <td>
-                    <rating max="5" ng-model="feedback.rating" readonly="true" class="nowrap"></rating>
+                    <span uib-rating max="5" ng-model="feedback.rating" read-only="true" class="nowrap"/>
                 </td>
                 <td>
                     <div class="btn-group">


### PR DESCRIPTION
Due to the new bootstrap UI, ratings weren't appearing on the administration page. This made it difficult to complete the challenge that involved deleting the 5 star ratings.
