### PR TITLE
Remove cookie consent

### DIFF
--- a/config/7ms.yml
+++ b/config/7ms.yml
@@ -20,15 +20,6 @@ application:
   altcoinName: Sevencoin
   welcomeBanner:
     showOnFirstStart: false
-  cookieConsent:
-    backgroundColor: '#0395d5'
-    textColor: '#ffffff'
-    buttonColor: '#b3b3b3'
-    buttonTextColor: '#000000'
-    message: 'If you stay on this website for more than 7 minutes our cookies will start tracking you.'
-    dismissText: 'I`ll be long gone by then!'
-    linkText: 'But I want to stay an arbitrary number of minutes!'
-    linkUrl: 'https://7ms.us/7ms-294-gdpr-me-asap/'
   privacyContactEmail: 'donotreply@7-ms.us'
   securityTxt:
     contact: 'mailto:donotreply@7-ms.us'

--- a/config/bodgeit.yml
+++ b/config/bodgeit.yml
@@ -20,15 +20,6 @@ application:
   altcoinName: Bodgecoin
   welcomeBanner:
     showOnFirstStart: false
-  cookieConsent:
-    backgroundColor: '#000000'
-    textColor: '#ffffff'
-    buttonColor: '#ffffff'
-    buttonTextColor: '#000000'
-    message: 'This website is so legacy, it might even run without cookies.'
-    dismissText: 'Bodge it!'
-    linkText: 'Lega-what?'
-    linkUrl: 'https://github.com/psiinon/bodgeit'
   privacyContactEmail: 'donotreply@thebodgeitstore.com'
   securityTxt:
     contact: 'mailto:donotreply@thebodgeitstore.com'

--- a/config/default.yml
+++ b/config/default.yml
@@ -29,15 +29,6 @@ application:
     showOnFirstStart: true
     title: 'Welcome to OWASP Juice Shop!'
     message: "<p>Being a web application with a vast number of intended security vulnerabilities, the <strong>OWASP Juice Shop</strong> is supposed to be the opposite of a best practice or template application for web developers: It is an awareness, training, demonstration and exercise tool for security risks in modern web applications. The <strong>OWASP Juice Shop</strong> is an open-source project hosted by the non-profit <a href='https://owasp.org' target='_blank'>Open Web Application Security Project (OWASP)</a> and is developed and maintained by volunteers. Check out the link below for more information and documentation on the project.</p><h1><a href='http://owasp-juice.shop' target='_blank'>http://owasp-juice.shop</a></h1>"
-  cookieConsent:
-    backgroundColor: '#546e7a'
-    textColor: '#ffffff'
-    buttonColor: '#558b2f'
-    buttonTextColor: '#ffffff'
-    message: 'This website uses fruit cookies to ensure you get the juiciest tracking experience.'
-    dismissText: 'Me want it!'
-    linkText: 'But me wait!'
-    linkUrl: 'https://www.youtube.com/watch?v=9PnbKL3wuH4'
   privacyContactEmail: donotreply@owasp-juice.shop
   securityTxt:
     contact: 'mailto:donotreply@owasp-juice.shop'

--- a/config/mozilla.yml
+++ b/config/mozilla.yml
@@ -21,15 +21,6 @@ application:
   altcoinName: Mozquito
   welcomeBanner:
     showOnFirstStart: false
-  cookieConsent:
-    backgroundColor: '#e95420'
-    textColor: '#ffffff'
-    buttonColor: '#2778c5'
-    buttonTextColor: '#ffffff'
-    message: 'This website uses a myriad of 3rd-party cookies for your convenience and tracking pleasure.'
-    dismissText: 'Never mind!'
-    linkText: 'How can I turn this off?'
-    linkUrl: 'https://support.mozilla.org/en-US/kb/disable-third-party-cookies'
   privacyContactEmail: 'donotreply@mozilla-ctf.op'
   securityTxt:
     contact: 'mailto:donotreply@mozilla-ctf.op'

--- a/frontend/src/app/Services/configuration.service.ts
+++ b/frontend/src/app/Services/configuration.service.ts
@@ -43,16 +43,6 @@ interface Config {
       title: string
       message: string
     }
-    cookieConsent: {
-      backgroundColor: string
-      textColor: string
-      buttonColor: string
-      buttonTextColor: string
-      message: string
-      dismissText: string
-      linkText: string
-      linkUrl: string
-    }
     privacyContactEmail: string
     securityTxt: {
       contact: string

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -7,21 +7,6 @@
   <meta name="description" content="Probably the most modern and sophisticated insecure web application">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link id="favicon" rel="icon" type="image/x-icon" href="assets/public/favicon_js.ico">
-  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css" />
-  <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-  <script>
-    window.addEventListener("load", function(){
-      window.cookieconsent.initialise({
-        "palette": {
-          "popup": { "background": "#37474f", "text": "#ffffff" },
-          "button": { "background": "#558b2f", "text": "#ffffff" }
-        },
-        "theme": "classic",
-        "position": "bottom-right",
-        "content": { "message": "This website uses fruit cookies to ensure you get the juiciest tracking experience.", "dismiss": "Me want it!", "link": "But me wait!", "href": "https://www.youtube.com/watch?v=9PnbKL3wuH4" }
-      })});
-  </script>
 </head>
 <body class="mat-app-background bluegrey-lightgreen-theme">
   <app-root></app-root>

--- a/lib/startup/customizeApplication.js
+++ b/lib/startup/customizeApplication.js
@@ -15,9 +15,6 @@ const customizeApplication = () => {
   if (config.get('application.theme')) {
     customizeTheme()
   }
-  if (config.get('application.cookieConsent')) {
-    customizeCookieConsentBanner()
-  }
   if (config.get('application.promotion')) {
     customizePromotionVideo()
     customizePromotionSubtitles()
@@ -76,33 +73,6 @@ const customizeTheme = () => {
   replace({
     regex: /"mat-app-background .*-theme"/,
     replacement: bodyClass,
-    paths: ['frontend/dist/frontend/index.html'],
-    recursive: false,
-    silent: true
-  })
-}
-
-const customizeCookieConsentBanner = () => {
-  const popupProperty = '"popup": { "background": "' + config.get('application.cookieConsent.backgroundColor') + '", "text": "' + config.get('application.cookieConsent.textColor') + '" }'
-  replace({
-    regex: /"popup": { "background": ".*", "text": ".*" }/,
-    replacement: popupProperty,
-    paths: ['frontend/dist/frontend/index.html'],
-    recursive: false,
-    silent: true
-  })
-  const buttonProperty = '"button": { "background": "' + config.get('application.cookieConsent.buttonColor') + '", "text": "' + config.get('application.cookieConsent.buttonTextColor') + '" }'
-  replace({
-    regex: /"button": { "background": ".*", "text": ".*" }/,
-    replacement: buttonProperty,
-    paths: ['frontend/dist/frontend/index.html'],
-    recursive: false,
-    silent: true
-  })
-  const contentProperty = '"content": { "message": "' + config.get('application.cookieConsent.message') + '", "dismiss": "' + config.get('application.cookieConsent.dismissText') + '", "link": "' + config.get('application.cookieConsent.linkText') + '", "href": "' + config.get('application.cookieConsent.linkUrl') + '" }'
-  replace({
-    regex: /"content": { "message": ".*", "dismiss": ".*", "link": ".*", "href": ".*" }/,
-    replacement: contentProperty,
     paths: ['frontend/dist/frontend/index.html'],
     recursive: false,
     silent: true

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -46,7 +46,6 @@ exports.config = {
 
     // Get all banners out of the way
     browser.get('/#')
-    browser.manage().addCookie({ name: 'cookieconsent_status', value: 'dismiss' })
     browser.manage().addCookie({ name: 'welcomebanner_status', value: 'dismiss' })
 
     // Ensure score board shows all challenges (by default only 1-star challenges are shown)


### PR DESCRIPTION
A cookie consent is only needed in the EU for the following reasons (beware, simplification ahead):

1. Third-party tracking cookies are used (eg Facebook)
2. User behavior is tracked or analyzed by or data sent to a third-party (eg Google Analytics)

In these cases, this tracking is not allowed to start or do anything without the explicit user consent. A user needs to have an easy option to say no. So only if a user has a choice and then clicks on "Yes", the tracking is allowed to start.

As JuiceShop does not utilize any measures that make it require a consent, and the current implementation is not compliant with EU regulation anyways, I recommend to simply remove the consent. This makes it easier to use for both users and administrators.

Vendors who want to add tracking to their page will need their own solution to manage the opt-in anyways.

This development has been sponsored by Panasonic Information Systems Company.