### PR TITLE
Fix password hint popup was skipped in "Log in with Bender/Jim's user account"

### DIFF
--- a/frontend/src/hacking-instructor/challenges/loginBender.ts
+++ b/frontend/src/hacking-instructor/challenges/loginBender.ts
@@ -7,7 +7,7 @@ import {
   waitForInputToHaveValue,
   waitForElementToGetClicked,
   waitInMs,
-  waitForAngularRouteToBeVisited, waitForLogOut, waitForInputToNotHaveValue
+  waitForAngularRouteToBeVisited, waitForLogOut, waitForInputToNotHaveValueAndNotBeEmpty
 } from '../helpers/helpers'
 import { ChallengeInstruction } from '../'
 
@@ -69,7 +69,7 @@ export const LoginBenderInstruction: ChallengeInstruction = {
       text: "Now put anything in the **password field**. Let's assume we don't know it yet, even if you happen to already do.",
       fixture: '#password',
       unskippable: true,
-      resolved: waitForInputToNotHaveValue('#password', 'OhG0dPlease1nsertLiquor!')
+      resolved: waitForInputToNotHaveValueAndNotBeEmpty('#password', 'OhG0dPlease1nsertLiquor!')
     },
     {
       text: 'Press the _Log in_ button.',

--- a/frontend/src/hacking-instructor/challenges/loginJim.ts
+++ b/frontend/src/hacking-instructor/challenges/loginJim.ts
@@ -7,7 +7,7 @@ import {
   waitForInputToHaveValue,
   waitForElementToGetClicked,
   waitInMs,
-  waitForAngularRouteToBeVisited, waitForLogOut, waitForInputToNotHaveValue
+  waitForAngularRouteToBeVisited, waitForLogOut, waitForInputToNotHaveValueAndNotBeEmpty
 } from '../helpers/helpers'
 import { ChallengeInstruction } from '../'
 
@@ -69,7 +69,7 @@ export const LoginJimInstruction: ChallengeInstruction = {
       text: "Now put anything in the **password field**. Let's assume we don't know it yet, even if you happen to already do.",
       fixture: '#password',
       unskippable: true,
-      resolved: waitForInputToNotHaveValue('#password', 'ncc-1701')
+      resolved: waitForInputToNotHaveValueAndNotBeEmpty('#password', 'ncc-1701')
     },
     {
       text: 'Press the _Log in_ button.',

--- a/frontend/src/hacking-instructor/helpers/helpers.ts
+++ b/frontend/src/hacking-instructor/helpers/helpers.ts
@@ -35,7 +35,7 @@ export function waitForInputToNotHaveValue (inputSelector: string, value: string
     while (true) {
       if (inputElement.value !== value) {
         break
-      } else if (options.ignoreCase && inputElement.value.toLowerCase() === value.toLowerCase()) {
+      } else if (options.ignoreCase && inputElement.value.toLowerCase() !== value.toLowerCase()) {
         break
       }
       await sleep(100)

--- a/frontend/src/hacking-instructor/helpers/helpers.ts
+++ b/frontend/src/hacking-instructor/helpers/helpers.ts
@@ -43,6 +43,25 @@ export function waitForInputToNotHaveValue (inputSelector: string, value: string
   }
 }
 
+export function waitForInputToNotHaveValueAndNotBeEmpty (inputSelector: string, value: string, options = { ignoreCase: true }) {
+  return async () => {
+    const inputElement = document.querySelector(
+      inputSelector
+    ) as HTMLInputElement
+
+    while (true) {
+      if (inputElement.value != "") {
+        if (inputElement.value !== value) {
+          break
+        } else if (options.ignoreCase && inputElement.value.toLowerCase() !== value.toLowerCase()) {
+          break
+        }
+      }
+      await sleep(100)
+    }
+  }
+}
+
 export function waitForInputToNotBeEmpty (inputSelector: string) {
   return async () => {
     const inputElement = document.querySelector(

--- a/frontend/src/hacking-instructor/helpers/helpers.ts
+++ b/frontend/src/hacking-instructor/helpers/helpers.ts
@@ -16,9 +16,9 @@ export function waitForInputToHaveValue (inputSelector: string, value: string, o
     ) as HTMLInputElement
 
     while (true) {
-      if (inputElement.value === value) {
+      if (options.ignoreCase && inputElement.value.toLowerCase() === value.toLowerCase()) {
         break
-      } else if (options.ignoreCase && inputElement.value.toLowerCase() === value.toLowerCase()) {
+      } else if (!options.ignoreCase && inputElement.value === value) {
         break
       }
       await sleep(100)
@@ -33,11 +33,11 @@ export function waitForInputToNotHaveValue (inputSelector: string, value: string
     ) as HTMLInputElement
 
     while (true) {
-      if (inputElement.value !== value) {
+      if (options.ignoreCase && inputElement.value.toLowerCase() !== value.toLowerCase()) {
         break
-      } else if (options.ignoreCase && inputElement.value.toLowerCase() !== value.toLowerCase()) {
+      } else if (!options.ignoreCase && inputElement.value !== value) {
         break
-      }
+      } else 
       await sleep(100)
     }
   }
@@ -51,9 +51,9 @@ export function waitForInputToNotHaveValueAndNotBeEmpty (inputSelector: string, 
 
     while (true) {
       if (inputElement.value != "") {
-        if (inputElement.value !== value) {
+        if (options.ignoreCase && inputElement.value.toLowerCase() !== value.toLowerCase()) {
           break
-        } else if (options.ignoreCase && inputElement.value.toLowerCase() !== value.toLowerCase()) {
+        } else if (!options.ignoreCase && inputElement.value !== value) {
           break
         }
       }

--- a/frontend/src/hacking-instructor/helpers/helpers.ts
+++ b/frontend/src/hacking-instructor/helpers/helpers.ts
@@ -37,7 +37,7 @@ export function waitForInputToNotHaveValue (inputSelector: string, value: string
         break
       } else if (!options.ignoreCase && inputElement.value !== value) {
         break
-      } else 
+      }
       await sleep(100)
     }
   }
@@ -50,7 +50,7 @@ export function waitForInputToNotHaveValueAndNotBeEmpty (inputSelector: string, 
     ) as HTMLInputElement
 
     while (true) {
-      if (inputElement.value != "") {
+      if (inputElement.value !== '') {
         if (options.ignoreCase && inputElement.value.toLowerCase() !== value.toLowerCase()) {
           break
         } else if (!options.ignoreCase && inputElement.value !== value) {


### PR DESCRIPTION
I noticed that the tutorial did not advise me to input a password and wanted me to login immediately (which does not work because the password field was empty) 🤔. Then I noticed in the source-code that actually there was supposed to be a check to verify that the password was not the expected one (to force us to use the SQL injection), but it did not verify that the value wasn't actually empty and thus this hint ("Now put anything in the **password field**. Let's assume we don't know it yet, even if you happen to already do") was skipped (because \<empty\> != \<real password\>) 🙃
So I created a new function `waitForInputToNotHaveValueAndNotBeEmpty`

I also re-ordered and added explicit checks for `ignoreCase` option, and fixed an invalid check ✔

I tested with this code and now:
* the password hint is indeed displayed, until something is typed
* the password hint does not go away if the real password is typed

By the way, this feature is awesome and I really like the framework you created to easily implement these tutorials! 👏