### PR TITLE
allow to configure proxy via env var

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -2,7 +2,7 @@
 
 var proxy = {
   proxyType: 'autodetect'
-};
+}
 
 if (process.env.http_proxy !== undefined && process.env.http_proxy !== null) {
   proxy = {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -4,7 +4,7 @@ var proxy = {
   proxyType: 'autodetect'
 };
 
-if (process.env.http_proxy != undefined && process.env.http_proxy != null) {
+if (process.env.http_proxy !== undefined && process.env.http_proxy !== null) {
   proxy = {
     proxyType: 'manual',
     httpProxy: process.env.http_proxy

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,5 +1,16 @@
 'use strict'
 
+var proxy = {};
+
+if (process.env.http_proxy != undefined && process.env.http_proxy != null){
+  proxy = {
+    proxyType: 'manual',
+    httpProxy: process.env.http_proxy
+  }
+}
+
+console.log(process.env);
+
 exports.config = {
   directConnect: true,
 
@@ -10,7 +21,8 @@ exports.config = {
   ],
 
   capabilities: {
-    browserName: 'chrome'
+    browserName: 'chrome',
+    proxy: proxy
   },
 
   baseUrl: 'http://localhost:3000',

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,17 +1,15 @@
 'use strict'
 
 var proxy = {
-  proxyType: 'unspecified'
+  proxyType: 'autodetect'
 };
 
-if (process.env.http_proxy != undefined && process.env.http_proxy != null){
+if (process.env.http_proxy != undefined && process.env.http_proxy != null) {
   proxy = {
     proxyType: 'manual',
     httpProxy: process.env.http_proxy
   }
 }
-
-console.log(process.env);
 
 exports.config = {
   directConnect: true,

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,6 +1,8 @@
 'use strict'
 
-var proxy = {};
+var proxy = {
+  proxyType = 'unspecified'
+};
 
 if (process.env.http_proxy != undefined && process.env.http_proxy != null){
   proxy = {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var proxy = {
-  proxyType = 'unspecified'
+  proxyType: 'unspecified'
 };
 
 if (process.env.http_proxy != undefined && process.env.http_proxy != null){


### PR DESCRIPTION
As part of a session I'm doing, I wanted to demo Zap capabilities as DAST solution. The best test case is, of course, juice shop. So I added a small change that will allow to run the existing e2e tests and scan them with Zap. All that is now required is to run:
```
http_proxy=http://localhost:8080 yarn run e2e
```
And the e2e will be proxied via Zap (assuming `http://localhost:8080` is Zap's proxy endpoint).
Is this something that you would like to merge? Do you want me to add a small docker compose file that will run everything in compose?
BTW I tried to proxy the API tests, but I couldn't find how to control firsby proxy behavior. I managed to do it only by changing the tests code, but this is pretty ugly and not something I think should merged.
Soluto/webdriverio-zap-proxy/issues/6