### PR TITLE
Config option to hide the version number

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,7 @@ application:
   showCtfFlagsInNotifications: false
   showGitHubRibbon: true
   showChallengeHints: true
+  showVersionNumber: true
   theme: "slate" # Options: cerulean  cosmo  cyborg  darkly  flatly lumen  paper  readable  sandstone  simplex  slate  spacelab  superhero  united  yeti
   twitterUrl: "https://twitter.com/owasp_juiceshop"
   facebookUrl: "https://www.facebook.com/owasp.juiceshop"

--- a/routes/appVersion.js
+++ b/routes/appVersion.js
@@ -1,7 +1,11 @@
 const utils = require('../lib/utils')
+const config = require('config');
+
 
 exports = module.exports = function retrieveAppVersion () {
   return (req, res) => {
-    res.json({ version: utils.version() })
+    res.json({
+      version: config.get('application.showVersionNumber') ? utils.version() : ''
+    })
   }
 }

--- a/routes/appVersion.js
+++ b/routes/appVersion.js
@@ -1,6 +1,5 @@
 const utils = require('../lib/utils')
-const config = require('config');
-
+const config = require('config')
 
 exports = module.exports = function retrieveAppVersion () {
   return (req, res) => {


### PR DESCRIPTION
Hi!
Added a config option to "hide" the juice shop version number.

This should help white labeling the JuiceShop in CTF environments and make cheating (by googeling for the solutions) just a bit harder 😅