### PR TITLE
package.json: Modify cookie-parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "colors": "~1.3.2",
     "concurrently": "~4.1.0",
     "config": "~2.0.0",
-    "cookie-parser": "~1.4",
+    "cookie-parser": "^1.4.4",
     "cors": "~2.8.5",
     "dottie": "~2.0.1",
     "download": "~7.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "colors": "~1.3.2",
     "concurrently": "~4.1.0",
     "config": "~2.0.0",
-    "cookie-parser": "~1.4",
+    "cookie-parser": "^1.4.3",
     "cors": "~2.8.5",
     "dottie": "~2.0.1",
     "download": "~7.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "colors": "~1.3.2",
     "concurrently": "~4.1.0",
     "config": "~2.0.0",
-    "cookie-parser": "^1.4.3",
+    "cookie-parser": "~1.4",
     "cors": "~2.8.5",
     "dottie": "~2.0.1",
     "download": "~7.1.0",


### PR DESCRIPTION
version "1.4.4" is breaking the build.
So,it has been rollbacked to version
"1.4.3".

Closes #806