### PR TITLE
Verify Admin Registration with truthy values

### DIFF
--- a/routes/verify.js
+++ b/routes/verify.js
@@ -36,7 +36,7 @@ exports.captchaBypassChallenge = () => (req, res, next) => {
 exports.registerAdminChallenge = () => (req, res, next) => {
   /* jshint eqeqeq:false */
   if (utils.notSolved(challenges.registerAdminChallenge)) {
-    if (req.body && req.body.isAdmin && req.body.isAdmin === true) {
+    if (req.body && req.body.isAdmin && req.body.isAdmin) {
       utils.solve(challenges.registerAdminChallenge)
     }
   }

--- a/test/api/userApiSpec.js
+++ b/test/api/userApiSpec.js
@@ -39,6 +39,28 @@ describe('/api/Users', () => {
       })
   })
 
+  it('POST new admin', () => {
+    return frisby.post(API_URL + '/Users', {
+      headers: jsonHeader,
+      body: {
+        email: 'horst2@horstma.nn',
+        password: 'hooooorst',
+        isAdmin: true
+      }
+    })
+      .expect('status', 201)
+      .expect('header', 'content-type', /application\/json/)
+      .expect('jsonTypes', 'data', {
+        id: Joi.number(),
+        createdAt: Joi.string(),
+        updatedAt: Joi.string()
+      })
+      .expect('json', 'data', {
+        password: insecurity.hash('hooooorst'),
+        isAdmin: true
+      })
+  })
+
   it('POST new user with XSS attack in email address', () => {
     return frisby.post(API_URL + '/Users', {
       headers: jsonHeader,


### PR DESCRIPTION
Allowing the challenge to resolve with truthy values, aligning with the behaviour of the underlying API.

This fixes #777.

The alternative would be to change how the API itself functioned, to make it more strict in the value of `isAdmin`, but that seemed like a harder change to me.

I couldn't find any tests for the verify functions, but added a jest test that checks admins can be created at all.