### PR TITLE
Fix Server Crash on Undeliverable Challenge Solved Webhook

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,7 +116,9 @@ exports.solve = function (challenge, isRestore) {
     logger.info(colors.green('Solved') + ' challenge ' + colors.cyan(solvedChallenge.name) + ' (' + solvedChallenge.description + ')')
     self.sendNotification(solvedChallenge, isRestore)
     if (process.env.SOLUTIONS_WEBHOOK && !isRestore) {
-      webhook.notify(solvedChallenge)
+      webhook.notify(solvedChallenge).catch((error) => {
+        logger.error('Webhook notification failed: ' + colors.red(error.message))
+      })
     }
   })
 }

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -4,14 +4,16 @@
  */
 
 const request = require('request')
+const { promisify } = require('util')
 const colors = require('colors/safe')
 const logger = require('../lib/logger')
 const utils = require('../lib/utils')
 const os = require('os')
 const config = require('config')
+const post = promisify(request.post)
 
-exports.notify = (challenge, webhook = process.env.SOLUTIONS_WEBHOOK) => {
-  request.post(webhook, {
+exports.notify = async (challenge, webhook = process.env.SOLUTIONS_WEBHOOK) => {
+  const res = await post(webhook, {
     json: {
       solution: {
         challenge: challenge.key,
@@ -27,11 +29,6 @@ exports.notify = (challenge, webhook = process.env.SOLUTIONS_WEBHOOK) => {
         version: utils.version()
       }
     }
-  }, (error, res) => {
-    if (error) {
-      logger.error('Webhook notification failed: ' + colors.red(error.message))
-      throw error
-    }
-    logger.info(`Webhook ${colors.bold(webhook)} notified about ${colors.cyan(challenge.key)} being solved: ${res.statusCode < 400 ? colors.green(res.statusCode) : colors.red(res.statusCode)}`)
   })
+  logger.info(`Webhook ${colors.bold(webhook)} notified about ${colors.cyan(challenge.key)} being solved: ${res.statusCode < 400 ? colors.green(res.statusCode) : colors.red(res.statusCode)}`)
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "serve": "concurrently --kill-others \"node app\" \"cd frontend && ng serve\"",
     "start": "node app",
     "test": "cd frontend && ng test --watch=false --source-map=true && cd .. && nyc --report-dir=./build/reports/coverage/server-tests mocha test/server",
+    "test:server": "nyc --report-dir=./build/reports/coverage/server-tests mocha test/server",
     "test:chromium": "cd frontend && ng test --watch=false --source-map=false --browsers=ChromiumHeadless && cd .. && nyc --report-dir=./build/reports/coverage/server-tests mocha test/server",
     "vagrant": "cd vagrant && vagrant up"
   },
@@ -165,6 +166,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "cross-spawn": "^7.0.3",
     "frisby": "^2.1.2",
     "grunt-cli": "^1.3.2",

--- a/test/server/webhookSpec.js
+++ b/test/server/webhookSpec.js
@@ -5,6 +5,8 @@
 
 const chai = require('chai')
 const expect = chai.expect
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
 
 describe('webhook', () => {
   const webhook = require('../../lib/webhook')
@@ -16,15 +18,15 @@ describe('webhook', () => {
 
   describe('notify', () => {
     it('fails when no webhook URL is provided via environment variable', () => {
-      expect(() => webhook.notify(challenge)).to.throw('options.uri is a required argument')
+      expect(webhook.notify(challenge)).to.eventually.throw('options.uri is a required argument')
     })
 
     it('fails when supplied webhook is not a valid URL', () => {
-      expect(() => webhook.notify(challenge, 'localhorst')).to.throw('Invalid URI "localhorst"')
+      expect(webhook.notify(challenge, 'localhorst')).to.eventually.throw('Invalid URI "localhorst"')
     })
 
     it('submits POST with payload to existing URL', () => {
-      expect(() => webhook.notify(challenge, 'https://enmmrmqnft1o.x.pipedream.net')).to.not.throw()
+      expect(webhook.notify(challenge, 'https://enmmrmqnft1o.x.pipedream.net')).to.eventually.not.throw()
     })
   })
 })


### PR DESCRIPTION
This can happen when the configured domain doesn't exist or doesn't respond at all.

This leads to errors like the following:

```bash
info: Solved challenge Score Board (Find the carefully hidden 'Score Board' page.)
error: Webhook notification failed: connect ECONNREFUSED 10.110.238.153:80
/juice-shop/lib/webhook.js:33
      throw error
      ^

Error: connect ECONNREFUSED 10.110.238.153:80
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1141:16) {
  errno: 'ECONNREFUSED',
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '10.110.238.153',
  port: 80
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! juice-shop@12.0.2 start: `node app`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the juice-shop@12.0.2 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/juicer/.npm/_logs/2020-11-20T17_49_42_309Z-debug.log
```

Had to do some bigger changes than I expected so that the function properly throws and catches the async error and are usable in the server tests.