### PR TITLE
Disallow closing the welcome banner when restrictToTutorialsFirst is enabled

### DIFF
--- a/frontend/src/app/welcome-banner/welcome-banner.component.html
+++ b/frontend/src/app/welcome-banner/welcome-banner.component.html
@@ -19,6 +19,7 @@
       <span fxShow fxHide.lt-lg translate>BTN_GETTING_STARTED</span>
     </button>
     <button mat-raised-button class="close-dialog" (click)="closeWelcome()" color="primary"
+            *ngIf="showDismissBtn"
             aria-label="Close Welcome Banner">
       <mat-icon>
         visibility_off

--- a/frontend/src/app/welcome-banner/welcome-banner.component.ts
+++ b/frontend/src/app/welcome-banner/welcome-banner.component.ts
@@ -17,6 +17,7 @@ export class WelcomeBannerComponent implements OnInit {
   public title: string = 'Welcome to OWASP Juice Shop'
   public message: string = "<p>Being a web application with a vast number of intended security vulnerabilities, the <strong>OWASP Juice Shop</strong> is supposed to be the opposite of a best practice or template application for web developers: It is an awareness, training, demonstration and exercise tool for security risks in modern web applications. The <strong>OWASP Juice Shop</strong> is an open-source project hosted by the non-profit <a href='https://owasp.org' target='_blank'>Open Web Application Security Project (OWASP)</a> and is developed and maintained by volunteers. Check out the link below for more information and documentation on the project.</p><h1><a href='https://owasp-juice.shop' target='_blank'>https://owasp-juice.shop</a></h1>"
   public showHackingInstructor: boolean = true
+  public showDismissBtn: boolean = true
 
   private readonly welcomeBannerStatusCookieKey = 'welcomebanner_status'
 
@@ -33,6 +34,11 @@ export class WelcomeBannerComponent implements OnInit {
       }
       if (config && config.application) {
         this.showHackingInstructor = config.hackingInstructor && config.hackingInstructor.isEnabled
+      }
+      // Don't allow to skip the tutorials when restrictToTutorialsFirst and showHackingInstructor are enabled
+      if (this.showHackingInstructor && config.challenges && config.challenges.restrictToTutorialsFirst) {
+        this.dialogRef.disableClose = true
+        this.showDismissBtn = false
       }
     }, (err) => console.log(err))
   }


### PR DESCRIPTION
Fixes #1389 

The logic according to the showHackingInstructor and restrictToTutorialsFirst flags
| showHackingInstructor        | restrictToTutorialsFirst           | Result  |
| ------------- |:-------------:| -----:|
| True      | True | Disallow dismiss |
| True      | False      |   Allow dismiss |
| False | True      |    Allow dismiss |
| False | False      |    Allow dismiss |

Please review and merge if ok.

Thanks,
Rotem