### PR TITLE
Add fixtureAfter to insert hint after fixture

### DIFF
--- a/frontend/src/hacking-instructor/challenges/forgedFeedback.ts
+++ b/frontend/src/hacking-instructor/challenges/forgedFeedback.ts
@@ -11,6 +11,7 @@ export const ForgedFeedbackInstruction: ChallengeInstruction = {
       text:
           'To start this challenge, first go to the _Customer Feedback_ page.',
       fixture: 'app-navbar',
+      fixtureAfter: true,
       unskippable: true,
       resolved: waitForAngularRouteToBeVisited('contact')
     },

--- a/frontend/src/hacking-instructor/challenges/loginAdmin.ts
+++ b/frontend/src/hacking-instructor/challenges/loginAdmin.ts
@@ -26,6 +26,7 @@ export const LoginAdminInstruction: ChallengeInstruction = {
       text:
         "Let's try if we find a way to log in with the administrator's user account. To begin, go to the _Login_ page via the _Account_ menu.",
       fixture: 'app-navbar',
+      fixtureAfter: true,
       unskippable: true,
       resolved: waitForAngularRouteToBeVisited('login')
     },

--- a/frontend/src/hacking-instructor/challenges/loginBender.ts
+++ b/frontend/src/hacking-instructor/challenges/loginBender.ts
@@ -25,6 +25,7 @@ export const LoginBenderInstruction: ChallengeInstruction = {
       text:
         "Let's try if we find a way to log in with Bender's user account. To begin, go to the _Login_ page via the _Account_ menu.",
       fixture: 'app-navbar',
+      fixtureAfter: true,
       unskippable: true,
       resolved: waitForAngularRouteToBeVisited('login')
     },
@@ -50,6 +51,7 @@ export const LoginBenderInstruction: ChallengeInstruction = {
       text:
         'Go to the _About Us_ page where user feedback is displayed among other things.',
       fixture: 'app-navbar',
+      fixtureAfter: true,
       resolved: waitForAngularRouteToBeVisited('about')
     },
     {

--- a/frontend/src/hacking-instructor/challenges/loginJim.ts
+++ b/frontend/src/hacking-instructor/challenges/loginJim.ts
@@ -25,6 +25,7 @@ export const LoginJimInstruction: ChallengeInstruction = {
       text:
         "Let's try if we find a way to log in with Jim's user account. To begin, go to the _Login_ page via the _Account_ menu.",
       fixture: 'app-navbar',
+      fixtureAfter: true,
       unskippable: true,
       resolved: waitForAngularRouteToBeVisited('login')
     },

--- a/frontend/src/hacking-instructor/challenges/passwordStrength.ts
+++ b/frontend/src/hacking-instructor/challenges/passwordStrength.ts
@@ -32,6 +32,7 @@ export const PasswordStrengthInstruction: ChallengeInstruction = {
       text:
         "If you don't know it already, you must first find out the admin's email address. The user feedback and product reviews are good places to look into. When you have it, go to the _Login_ page.",
       fixture: 'app-navbar',
+      fixtureAfter: true,
       unskippable: true,
       resolved: waitForAngularRouteToBeVisited('login')
     },

--- a/frontend/src/hacking-instructor/challenges/privacyPolicy.ts
+++ b/frontend/src/hacking-instructor/challenges/privacyPolicy.ts
@@ -15,6 +15,7 @@ export const PrivacyPolicyInstruction: ChallengeInstruction = {
       text:
         'Log in with any user to begin this challenge. You can use an existing or freshly registered account.',
       fixture: 'app-navbar',
+      fixtureAfter: true,
       unskippable: true,
       resolved: waitForLogIn()
     },

--- a/frontend/src/hacking-instructor/challenges/viewBasket.ts
+++ b/frontend/src/hacking-instructor/challenges/viewBasket.ts
@@ -70,6 +70,7 @@ export const ViewBasketInstruction: ChallengeInstruction = {
       text:
           'Now, go to any other screen and then back to _Your Basket_. If nothing happens you might have set an invalid or non-existing `bid`. Try another in that case.',
       fixture: 'app-navbar',
+      fixtureAfter: true,
       unskippable: true,
       async resolved () {
         let total = sessionStorage.getItem('itemTotal')
@@ -84,7 +85,7 @@ export const ViewBasketInstruction: ChallengeInstruction = {
     {
       text:
           "🎉 Congratulations! You are now viewing another user's shopping basket!",
-      fixture: 'app-navbar',
+      fixture: 'app-basket',
       resolved: waitInMs(15000)
     }
   ]

--- a/frontend/src/hacking-instructor/index.ts
+++ b/frontend/src/hacking-instructor/index.ts
@@ -49,6 +49,11 @@ export interface ChallengeHint {
    */
   fixture: string
   /**
+   * Set to true if the hint should be displayed after the target
+   * Defaults to false (hint displayed before target)
+   */
+  fixtureAfter?: boolean
+  /**
    * Set to true if the hint should not be able to be skipped by clicking on it.
    * Defaults to false
    */
@@ -105,7 +110,13 @@ function loadHint (hint: ChallengeHint): HTMLElement {
   relAnchor.style.display = 'inline'
   relAnchor.appendChild(elem)
 
-  target.parentElement!.insertBefore(relAnchor, target)
+  if (hint.fixtureAfter) {
+    // insertAfter does not exist so we simulate it this way
+    target.parentElement!.insertBefore(relAnchor, target.nextSibling)
+  }
+  else {
+    target.parentElement!.insertBefore(relAnchor, target)
+  }
 
   return relAnchor
 }


### PR DESCRIPTION
Instead of before fixture otherwise. Helps to prevents cases where the
hint box hides the menu button or another mandatory UI item

* Before:
![image](https://user-images.githubusercontent.com/550823/100682309-18ca4a00-3376-11eb-9c60-c9090a9e3746.png)

* After:
![image](https://user-images.githubusercontent.com/550823/100682316-1d8efe00-3376-11eb-906b-425fd49547f7.png)

* Before 2:
![image](https://user-images.githubusercontent.com/550823/100682323-21bb1b80-3376-11eb-9dd8-b091d0d93670.png)

* After 2:
![image](https://user-images.githubusercontent.com/550823/100682333-254ea280-3376-11eb-9f6d-49af933981a8.png)

I tried to identify all cases where it could be useful.

I also tried to apply it everywhere, instead of optionally, but it was worse in some cases (e.g. had to scroll the window horizontally)