### PR TITLE
Changed Docker Baseimage to node-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # OWASP Juice Shop - An intentionally insecure Javascript Web Application
-FROM            node:6
+FROM            node:6-alpine
 MAINTAINER      Bjoern Kimminich <bjoern.kimminich@owasp.org>
 LABEL version = "2.26.0-SNAPSHOT"
 

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -1,5 +1,5 @@
 # OWASP Juice Shop - An intentionally insecure Javascript Web Application
-FROM            node:%%NODE_VERSION%%
+FROM            node:%%NODE_VERSION%%-alpine
 MAINTAINER      Bjoern Kimminich <bjoern.kimminich@owasp.org>
 LABEL version = "%%APP_VERSION%%"
 

--- a/node4.df
+++ b/node4.df
@@ -1,5 +1,5 @@
 # OWASP Juice Shop - An intentionally insecure Javascript Web Application
-FROM            node:4
+FROM            node:4-alpine
 MAINTAINER      Bjoern Kimminich <bjoern.kimminich@owasp.org>
 LABEL version = "2.26.0-SNAPSHOT"
 

--- a/node6.df
+++ b/node6.df
@@ -1,5 +1,5 @@
 # OWASP Juice Shop - An intentionally insecure Javascript Web Application
-FROM            node:6
+FROM            node:6-alpine
 MAINTAINER      Bjoern Kimminich <bjoern.kimminich@owasp.org>
 LABEL version = "2.26.0-SNAPSHOT"
 

--- a/node7.df
+++ b/node7.df
@@ -1,5 +1,5 @@
 # OWASP Juice Shop - An intentionally insecure Javascript Web Application
-FROM            node:7
+FROM            node:7-alpine
 MAINTAINER      Bjoern Kimminich <bjoern.kimminich@owasp.org>
 LABEL version = "2.26.0-SNAPSHOT"
 


### PR DESCRIPTION
Hi!
I made a small change to the Dockerfile Template so that it is now based on the node-alpine images which are a lot smaller then the regular node images.

I build the images locally for a comparison and to test them.
Here is a overview of the size differences:
```
juice-shop-alpine                6                  267 MB
juice-shop-alpine                latest             267 MB
juice-shop-alpine                7                  272 MB
juice-shop-alpine                4                  379 MB
bkimminich/juice-shop            latest             869 MB
```

The base RAM usage of the containers will also decrease by a bit (in a small tests on my machine ram usage went from ~150MB to ~110MB)