### PR TITLE
Use stryker-javascript-mutator

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "stryker-api": "~0",
     "stryker-html-reporter": "~0",
     "stryker-jasmine": "~0",
+    "stryker-javascript-mutator": "~0",
     "stryker-karma-runner": "~0",
     "stryker-mocha-runner": "~0"
   },

--- a/stryker.client-conf.js
+++ b/stryker.client-conf.js
@@ -7,6 +7,7 @@ module.exports = function (config) {
     testRunner: 'karma',
     testFramework: 'jasmine',
     coverageAnalysis: 'perTest',
+    mutator: 'javascript',
     reporter: ['html', 'progress'],
     htmlReporter: {
       baseDir: 'build/reports/mutation/client'

--- a/stryker.server-conf.js
+++ b/stryker.server-conf.js
@@ -18,6 +18,7 @@ module.exports = function (config) {
     testRunner: 'mocha',
     testFramework: 'mocha',
     coverageAnalysis: 'perTest',
+    mutator: 'javascript',
     reporter: ['html', 'progress'],
     htmlReporter: {
       baseDir: 'build/reports/mutation/server'


### PR DESCRIPTION
The existing mutator in stryker will be removed in the future. It has been migrated to the stryker-javascript-mutator package. More info can be found in our [blog post](https://stryker-mutator.github.io/blog/2017-12-01/babel-support.html).