### PR TITLE
Facelift: Fix some minor Styling issues

### DIFF
--- a/frontend/src/app/login/login.component.scss
+++ b/frontend/src/app/login/login.component.scss
@@ -65,3 +65,13 @@ mat-form-field:nth-child(2) {
   align-self: center;
   margin-top: 40px;
 }
+
+:host ::ng-deep .mat-form-field-suffix{
+ margin-bottom: auto !important;
+ margin-top: auto !important;
+}
+
+:host ::ng-deep .mat-icon-button {
+ height: 40px !important;
+ width: 24px !important;
+}

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -109,7 +109,7 @@
       </mat-radio-button>
     </mat-menu>
 
-    <mat-menu #subMenu="matMenu" style="width: 250px;">
+    <mat-menu #subMenu="matMenu">
       <button mat-menu-item [routerLink]="['privacy-security/privacy-policy']" aria-label="Go to privacy policy page">
         <mat-icon>
           assignment


### PR DESCRIPTION
- Since the Show/Hide password had changed, the styles were adjusted so that the button is now displayed as before and not moved down.

- Due to the corrected style, the whole menu in the navbar has shifted to the left. Since this is not needed, it was removed. Now the display should be as before.