### PR TITLE
Fix OWASP Top 10 broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ OWASP Juice Shop is probably the most modern and sophisticated insecure
 web application! It can be used in security trainings, awareness demos,
 CTFs and as a guinea pig for security tools! Juice Shop encompasses
 vulnerabilities from the entire
-[OWASP Top Ten](https://www.owasp.org/index.php/OWASP_Top_Ten) along
+[OWASP Top Ten](https://owasp.org/www-project-top-ten) along
 with many other security flaws found in real-world applications!
 
 ![Juice Shop Screenshot Slideshow](screenshots/slideshow.gif)


### PR DESCRIPTION
The [old link](https://www.owasp.org/index.php/OWASP_Top_Ten) for the OWASP top ten is broken and goes to a 404 page. The new link is [https://owasp.org/www-project-top-ten](https://owasp.org/www-project-top-ten).