### PR TITLE
Replace label schema labels with open container labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,17 @@ FROM node:10-alpine
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL maintainer="Bjoern Kimminich <bjoern.kimminich@owasp.org>" \
-      org.label-schema.name="OWASP Juice Shop" \
-      org.label-schema.description="An intentionally insecure JavaScript Web Application" \
-      org.label-schema.vendor="Open Web Application Security Project" \
-      org.label-schema.url="http://owasp-juice.shop" \
-      org.label-schema.usage="http://help.owasp-juice.shop" \
-      org.label-schema.license="MIT" \
-      org.label-schema.version="8.1.0-SNAPSHOT" \
-      org.label-schema.docker.cmd="docker run --rm -p 3000:3000 bkimminich/juice-shop" \
-      org.label-schema.docker.params="NODE_ENV=string name of the custom configuration,CTF_KEY=string key to hash challenges into CTF flag codes" \
-      org.label-schema.vcs-url="https://github.com/bkimminich/juice-shop.git" \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.schema-version="1.0.0-rc1"
+    org.opencontainers.image.title="OWASP Juice Shop" \
+    org.opencontainers.image.description="An intentionally insecure JavaScript Web Application" \
+    org.opencontainers.image.authors="Bjoern Kimminich <bjoern.kimminich@owasp.org>" \
+    org.opencontainers.image.vendor="Open Web Application Security Project" \
+    org.opencontainers.image.documentation="http://help.owasp-juice.shop" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.version="8.1.0-SNAPSHOT" \
+    org.opencontainers.image.url="http://owasp-juice.shop" \
+    org.opencontainers.image.source="https://github.com/bkimminich/juice-shop" \
+    org.opencontainers.image.revision=$VCS_REF \
+    org.opencontainers.image.created=$BUILD_DATE
 WORKDIR /juice-shop
 COPY --from=installer /juice-shop .
 RUN addgroup juicer && \


### PR DESCRIPTION
[LabelSchema has been deprecated](https://github.com/label-schema/label-schema.org#label-schemaorg). It got replaced by a [standard of the OpenContainer Foundation](https://github.com/opencontainers/image-spec/blob/master/annotations.md).

The labels are mostly compatible, only once i could not replace with the OpenContainer labels are `org.label-schema.docker.params` and `org.label-schema.docker.cmd`. Im guessing they don't want vendor specific labels in there... 