### PR TITLE
Allow users to upload a profile image of any image type

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "express-security.txt": "~2.0",
     "file-stream-rotator": "~0.4.1",
     "finale-rest": "^1.0.3",
+    "file-type": "~4.4",
     "fs-extra": "~7.0.0",
     "glob": "~7.1.3",
     "grunt": "~1.0",

--- a/routes/profileImageFileUpload.js
+++ b/routes/profileImageFileUpload.js
@@ -13,7 +13,7 @@ module.exports = function fileUpload () {
     if (uploadedFileType !== null && utils.startsWith(uploadedFileType.mime, 'image')) {
       const loggedInUser = insecurity.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
-        fs.open('frontend/dist/frontend/assets/public/images/uploads/' + loggedInUser.data.id + '.'+ uploadedFileType.ext, 'w', function (err, fd) {
+        fs.open('frontend/dist/frontend/assets/public/images/uploads/' + loggedInUser.data.id + '.' + uploadedFileType.ext, 'w', function (err, fd) {
           if (err) logger.warn('Error opening file: ' + err.message)
           fs.write(fd, buffer, 0, buffer.length, null, function (err) {
             if (err) logger.warn('Error writing file: ' + err.message)
@@ -21,7 +21,7 @@ module.exports = function fileUpload () {
           })
         })
         models.User.findByPk(loggedInUser.data.id).then(user => {
-          return user.update({ profileImage: loggedInUser.data.id + '.' + uploadedFileType.ext})
+          return user.update({ profileImage: loggedInUser.data.id + '.' + uploadedFileType.ext })
         }).catch(error => {
           next(error)
         })

--- a/routes/profileImageFileUpload.js
+++ b/routes/profileImageFileUpload.js
@@ -3,15 +3,17 @@ const fs = require('fs')
 const models = require('../models/index')
 const insecurity = require('../lib/insecurity')
 const logger = require('../lib/logger')
+const fileType = require('file-type')
 
 module.exports = function fileUpload () {
   return (req, res, next) => {
     const file = req.file
-    if (utils.endsWith(file.originalname.toLowerCase(), '.jpg')) {
+    const buffer = file.buffer
+    const uploadedFileType = fileType(buffer)
+    if (uploadedFileType !== null && utils.startsWith(uploadedFileType.mime, 'image')) {
       const loggedInUser = insecurity.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
-        const buffer = file.buffer
-        fs.open('frontend/dist/frontend/assets/public/images/uploads/' + loggedInUser.data.id + '.jpg', 'w', function (err, fd) {
+        fs.open('frontend/dist/frontend/assets/public/images/uploads/' + loggedInUser.data.id + '.'+ uploadedFileType.ext, 'w', function (err, fd) {
           if (err) logger.warn('Error opening file: ' + err.message)
           fs.write(fd, buffer, 0, buffer.length, null, function (err) {
             if (err) logger.warn('Error writing file: ' + err.message)
@@ -19,7 +21,7 @@ module.exports = function fileUpload () {
           })
         })
         models.User.findByPk(loggedInUser.data.id).then(user => {
-          return user.update({ profileImage: loggedInUser.data.id + '.jpg' })
+          return user.update({ profileImage: loggedInUser.data.id + '.' + uploadedFileType.ext})
         }).catch(error => {
           next(error)
         })


### PR DESCRIPTION
Previously only files ending in string '.jpg' could be set as a profile image, this PR adds the ability to use files of any image type e.g. jpeg,gif, png. At the moment it uses the mime type to set the file extension. In future a challenge could be set to use a mime type and extension that don't agree but I thought it would be good to get this enhancement in first.