### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ Dockerfile
 
 # Pattern is *not covered* by node_modules/ above no matter what IntelliJ says!
 frontend/node_modules/
+frontend/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ LABEL maintainer="Bjoern Kimminich <bjoern.kimminich@owasp.org>" \
     org.opencontainers.image.revision=$VCS_REF \
     org.opencontainers.image.created=$BUILD_DATE
 WORKDIR /juice-shop
-COPY --from=installer /juice-shop .
 RUN addgroup juicer && \
-    adduser -D -G juicer juicer && \
-    chown -R juicer /juice-shop && \
-    chgrp -R 0 /juice-shop/ && \
-    chmod -R g=u /juice-shop/
+    adduser -D -G juicer juicer
+COPY --from=installer --chown=juicer /juice-shop .
+RUN mkdir logs && \
+    chgrp -R 0 ftp/ frontend/dist/ logs/ data/ && \
+    chmod -R g=u ftp/ frontend/dist/ logs/ data/
 USER juicer
 EXPOSE  3000
 CMD ["npm", "start"]


### PR DESCRIPTION
This PR reduces the Image size from:

Compressed: `162 MB` → `114 MB`
Uncompressed: `401MB` → `268MB`

This was done by only running chgrp and chmod on the folders in which files are actively written to, instead of running it against the entire application including the `node_modules` folder.
The chown part was done using the Dockerfile Copy `--chown` option.

This way only about `20 MB` (Uncompressed) are duplicated, which consists mostly of compiled frontend resources.
