### PR TITLE
Ignore prometheus scraper for metrics challenge

### DIFF
--- a/routes/metrics.js
+++ b/routes/metrics.js
@@ -13,7 +13,10 @@ const Op = models.Sequelize.Op
 
 exports.serveMetrics = function serveMetrics (reg) {
   return (req, res, next) => {
-    utils.solveIf(challenges.exposedMetricsChallenge, () => { return true })
+    utils.solveIf(challenges.exposedMetricsChallenge, () => {
+      const userAgent = req.headers['user-agent'] || ''
+      return !userAgent.includes('Prometheus')
+    })
     res.set('Content-Type', reg.contentType)
     res.end(reg.metrics())
   }


### PR DESCRIPTION
As suggested in #1275 this ignores the user-agent used by the prometheus scraper from solving the challenge.

The prometheus scraper uses a user agent like this: `Prometheus/2.15.2`

Was thinking about adding a e2e test to verify this automatically, but changing the user-agent in protractor seems to be only possible via a global config: https://stackoverflow.com/questions/23520900/protractor-change-user-agent

Via the api tests this would be relatively easy. Do we have a way to test if api tests solve a challenge?