### PR TITLE
Fix devtools detection perf issue on Firefox

### DIFF
--- a/frontend/src/hacking-instructor/helpers/helpers.ts
+++ b/frontend/src/hacking-instructor/helpers/helpers.ts
@@ -160,6 +160,7 @@ export function waitForDevTools () {
   return async () => {
     while (true) {
       console.dir(element)
+      console.clear()
       if (checkStatus) {
         break
       }


### PR DESCRIPTION
Clearing console allows to not overload it on Firefox. Detection still
does not work (whereas it works on Chrome), but it will properly stop
and won't overload CPU/RAM.
Idea by @J12934
Closes #1525