### PR TITLE
Update Docker APT references in Vagrant

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 
+# Exit on error
+set -e
+
 # Add docker key and repository
-apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" | sudo tee /etc/apt/sources.list.d/docker.list
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable" | sudo tee /etc/apt/sources.list.d/docker.list
 
 
 # Install apache and docker
 apt-get update -q
 apt-get upgrade -qy
-apt-get install -qy apache2 docker-engine
+apt-get install -qy apache2 docker-ce
 
 # Put the relevant files in place
 cp /tmp/juice-shop/default.conf /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
Hi, I noticed Vagrant version of JuiceShop does not provision, due to errors with apt repository:

```
default: W: The repository 'https://apt.dockerproject.org/repo ubuntu-xenial Release' does not have a Release file.
default: E: Failed to fetch https://apt.dockerproject.org/repo/dists/ubuntu-xenial/main/binary-amd64/Packages  404  Not Found
default: E: Some index files failed to download. They have been ignored, or old ones used instead.
```
and therefore:
```
default: E: Package 'docker-engine' has no installation candidate
```

Entering https://apt.dockerproject.org/repo/ shows a notice that dockerproject.org shuts down in the end of March 2020:

```
Notice: Shutting down dockerproject.org APT and YUM repos 2020-03-31

Docker will be shutting down the deprecated APT and YUM repositories hosted at "dockerproject.org" and "dockerproject.com" on the 31st of March 2020.

We noticed that this project is referencing one of these repositories, and recommend updating to use the "download.docker.com" repository to prevent disruption.

More info: https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/ 
```

So I:
- changed public key reference to official Ubuntu keyserver
- changed apt repository line to docker.com
- replaced deprecated `docker-engine` installation to `docker-ce`
- added `set -e` script option to stop on errors (so with previous errors it would stop on dockerproject.org repo error and not go further trying to download docker-engine)
