### PR TITLE
fix: check for previous challenge key before sending the notification

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,8 @@ const isHeroku = require('is-heroku')
 
 const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
 
+let prevChallengeKey = ''
+
 let ctfKey
 if (process.env.CTF_KEY !== undefined && process.env.CTF_KEY !== '') {
   ctfKey = process.env.CTF_KEY
@@ -116,9 +118,10 @@ exports.sendNotification = function (challenge, isRestore) {
       isRestore: isRestore
     }
     notifications.push(notification)
-    if (global.io) {
+    if (global.io && prevChallengeKey !== challenge.key) {
       global.io.emit('challenge solved', notification)
     }
+    prevChallengeKey = challenge.key
   }
 }
 


### PR DESCRIPTION
It seems that the challenge is marked solved exactly once but multiple entries line up in the notification queue during restart. It is solved by checking the previous challenge key before sending the notification to prevent resending it.
@bkimminich, please review.