### PR TITLE
Fix docker container crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN addgroup juicer && \
     adduser -D -G juicer juicer
 COPY --from=installer --chown=juicer /juice-shop .
 RUN mkdir logs && \
+    chown -R juicer logs && \
     chgrp -R 0 ftp/ frontend/dist/ logs/ data/ && \
     chmod -R g=u ftp/ frontend/dist/ logs/ data/
 USER juicer


### PR DESCRIPTION
Just noticed that ever since my docker image size improvements the docker containers crash on anything other than OpenShift. I've never seen an image that runs on OpenShift but not on normal Docker, always the reverse 😳

![shame](https://user-images.githubusercontent.com/13718901/63711392-9df1b580-c83b-11e9-88a0-14ecbfc3ecb8.jpeg)

This should fix that. Was basically missing the logs ownership as the folder gets created after the copy & own operation.


