### PR TITLE
Reduce the number of score board challenge status api calls

### DIFF
--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -163,7 +163,6 @@ export class NavbarComponent implements OnInit {
   }
 
   getScoreBoardStatus () {
-    console.log('mainnav: getting score board challenge status')
     this.challengeService.find({ name: 'Score Board' }).subscribe((challenges: any) => {
       this.ngZone.run(() => {
         this.scoreBoardVisible = challenges[0].solved

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -103,8 +103,10 @@ export class NavbarComponent implements OnInit {
     this.getScoreBoardStatus()
 
     this.ngZone.runOutsideAngular(() => {
-      this.io.socket().on('challenge solved', () => {
-        this.getScoreBoardStatus()
+      this.io.socket().on('challenge solved', (challenge) => {
+        if (challenge.key === 'scoreBoardChallenge') {
+          this.scoreBoardVisible = true
+        }
       })
     })
   }
@@ -161,6 +163,7 @@ export class NavbarComponent implements OnInit {
   }
 
   getScoreBoardStatus () {
+    console.log('mainnav: getting score board challenge status')
     this.challengeService.find({ name: 'Score Board' }).subscribe((challenges: any) => {
       this.ngZone.run(() => {
         this.scoreBoardVisible = challenges[0].solved

--- a/frontend/src/app/sidenav/sidenav.component.ts
+++ b/frontend/src/app/sidenav/sidenav.component.ts
@@ -53,8 +53,10 @@ export class SidenavComponent implements OnInit {
       }
     })
     this.ngZone.runOutsideAngular(() => {
-      this.io.socket().on('challenge solved', () => {
-        this.getScoreBoardStatus()
+      this.io.socket().on('challenge solved', (challenge) => {
+        if (challenge.key === 'scoreBoardChallenge') {
+          this.scoreBoardVisible = true
+        }
       })
     })
   }
@@ -80,6 +82,7 @@ export class SidenavComponent implements OnInit {
   noop () { }
 
   getScoreBoardStatus () {
+    console.log('sidenav: getting score board challenge status')
     this.challengeService.find({ name: 'Score Board' }).subscribe((challenges: any) => {
       this.ngZone.run(() => {
         this.scoreBoardVisible = challenges[0].solved

--- a/frontend/src/app/sidenav/sidenav.component.ts
+++ b/frontend/src/app/sidenav/sidenav.component.ts
@@ -82,7 +82,6 @@ export class SidenavComponent implements OnInit {
   noop () { }
 
   getScoreBoardStatus () {
-    console.log('sidenav: getting score board challenge status')
     this.challengeService.find({ name: 'Score Board' }).subscribe((challenges: any) => {
       this.ngZone.run(() => {
         this.scoreBoardVisible = challenges[0].solved


### PR DESCRIPTION
Currently every time a new challenge get solved both the regular navbar and the sidenav (even if it isn't displayed) are making api calls to check if the score-board challenge is now solved.

This is pretty wasteful but not to big of a trouble when you are just solving challenges normally, but this gets kind of absurd when you restart a server with a large number of challenges solved 😅 
Especially with every api call being performed twice it's quite the performance hit.

![juice-shop-scoreboard-calls](https://user-images.githubusercontent.com/13718901/62009020-3ff98180-b15a-11e9-86dd-e2e0181257e4.gif)

And its actually quite the easy fix as the notifications already contain the info about what challenge has been solved, so there is no real point in repeating the api call every time.

