### PR TITLE
Added Scoreboard Autoupdate as suggested in #307.

### DIFF
--- a/app/js/controllers/ChallengeController.js
+++ b/app/js/controllers/ChallengeController.js
@@ -7,7 +7,8 @@ angular.module('juiceShop').controller('ChallengeController', [
   '$window',
   'ChallengeService',
   'ConfigurationService',
-  function ($scope, $sce, $translate, $cookies, $uibModal, $window, challengeService, configurationService) {
+  'socket',
+  function ($scope, $sce, $translate, $cookies, $uibModal, $window, challengeService, configurationService, socket) {
     'use strict'
 
     configurationService.getApplicationConfiguration().then(function (data) {
@@ -56,11 +57,15 @@ angular.module('juiceShop').controller('ChallengeController', [
       })
     }
 
-    challengeService.find().then(function (challenges) {
-      $scope.challenges = challenges
-      var solvedChallenges = 0
+    $scope.trustDescriptionHtml = function () {
       for (var i = 0; i < $scope.challenges.length; i++) {
         $scope.challenges[i].description = $sce.trustAsHtml($scope.challenges[i].description)
+      }
+    }
+
+    $scope.calculateProgressPercentage = function () {
+      var solvedChallenges = 0
+      for (var i = 0; i < $scope.challenges.length; i++) {
         solvedChallenges += ($scope.challenges[i].solved) ? 1 : 0
       }
       $scope.percentChallengesSolved = (100 * solvedChallenges / $scope.challenges.length).toFixed(0)
@@ -71,8 +76,26 @@ angular.module('juiceShop').controller('ChallengeController', [
       } else {
         $scope.completionColor = 'danger'
       }
+    }
+
+    challengeService.find().then(function (challenges) {
+      $scope.challenges = challenges
+      $scope.trustDescriptionHtml()
+      $scope.calculateProgressPercentage()
     }).catch(function (err) {
       console.log(err)
+    })
+
+    socket.on('challenge solved', function (data) {
+      if (data && data.challenge) {
+        for (var i = 0; i < $scope.challenges.length; i++) {
+          if ($scope.challenges[i].name === data.name) {
+            $scope.challenges[i].solved = true
+            break
+          }
+        }
+        $scope.calculateProgressPercentage()
+      }
     })
 
     challengeService.continueCode().then(function (continueCode) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -103,6 +103,7 @@ exports.notify = function (challenge) {
   if (!this.notSolved(challenge)) {
     var flag = this.toHmac(challenge.name)
     var notification = {
+      name: challenge.name,
       challenge: challenge.name + ' (' + challenge.description + ')',
       flag: flag,
       hidden: !config.get('application.showChallengeSolvedNotifications')

--- a/test/client/challengeControllerSpec.js
+++ b/test/client/challengeControllerSpec.js
@@ -139,6 +139,34 @@ describe('controllers', function () {
       }))
     })
 
+    describe('live updates', function () {
+      var socket
+
+      beforeEach(inject(function (_socket_) {
+        socket = _socket_
+        $httpBackend.whenGET('/rest/continue-code').respond(200, {})
+        $httpBackend.whenGET('/api/Challenges/').respond(200, {
+          data: [
+            {name: 'Challenge #1', solved: false},
+            {name: 'Challenge #2', solved: false}
+          ]
+        })
+        $httpBackend.flush()
+      }))
+
+      it('should update the correct challenge when a challenge solved event occurs', inject(function () {
+        socket.receive('challenge solved', { challenge: 'ping', name: 'Challenge #1' })
+        expect(scope.challenges[ 0 ].solved).toBe(true)
+        expect(scope.challenges[ 1 ].solved).toBe(false)
+      }))
+
+      it('should not update when a challenge solved event to a nonexistent challenge occurs', inject(function () {
+        socket.receive('challenge solved', { challenge: 'ping', name: 'Challenge #1337' })
+        expect(scope.challenges[ 0 ].solved).toBe(false)
+        expect(scope.challenges[ 1 ].solved).toBe(false)
+      }))
+    })
+
     describe('loading current continue code', function () {
       beforeEach(inject(function ($httpBackend) {
         $httpBackend.whenGET('/api/Challenges/').respond(200, { data: [] })


### PR DESCRIPTION
The challenge controller responsible for the scoreboard is now listening to the 'challenge solved' web socket and will update the model automatically when a new challenge was solved.