### PR TITLE
Ensure OpenShift compatibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ WORKDIR /juice-shop
 COPY --from=installer /juice-shop .
 RUN addgroup juicer && \
     adduser -D -G juicer juicer && \
-    chown -R juicer /juice-shop
+    chown -R juicer /juice-shop && \
+    chgrp -R 0 /juice-shop/ && \
+    chmod -R g=u /juice-shop/
 USER juicer
 EXPOSE  3000
 CMD ["npm", "start"]


### PR DESCRIPTION
This adds extends the rights in the dockerfile to the root group.
OpenShift has some interesting security mechanisms including ignoring the user set in the dockerfile and just creating a new one which is member of the root group.

This should (to the best of my very limited unix rights management knowledge 😅) have no impact on the normal usage of the docker container.

If anybody is interested more about the details of this here's the OpenShift documentation for it: https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-specific-guidelines