### PR TITLE
score-board: Add class for overlay

### DIFF
--- a/frontend/src/app/score-board/score-board.component.html
+++ b/frontend/src/app/score-board/score-board.component.html
@@ -119,4 +119,4 @@
 
 <img src="assets/public/images/padding/1px.png"/>
 
-<ngx-spinner></ngx-spinner>
+<ngx-spinner class="overlay-fullscreen"></ngx-spinner>

--- a/frontend/src/app/score-board/score-board.component.scss
+++ b/frontend/src/app/score-board/score-board.component.scss
@@ -40,3 +40,7 @@ mat-table {
 .category-toggle {
   font-size: small;
 }
+
+.overlay-fullscreen /deep/ .black-overlay{
+  position: fixed;
+}


### PR DESCRIPTION
The overlay will cover the whole page. With
spinner in the middle always.

Closes #816 