### PR TITLE
Custom app name in 2fa setup string

### DIFF
--- a/frontend/src/app/Services/configuration.service.ts
+++ b/frontend/src/app/Services/configuration.service.ts
@@ -2,6 +2,70 @@ import { environment } from '../../environments/environment'
 import { Injectable } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import { Observable } from 'rxjs'
+
+interface ConfigResponse {
+  config: Config
+}
+interface Config {
+  server: {
+    port: number
+  }
+  application: {
+    domain: string
+    name: string
+    logo: string
+    favicon: string
+    numberOfRandomFakeUsers: number
+    showChallengeSolvedNotifications: boolean
+    showChallengeHints: boolean
+    showVersionNumber: boolean
+    theme: string
+    gitHubRibbon: boolean
+    twitterUrl: string
+    facebookUrl: string
+    slackUrl: string
+    redditUrl: string
+    pressKitUrl: string
+    planetOverlayMap: string
+    planetName: string
+    recyclePage: {
+      topProductImage: string
+      bottomProductImage: string
+    }
+    altcoinName: string
+    cookieConsent: {
+      backgroundColor: string
+      textColor: string
+      buttonColor: string
+      buttonTextColor: string
+      message: string
+      dismissText: string
+      linkText: string
+      linkUrl: string
+    }
+    privacyContactEmail: string
+    securityTxt: {
+      contact: string
+      encryption: string
+      acknowledgements: string
+    }
+    promotion: {
+      video
+      subtitles
+    }
+  }
+  challenges: {
+    safetyOverride: boolean
+    overwriteUrlForProductTamperingChallenge: string
+  }
+  products: any[]
+  ctf: {
+    showFlagsInNotifications: boolean
+    showCountryDetailsInNotifications: string
+    countryMapping: any[]
+  }
+}
 
 @Injectable({
   providedIn: 'root'
@@ -13,11 +77,11 @@ export class ConfigurationService {
   private configObservable
   constructor (private http: HttpClient) { }
 
-  getApplicationConfiguration () {
+  getApplicationConfiguration (): Observable<Config> {
     if (this.configObservable) {
       return this.configObservable
     } else {
-      this.configObservable = this.http.get(this.host + '/application-configuration').pipe(map((response: any) => response.config, catchError((err) => { throw err })))
+      this.configObservable = this.http.get(this.host + '/application-configuration').pipe(map((response: ConfigResponse) => response.config, catchError((err) => { throw err })))
       return this.configObservable
     }
   }

--- a/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
+++ b/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
@@ -49,8 +49,9 @@ export class TwoFactorAuthComponent {
     const status = this.twoFactorAuthService.status()
     const config = this.configurationService.getApplicationConfiguration()
 
-    forkJoin(status, config).subscribe(([{ setup, email, secret, setupToken }, config]) => {
+    forkJoin(status, config).subscribe(([{ setup, email, secret, setupToken }, config ]) => {
       this.setupStatus = setup
+      this.appName = config.application.name
       if (setup === false) {
         const encodedAppName = encodeURIComponent(this.appName)
         this.totpUrl = `otpauth://totp/${encodedAppName}:${email}?secret=${secret}&issuer=${encodedAppName}`

--- a/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
+++ b/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
@@ -2,9 +2,12 @@ import { Component } from '@angular/core'
 import { FormControl, FormGroup } from '@angular/forms'
 
 import { TwoFactorAuthService } from '../Services/two-factor-auth-service'
+import { ConfigurationService } from '../Services/configuration.service'
 
 import { library, dom } from '@fortawesome/fontawesome-svg-core'
 import { faUnlockAlt, faSave } from '@fortawesome/free-solid-svg-icons'
+
+import { forkJoin } from 'rxjs'
 
 library.add(faUnlockAlt, faSave)
 dom.watch()
@@ -34,7 +37,9 @@ export class TwoFactorAuthComponent {
 
   private setupToken?: string
 
-  constructor (private twoFactorAuthService: TwoFactorAuthService) {}
+  private appName = 'OWASP Juice Shop'
+
+  constructor (private twoFactorAuthService: TwoFactorAuthService, private configurationService: ConfigurationService) {}
 
   ngOnInit () {
     this.updateStatus()
@@ -42,10 +47,13 @@ export class TwoFactorAuthComponent {
 
   updateStatus () {
     const status = this.twoFactorAuthService.status()
-    status.subscribe(({ setup, email, secret, setupToken }) => {
+    const config = this.configurationService.getApplicationConfiguration()
+
+    forkJoin(status, config).subscribe(([{ setup, email, secret, setupToken }, config]) => {
       this.setupStatus = setup
       if (setup === false) {
-        this.totpUrl = `otpauth://totp/JuiceShop:${email}?secret=${secret}&issuer=JuiceShop` // FIXME Use app name from config instead of fixed "JuiceShop"
+        const encodedAppName = encodeURIComponent(this.appName)
+        this.totpUrl = `otpauth://totp/${encodedAppName}:${email}?secret=${secret}&issuer=${encodedAppName}`
         this.totpSecret = secret
         this.setupToken = setupToken
       }


### PR DESCRIPTION
The customized app name will now show up in the totp setup string, so that Apps like Google Authenticator will show the customized app name instead of a fixed string.

Also added typing's to the config service.