### PR TITLE
change log location to /logs to facilitate local sharing with analytics

### DIFF
--- a/server.js
+++ b/server.js
@@ -128,7 +128,7 @@ app.use(cookieParser('kekse'))
 app.use(bodyParser.json())
 
 /* HTTP request logging */
-let accessLogStream = require('file-stream-rotator').getStream({ filename: './access.log', frequency: 'daily', verbose: false, max_logs: '2d' })
+let accessLogStream = require('file-stream-rotator').getStream({ filename: './logs/access.log', frequency: 'daily', verbose: false, max_logs: '2d' })
 app.use(morgan('combined', { stream: accessLogStream }))
 
 /* Rate limiting */


### PR DESCRIPTION
By moving the access logging into a directory a user can then bind that directory to the host allowing for easier access to the logs by analytics tools (e.q. Splunk forwarder) without needing to modify the base image. 

This change allows a cross-functional training exercise where devs and QA are trained on attack and prevention techniques, while incident response and the SOC are able to review the traffic in real-time for detection and alerting.