### PR TITLE
Added .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+node_modules/
+screenshots/
+test/
+build/
+docker/
+vagrant/


### PR DESCRIPTION
Hi!
I got another improvement to the size of the docker images. This one is way smaller thought...

I added a .dockerignore file to make sure only runtime essential files will get copied into the docker images. 

Especially the .git folder is relatively big and is not at all required to run the juice-shop inside the container.

On my local machine this changed the uncompressed size of the images like the following:
without-dockerignore: 346MB
with-dockerignore: 259MB

This differences will probably be way smaller once the iamges get compressed but it might save a few mbs.