### PR TITLE
Clear token from cookie and local storage to better clean

### DIFF
--- a/frontend/src/app/server-started-notification/server-started-notification.component.ts
+++ b/frontend/src/app/server-started-notification/server-started-notification.component.ts
@@ -65,6 +65,10 @@ export class ServerStartedNotificationComponent implements OnInit {
 
   clearProgress () {
     this.cookieService.delete('continueCode', '/')
+    this.cookieService.delete('token', '/')
+    sessionStorage.removeItem('bid')
+    sessionStorage.removeItem('itemTotal')
+    localStorage.removeItem('token')
     localStorage.removeItem('displayedDifficulties')
     localStorage.removeItem('showSolvedChallenges')
     localStorage.removeItem('showDisabledChallenges')


### PR DESCRIPTION
Prevent the state where we are disconnected (from the app point of view
since we did not login) while the UI shows us still connected because we
still have a token in cookie/localstorage

Another option would be to call the logout function from navbar, but I don't know how to do it. What do you think?