### PR TITLE
1197 - Wallet bug solution

### DIFF
--- a/frontend/src/app/payment/payment.component.spec.ts
+++ b/frontend/src/app/payment/payment.component.spec.ts
@@ -31,7 +31,7 @@ import { Location } from '@angular/common'
 import { MatIconModule, MatCheckboxModule, MatTooltipModule } from '@angular/material'
 import { WalletComponent } from '../wallet/wallet.component'
 
-fdescribe('PaymentComponent', () => {
+describe('PaymentComponent', () => {
   let component: PaymentComponent
   let fixture: ComponentFixture<PaymentComponent>
   let configurationService
@@ -333,8 +333,8 @@ fdescribe('PaymentComponent', () => {
     expect(console.log).toHaveBeenCalledWith('Error')
   }))
 
-  fit('should remove walletTotal from session storage on calling choosePayment in wallet mode', () => {
-    component.payUsingWallet = true;
+  it('should remove walletTotal from session storage on calling choosePayment in wallet mode', () => {
+    component.payUsingWallet = true
     spyOn(sessionStorage,'setItem')
     component.choosePayment()
     expect(sessionStorage.setItem).toHaveBeenCalledWith('paymentId', 'wallet')

--- a/frontend/src/app/payment/payment.component.spec.ts
+++ b/frontend/src/app/payment/payment.component.spec.ts
@@ -31,7 +31,7 @@ import { Location } from '@angular/common'
 import { MatIconModule, MatCheckboxModule, MatTooltipModule } from '@angular/material'
 import { WalletComponent } from '../wallet/wallet.component'
 
-describe('PaymentComponent', () => {
+fdescribe('PaymentComponent', () => {
   let component: PaymentComponent
   let fixture: ComponentFixture<PaymentComponent>
   let configurationService
@@ -333,11 +333,10 @@ describe('PaymentComponent', () => {
     expect(console.log).toHaveBeenCalledWith('Error')
   }))
 
-  it('should remove walletTotal from session storage on calling choosePayment in wallet mode', () => {
-    component.mode = 'wallet'
-    walletService.put.and.returnValue(of({}))
-    spyOn(sessionStorage,'removeItem')
+  fit('should remove walletTotal from session storage on calling choosePayment in wallet mode', () => {
+    component.payUsingWallet = true;
+    spyOn(sessionStorage,'setItem')
     component.choosePayment()
-    expect(sessionStorage.removeItem).toHaveBeenCalledWith('walletTotal')
+    expect(sessionStorage.setItem).toHaveBeenCalledWith('paymentId', 'wallet')
   })
 })

--- a/frontend/src/app/payment/payment.component.ts
+++ b/frontend/src/app/payment/payment.component.ts
@@ -84,9 +84,7 @@ export class PaymentComponent implements OnInit {
   initTotal () {
     this.activatedRoute.paramMap.subscribe((paramMap: ParamMap) => {
       this.mode = paramMap.get('entity')
-      if (this.mode === 'wallet') {
-        this.totalPrice = parseFloat(sessionStorage.getItem('walletTotal'))
-      } else if (this.mode === 'deluxe') {
+      if (this.mode === 'deluxe') {
         this.userService.deluxeStatus().subscribe((res) => {
           this.totalPrice = res.membershipCost
         }, (err) => console.log(err))
@@ -146,12 +144,7 @@ export class PaymentComponent implements OnInit {
 
   choosePayment () {
     sessionStorage.removeItem('itemTotal')
-    if (this.mode === 'wallet') {
-      this.walletService.put({ balance: this.totalPrice }).subscribe(() => {
-        sessionStorage.removeItem('walletTotal')
-        this.router.navigate(['/wallet'])
-      },(err) => console.log(err))
-    } else if (this.mode === 'deluxe') {
+    if (this.mode === 'deluxe') {
       this.userService.upgradeToDeluxe(this.payUsingWallet).subscribe(() => {
         this.logout()
       }, (err) => console.log(err))
@@ -211,8 +204,7 @@ export class PaymentComponent implements OnInit {
   }
 
   addMoneyToWallet () {
-    sessionStorage.setItem('walletTotal', (this.totalPrice - this.walletBalance).toString())
-    this.router.navigate(['/payment', 'wallet'])
+    this.router.navigate(['/wallet'])
   }
 
   useWallet () {

--- a/frontend/src/app/wallet/wallet.component.ts
+++ b/frontend/src/app/wallet/wallet.component.ts
@@ -24,7 +24,10 @@ export class WalletComponent implements OnInit {
   }
 
   continue () {
-    sessionStorage.setItem('walletTotal', this.balanceControl.value)
-    this.router.navigate(['/payment', 'wallet'])
+    this.walletService.put({ balance: this.balanceControl.value }).subscribe(() => {
+      this.router.navigate(['/payment/shop'])
+    }, (err) => {
+      console.log(err)
+    })
   }
 }


### PR DESCRIPTION
#1197  Bug-fix

I could not find any documentation of the wallet feature (maybe I didn't look hard enough) so I wasn't sure of the initial requirements for the wallet feature.  For this particular bug I removed the use of `sessionStorage` for setting the total balance of the wallet as I didn't see it was being used as a possible vulnerability.  The original code utilized session storage to save the additional wallet funds from the wallet component.  Only after the user pressed `Continue` from the shop, would the API HTTP PUT request '/api/Wallets/' be called.  I found this a bit convoluted, so instead, I moved the API call to the wallet component itself where the API request would be called on submit of the added wallet value.  After adding the additional funds to the wallet, the application will now navigate back to the shop where the user can now select the wallet and continue to the confirmation page.

I want to reiterate that I was not sure of the initial requirements such as the use of session storage or the use of the "wallet" component mode.  If these properties are needed, let me know.
