### PR TITLE
Use relative paths

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -235,6 +235,10 @@ where this project was mentioned or used!
 
 #### 2019
 
+* [Introduction to OWASP Juice Shop](https://bsidesmcr2019.sched.com/event/Sw0q/introduction-to-owasp-juice-shop)
+  by Tim Corless-Carter,
+  [BSidesMCR 2019](https://www.bsidesmcr.org.uk/), 29.08.2019
+  ([Youtube](https://youtu.be/hlgp7oeVpac) :godmode:)
 * [JavaScript-Security: "Pwn" den Juice Shop](https://www.enterjs.de/single?id=7685&javascript-security%3A-%22pwn%22-den-juice-shop)
   workshop with Timo Pagel & Björn Kimminich,
   [enterJS 2019](https://www.enterjs.de/2019/), 25.06.2019
@@ -250,7 +254,7 @@ where this project was mentioned or used!
   [Pixels Camp v3.0](https://pixels.camp), 21.03.2019
 * [OWASP Juice Shop - First you :-D :-D then you :,-(](https://github.com/PixelsCamp/talks/blob/master/2019/owasp-juice-shop_bjoern-kimminich.md)
   by Björn Kimminich, [Pixels Camp v3.0](https://pixels.camp),
-  21.03.2019
+  21.03.2019 ([Youtube](https://youtu.be/v9qrAK_iBa0) :bulb:)
 * [News from the fruit press: Juice Shop 8](https://www.meetup.com/de-DE/OWASP-Hamburg-Stammtisch/events/258185324/)
   by Björn Kimminich,
   [39. OWASP Stammtisch Hamburg](https://www.meetup.com/de-DE/OWASP-Hamburg-Stammtisch),

--- a/frontend/src/app/Services/socket-io.service.ts
+++ b/frontend/src/app/Services/socket-io.service.ts
@@ -13,8 +13,8 @@ export class SocketIoService {
   constructor (private ngZone: NgZone) {
     this.ngZone.runOutsideAngular(() => {
       if (environment.hostServer === '.') {
-        this._socket = this.io.connect({
-          path: window.location.pathname
+        this._socket = this.io.connect(window.location.href, {
+          path: '/socket.io' + window.location.pathname
         })
       } else {
         this._socket = this.io.connect(environment.hostServer)

--- a/frontend/src/app/Services/socket-io.service.ts
+++ b/frontend/src/app/Services/socket-io.service.ts
@@ -13,7 +13,7 @@ export class SocketIoService {
   constructor (private ngZone: NgZone) {
     this.ngZone.runOutsideAngular(() => {
       if (environment.hostServer === '.') {
-        this._socket = this.io.connect(window.location.protocol + '://' + window.location.host, {
+        this._socket = this.io.connect({
           path: window.location.pathname
         })
       } else {

--- a/frontend/src/app/Services/socket-io.service.ts
+++ b/frontend/src/app/Services/socket-io.service.ts
@@ -14,7 +14,7 @@ export class SocketIoService {
     this.ngZone.runOutsideAngular(() => {
       if (environment.hostServer === '.') {
         this._socket = this.io.connect(window.location.href, {
-          path: '/socket.io' + window.location.pathname
+          path: (window.location.pathname === '/' ? '/' : window.location.pathname + '/') + 'socket.io'
         })
       } else {
         this._socket = this.io.connect(environment.hostServer)

--- a/frontend/src/app/Services/socket-io.service.ts
+++ b/frontend/src/app/Services/socket-io.service.ts
@@ -12,7 +12,13 @@ export class SocketIoService {
 
   constructor (private ngZone: NgZone) {
     this.ngZone.runOutsideAngular(() => {
-      this._socket = this.io.connect(environment.hostServer)
+      if(environment.hostServer == '.') {
+        this._socket = this.io.connect(window.location.protocol+"://"+window.location.host, {
+          path: window.location.pathname
+        })
+      } else {
+        this._socket = this.io.connect(environment.hostServer)
+      }
     })
   }
 

--- a/frontend/src/app/Services/socket-io.service.ts
+++ b/frontend/src/app/Services/socket-io.service.ts
@@ -12,8 +12,8 @@ export class SocketIoService {
 
   constructor (private ngZone: NgZone) {
     this.ngZone.runOutsideAngular(() => {
-      if(environment.hostServer == '.') {
-        this._socket = this.io.connect(window.location.protocol+"://"+window.location.host, {
+      if (environment.hostServer === '.') {
+        this._socket = this.io.connect(window.location.protocol + '://' + window.location.host, {
           path: window.location.pathname
         })
       } else {

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -124,7 +124,7 @@ import { DeluxeUserComponent } from './deluxe-user/deluxe-user.component'
 import { AccountingGuard, AdminGuard, LoginGuard, DeluxeGuard } from './app.guard'
 
 export function HttpLoaderFactory (http: HttpClient) {
-  return new TranslateHttpLoader(http, './../assets/i18n/', '.json')
+  return new TranslateHttpLoader(http, './assets/i18n/', '.json')
 }
 
 @NgModule({

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  hostServer: ''
+  hostServer: '.'
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>OWASP Juice Shop</title>
-  <base href="/">
   <meta name="description" content="Probably the most modern and sophisticated insecure web application">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link id="favicon" rel="icon" type="image/x-icon" href="assets/public/favicon_js.ico">


### PR DESCRIPTION
In our company, we would like to run juice-shop as a docker below a certain folder, eg http://example.com/juice-shop (via reverse proxy). This helps us reduce overhead (creating and managing new domain, approvals etc) and helps not being enumerable via DNS.

However, at the moment juice-shop has the root directory hardcoded at a few places, so while the framework supports it, a lot of files are referenced via root.

The minor changes here have been locally tested and allow juice-shop to work in whatever directory it is located in.

This development has been sponsored by Panasonic Information Systems Company Europe.