### PR TITLE
Fix broken link to project logo in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": "Probably the most modern and sophisticated insecure web application",
   "website": "https://www.owasp.org/index.php/OWASP_Juice_Shop_Project",
   "repository": "https://github.com/bkimminich/juice-shop",
-  "logo": "https://raw.githubusercontent.com/bkimminich/juice-shop/master/app/public/images/JuiceShop_Logo.png",
+  "logo": "https://raw.githubusercontent.com/bkimminich/juice-shop/master/frontend/src/assets/public/images/JuiceShop_Logo.png",
   "keywords": [
     "web security",
     "web application security",


### PR DESCRIPTION
Looks like project structure was changed and link to project logo in `app.json` no longer worked. This fixes that!