### PR TITLE
Fix OpenShift crash on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN addgroup juicer && \
 COPY --from=installer --chown=juicer /juice-shop .
 RUN mkdir logs && \
     chown -R juicer logs && \
-    chgrp -R 0 ftp/ frontend/dist/ logs/ data/ && \
-    chmod -R g=u ftp/ frontend/dist/ logs/ data/
+    chgrp -R 0 ftp/ frontend/dist/ logs/ data/ i18n/ && \
+    chmod -R g=u ftp/ frontend/dist/ logs/ data/ i18n/
 USER juicer
 EXPOSE 3000
 CMD ["npm", "start"]


### PR DESCRIPTION
Add rights to `i18n/` folder.
Closes #1233