### PR TITLE
Run unit tests also on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
       - name: "Install application"
         run: npm install
       - name: "Execute unit tests"
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' # FIXME Reliability issues with tests on Windows are a known issue from Travis-CI
         run: npm test
       - name: "Execute integration tests"
         run: |


### PR DESCRIPTION
(testing stability, might get deactivated again
if they continue to fail)