### PR TITLE
Simplify Vagrant setup

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -5,16 +5,12 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.hostname = "juice.sh"
 
-  config.vm.provision "shell", inline: "sudo mkdir -p /var/www/html && chmod 777 /var/www/html" 
-
   config.vm.network "private_network", ip: "192.168.33.10"
-  config.vm.provision "file", source: "./logger.php", destination: "/var/www/html/logger.php"
-  config.vm.provision "file", source: "./shake.js", destination: "/var/www/html/shake.js"
+
+  config.vm.provision "file", source: "./logger.php", destination: "/tmp/juice-shop/logger.php"
+  config.vm.provision "file", source: "./shake.js", destination: "/tmp/juice-shop/shake.js"
+  config.vm.provision "file", source: "./default.conf", destination: "/tmp/juice-shop/default.conf"
 
   config.vm.provision :shell, path: "bootstrap.sh"
-
-  config.vm.provision "shell", inline: "sudo mkdir -p /etc/apache2/sites-enabled/ && sudo chmod -R 777 /etc/apache2/sites-available/" 
-  config.vm.provision "file", source: "./default.conf", destination: "/etc/apache2/sites-available/000-default.conf"
-  config.vm.provision :shell, path: "bootstrap-post.sh"
 
 end

--- a/vagrant/bootstrap-post.sh
+++ b/vagrant/bootstrap-post.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-systemctl restart apache2

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,14 +1,23 @@
 #!/bin/sh
 
-curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
-apt-get install -y apache2
-
+# Add docker key and repository
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" | sudo tee /etc/apt/sources.list.d/docker.list
-apt-get update
-apt-get install -y docker-engine
 
-a2enmod proxy_http
-systemctl restart apache2
 
+# Install apache and docker
+apt-get update -q
+apt-get upgrade -qy
+apt-get install -qy apache2 docker-engine
+
+# Put the relevant files in place
+cp /tmp/juice-shop/shake.js /var/www/html
+cp /tmp/juice-shop/logger.php /var/www/html
+cp /tmp/juice-shop/default.conf /etc/apache2/sites-available/000-default.conf
+
+# Download and start docker image with Juice Shop
 docker run --restart=always -d -p 3000:3000 bkimminich/juice-shop
+
+# Enable proxy modules in apache and restart
+a2enmod proxy_http
+systemctl restart apache2.service

--- a/vagrant/default.conf
+++ b/vagrant/default.conf
@@ -1,11 +1,11 @@
 <VirtualHost *:80>
  ServerAdmin webmaster@juice-sh.op
- ServerName 192.168.33.10
+ ServerName juice-sh.op
 
- proxypass /logger.php !
- proxypass /shake.js !
- proxypass / http://localhost:3000/
- proxypassreverse / http://localhost:3000
+ ProxyPass /logger.php !
+ ProxyPass /shake.js !
+ ProxyPass / http://localhost:3000/
+ ProxyPassReverse / http://localhost:3000
 
  DocumentRoot /var/www/html
 


### PR DESCRIPTION
* Made the `Vagrantfile` simpler, and don't mess with permissions of
  the Apache dirs

* Consolidated the two provision scripts into one, and commented that
  provision script.

* Clean up the provision script (no need to add the node repository)

* Minor clean up of the apache `default.conf` file

Maybe this will fix #434, at least it works for me using Vagrant 2.0.2 on MacOS.
