### PR TITLE
align schema with config/fbctf.yml

### DIFF
--- a/config.schema.yml
+++ b/config.schema.yml
@@ -626,3 +626,13 @@ ctf:
         type: string
       code:
         type: string
+    xssBonusChallenge:
+      name:
+        type: string
+      code:
+        type: string
+    resetPasswordUvoginChallenge:
+      name:
+        type: string
+      code:
+        type: string


### PR DESCRIPTION
Juice shop currently won't start with fbctf because fbctf.yml is considered invalid since xssBonusChallenge and resetPasswordUvoginChallenge were added.