### PR TITLE
Fix createMemories() to download remote images

### DIFF
--- a/data/datacreator.js
+++ b/data/datacreator.js
@@ -230,7 +230,7 @@ function createMemories () {
   })]
   Array.prototype.push.apply(memories, Promise.all(
     config.get('memories').map((memory) => {
-      tmpImageFileName = memory.image
+      let tmpImageFileName = memory.image
       if (utils.startsWith(memory.image, 'http')) {
         const imageUrl = memory.image
         tmpImageFileName = utils.extractFilename(memory.image)

--- a/data/datacreator.js
+++ b/data/datacreator.js
@@ -230,13 +230,14 @@ function createMemories () {
   })]
   Array.prototype.push.apply(memories, Promise.all(
     config.get('memories').map((memory) => {
+      tmpImageFileName = memory.image
       if (utils.startsWith(memory.image, 'http')) {
         const imageUrl = memory.image
-        memory.image = utils.extractFilename(memory.image)
-        utils.downloadToFile(imageUrl, 'assets/public/images/uploads/' + memory.image)
+        tmpImageFileName = utils.extractFilename(memory.image)
+        utils.downloadToFile(imageUrl, 'frontend/dist/frontend/assets/public/images/uploads/' + tmpImageFileName)
       }
       return models.Memory.create({
-        imagePath: 'assets/public/images/uploads/' + memory.image,
+        imagePath: 'assets/public/images/uploads/' + tmpImageFileName,
         caption: memory.caption,
         UserId: datacache.users[memory.user].id
       }).catch((err) => {


### PR DESCRIPTION
While creating a custom config I discovered memories would not load properly if the `image:` value was a URL.

For example, a config YAML that is a direct copy of default.yml with a URL specified for one of the memory images like this:

```
memories:
  -
    image: 'https://pbs.twimg.com/media/ER-wbuRXkAQllCT?format=jpg&name=large'
    caption: 'Magn(et)ificent!'
    user: bjoernGoogle
```

Will result in a warning when starting up:

```
info: Port 3000 is available (OK)
info: Server listening on port 3000
warn: Failed to download https://pbs.twimg.com/media/ER-wbuRXkAQllCT?format=jpg&name=large (undefined)
```

Also, `downloadToFile` in `createMemories` looks like it was being called with the incorrect destination path, so I made it the same as in `createProducts`.