### PR TITLE
refine docker usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Feel free to have a look at the latest version of OWASP Juice Shop:
 1. Install [Docker](https://www.docker.com)
 2. Run `docker pull bkimminich/juice-shop`
 3. Run `docker run -d -p 3000:3000 bkimminich/juice-shop`
-4. Browse to <http://localhost:3000> (on macOS browse to
-   <http://192.168.99.100:3000> instead)
+4. Browse to <http://localhost:3000> 
+   (on macOS and Windows browse to <http://192.168.99.100:3000> if you are using docker-machine instead of the native docker installation )
 
 #### Even easier: Run Docker Container from Docker Toolbox (Kitematic)
 


### PR DESCRIPTION
docker has been available as native windows/macOS installation for about a year and is considered "stable", see https://docs.docker.com/docker-for-mac/install/#download-docker-for-mac