### PR TITLE
Fix absolute paths for serveIndex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Juice Shop Logo](https://raw.githubusercontent.com/bkimminich/juice-shop/master/frontend/src/assets/public/images/JuiceShop_Logo_100px.png) OWASP Juice Shop [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Flagship_Projects) [![GitHub release](https://img.shields.io/github/release/bkimminich/juice-shop.svg)](https://github.com/bkimminich/juice-shop/releases/latest) [![Twitter Follow](https://img.shields.io/twitter/follow/owasp_juiceshop.svg?style=social&label=Follow)](https://twitter.com/owasp_juiceshop) [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/owasp_juiceshop?style=social)](https://reddit.com/r/owasp_juiceshop)
+# ![Juice Shop Logo](https://raw.githubusercontent.com/bkimminich/juice-shop/master/frontend/src/assets/public/images/JuiceShop_Logo_100px.png) OWASP Juice Shop [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Flagship_Projects) [![GitHub release](https://img.shields.io/github/release/bkimminich/juice-shop.svg)](https://github.com/bkimminich/juice-shop/releases/latest) [![Twitter Follow](https://img.shields.io/twitter/follow/owasp_juiceshop.svg?style=social&label=Follow)](https://twitter.com/owasp_juiceshop) [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/owasp_juiceshop?style=social)](https://reddit.com/r/owasp_juiceshop)
 
 [![Build Status](https://travis-ci.org/bkimminich/juice-shop.svg?branch=master)](https://travis-ci.org/bkimminich/juice-shop)
 [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/bkimminich/juice-shop.svg)](https://cloud.docker.com/repository/docker/bkimminich/juice-shop/builds)
@@ -90,8 +90,10 @@ overview please visit the official project page:
 [![Docker Automated build](https://img.shields.io/docker/automated/bkimminich/juice-shop.svg)](https://registry.hub.docker.com/u/bkimminich/juice-shop/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/bkimminich/juice-shop.svg)](https://registry.hub.docker.com/u/bkimminich/juice-shop/)
 ![Docker Stars](https://img.shields.io/docker/stars/bkimminich/juice-shop.svg)
-[![](https://images.microbadger.com/badges/image/bkimminich/juice-shop.svg)](https://microbadger.com/images/bkimminich/juice-shop "Get your own image badge on microbadger.com")
-[![](https://images.microbadger.com/badges/version/bkimminich/juice-shop.svg)](https://microbadger.com/images/bkimminich/juice-shop "Get your own version badge on microbadger.com")
+[![](https://images.microbadger.com/badges/image/bkimminich/juice-shop.svg)](https://microbadger.com/images/bkimminich/juice-shop
+"Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/bkimminich/juice-shop.svg)](https://microbadger.com/images/bkimminich/juice-shop
+"Get your own version badge on microbadger.com")
 
 1. Install [Docker](https://www.docker.com)
 2. Run `docker pull bkimminich/juice-shop`
@@ -145,21 +147,26 @@ docker run -d -p 80:3000 bkimminich/juice-shop
    --ip-address public`
 4. Your container will be available at `http://<dns name
    label>.<location name>.azurecontainer.io:3000`
-   
+
 ### Google Compute Engine Instance
 
-1. Login to the Google Cloud Console and [open Cloud Shell](https://console.cloud.google.com/home/dashboard?cloudshell=true).
-2. Launch a new GCE instance based on the juice-shop container. Take note of the `EXTERNAL_IP` provided in the output.
+1. Login to the Google Cloud Console and
+   [open Cloud Shell](https://console.cloud.google.com/home/dashboard?cloudshell=true).
+2. Launch a new GCE instance based on the juice-shop container. Take
+   note of the `EXTERNAL_IP` provided in the output.
+
 ```
 gcloud compute instances create-with-container owasp-juice-shop-app --container-image bkimminich/juice-shop
 ```
 
 3. Create a firewall rule that allows inbound traffic to port 3000
+
 ```
 gcloud compute firewall-rules create juice-rule --allow tcp:3000
 ```
-    
-4. Your container is now running and available at `http://[EXTERNAL_IP]:3000/`
+
+4. Your container is now running and available at
+   `http://<EXTERNAL_IP>:3000/`
 
 ## Node.js version compatibility
 
@@ -223,7 +230,7 @@ questions!**
 
 ## Documentation
 
-### Pwning OWASP Juice Shop [![Write Goodreads Review](https://img.shields.io/badge/goodreads-write%20review-47129532.svg)](https://www.goodreads.com/review/edit/47129532)
+### Pwning OWASP Juice Shop [![Write Goodreads Review](https://img.shields.io/badge/goodreads-write%20review-47129532.svg)](https://www.goodreads.com/review/edit/47129532)
 
 This is the official companion guide to the OWASP Juice Shop. It will
 give you a complete overview of the vulnerabilities found in the
@@ -243,7 +250,7 @@ also [browse the full content online](https://pwning.owasp-juice.shop)!
   HTML5
 * [PDF of the Intro Slide Deck](docs/OWASP%20Juice%20Shop%20-%20Probably%20the%20most%20modern%20and%20sophisticated%20insecure%20web%20application.pdf)
 
-## Contributing [![GitHub contributors](https://img.shields.io/github/contributors/bkimminich/juice-shop.svg)](https://github.com/bkimminich/juice-shop/graphs/contributors) [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/) [![Crowdin](https://d322cqt584bo4o.cloudfront.net/owasp-juice-shop/localized.svg)](https://crowdin.com/project/owasp-juice-shop) [![Bountysource Activity](https://img.shields.io/bountysource/team/juice-shop/activity.svg)](https://www.bountysource.com/teams/juice-shop) ![GitHub issues by-label](https://img.shields.io/github/issues/bkimminich/juice-shop/help%20wanted.svg) ![GitHub issues by-label](https://img.shields.io/github/issues/bkimminich/juice-shop/good%20first%20issue.svg)
+## Contributing [![GitHub contributors](https://img.shields.io/github/contributors/bkimminich/juice-shop.svg)](https://github.com/bkimminich/juice-shop/graphs/contributors) [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/) [![Crowdin](https://d322cqt584bo4o.cloudfront.net/owasp-juice-shop/localized.svg)](https://crowdin.com/project/owasp-juice-shop) [![Bountysource Activity](https://img.shields.io/bountysource/team/juice-shop/activity.svg)](https://www.bountysource.com/teams/juice-shop) ![GitHub issues by-label](https://img.shields.io/github/issues/bkimminich/juice-shop/help%20wanted.svg) ![GitHub issues by-label](https://img.shields.io/github/issues/bkimminich/juice-shop/good%20first%20issue.svg)
 
 We are always happy to get new contributors on board! Please check
 [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to

--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ docker run -d -p 80:3000 bkimminich/juice-shop
    --ip-address public`
 4. Your container will be available at `http://<dns name
    label>.<location name>.azurecontainer.io:3000`
+   
+### Google Compute Engine Instance
+
+1. Login to the Google Cloud Console and [open Cloud Shell](https://console.cloud.google.com/home/dashboard?cloudshell=true).
+2. Launch a new GCE instance based on the juice-shop container. Take note of the `EXTERNAL_IP` provided in the output.
+```
+gcloud compute instances create-with-container owasp-juice-shop-app --container-image bkimminich/juice-shop
+```
+
+3. Create a firewall rule that allows inbound traffic to port 3000
+```
+gcloud compute firewall-rules create juice-rule --allow tcp:3000
+```
+    
+4. Your container is now running and available at `http://[EXTERNAL_IP]:3000/`
 
 ## Node.js version compatibility
 

--- a/frontend/src/app/about/about.component.html
+++ b/frontend/src/app/about/about.component.html
@@ -23,7 +23,7 @@
         delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit,
         sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
 
-        <a href="/ftp/legal.md" aria-label="Link to the Terms of Use" translate>LINK_TERMS_OF_USE</a>
+        <a href="ftp/legal.md" aria-label="Link to the Terms of Use" translate>LINK_TERMS_OF_USE</a>
 
         At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
         Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod

--- a/server.js
+++ b/server.js
@@ -176,16 +176,28 @@ app.use('/assets/i18n', verify.accessControlChallenges())
 /* Checks for challenges solved by abusing SSTi and SSRF bugs */
 app.use('/solve/challenges/server-side', verify.serverSideChallenges())
 
+/* Create middleware to change paths from the serve-index plugin from absolute to relative */
+const serveIndexMiddleware = (req, res, next) => {
+  const origEnd = res.end
+  res.end = function () {
+    if (arguments.length) {
+      arguments[0] = arguments[0].replace(/a href="\/([^"]+?)"/, 'a href="$1"')
+    }
+    origEnd.apply(this, arguments)
+  }
+  next()
+}
+
 /* /ftp directory browsing and file download */
-app.use('/ftp', serveIndex('ftp', { icons: true }))
+app.use('/ftp', serveIndexMiddleware, serveIndex('ftp', { icons: true }))
 app.use('/ftp/:file', fileServer())
 
 /* /encryptionkeys directory browsing */
-app.use('/encryptionkeys', serveIndex('encryptionkeys', { icons: true, view: 'details' }))
+app.use('/encryptionkeys', serveIndexMiddleware, serveIndex('encryptionkeys', { icons: true, view: 'details' }))
 app.use('/encryptionkeys/:file', keyServer())
 
 /* /logs directory browsing */
-app.use('/support/logs', serveIndex('logs', { icons: true, view: 'details' }))
+app.use('/support/logs', serveIndexMiddleware, serveIndex('logs', { icons: true, view: 'details' }))
 app.use('/support/logs', verify.accessControlChallenges())
 app.use('/support/logs/:file', logFileServer())
 

--- a/server.js
+++ b/server.js
@@ -178,6 +178,7 @@ app.use('/solve/challenges/server-side', verify.serverSideChallenges())
 
 /* Create middleware to change paths from the serve-index plugin from absolute to relative */
 const serveIndexMiddleware = (req, res, next) => {
+<<<<<<< HEAD
   const origEnd = res.end
   res.end = function () {
     if (arguments.length) {
@@ -186,6 +187,16 @@ const serveIndexMiddleware = (req, res, next) => {
     origEnd.apply(this, arguments)
   }
   next()
+=======
+	const origEnd = res.end
+	res.end = function() {
+		if(arguments.length) {
+			arguments[0] = arguments[0].replace(/a href="\/([^"]+?)"/, 'a href="$1"')
+		}
+		origEnd.apply(this, arguments)
+	}
+	next()
+>>>>>>> Patch output from serve-index package to fix it breaking links in subdirectories
 }
 
 /* /ftp directory browsing and file download */


### PR DESCRIPTION
Before: Running juiceshop ina subdirectory broke the links to files that are interacted with using the serve-index package (eg /ftp), as it uses an absolute link. From domain.com/subdir/ftp it will link to domain.com/ftp (which is not available).

Now: All links are rewritten to be relative, so that even if it runs in a subfolder it will continue to work.

There should be no impact for projects in the root directory.