### PR TITLE
Fix failing test in serverStartedNotificationControllerSpec.js

### DIFF
--- a/test/client/controllers/serverStartedNotificationControllerSpec.js
+++ b/test/client/controllers/serverStartedNotificationControllerSpec.js
@@ -20,6 +20,9 @@ describe('controllers', function () {
       controller = $controller('ServerStartedNotificationController', {
         '$scope': scope
       })
+      if (cookies.get('continueCode')) {
+        cookies.remove('continueCode')
+      }
     }))
 
     it('should be defined', inject(function () {
@@ -93,12 +96,11 @@ describe('controllers', function () {
     }))
 
     it('do nothing if continueCode cookie is not present', inject(function () {
-      cookies.remove('continueCode')
       socket.receive('server started')
       $httpBackend.flush()
     }))
 
-    xit('should remove the restore message when closing the notification', inject(function () {
+    it('should remove the restore message when closing the notification', inject(function () {
       socket.receive('server started')
       $httpBackend.flush()
 


### PR DESCRIPTION
The test was failing due to an unexpected PUT request to _/rest/continue-code/apply/CODE_ which was possibly happening due to a cookie with key 'continueCode' being present.

![image](https://user-images.githubusercontent.com/30633088/38168102-0d20cec4-3561-11e8-8788-181a744efa38.png)

This can be eliminated by removing this cookie if present, prior to each spec. 