### PR TITLE
Add on: pull_request trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "Code Scanning"
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 18 * * 6'
 

--- a/SOLUTIONS.md
+++ b/SOLUTIONS.md
@@ -78,6 +78,7 @@ Shop easier to hack!
   * [Level 1](https://youtu.be/ccy-eKYpdbk)
   * [Level 2](https://youtu.be/KtMPEDJx0Sg)
   * [Level 3](https://youtu.be/aqXfFVHJ91g)
+  * [Level 4](https://youtu.be/jfe-iEePlTc)
 * [HackerOne #h1-2004 Community Day: Intro to Web Hacking - OWASP Juice Shop](https://youtu.be/KmlwIwG7Kv4)
   by [Nahamsec](https://twitch.tv/nahamsec) including the creation of a
   (fake) bugbounty report for all findings (🧃`v10.x`)


### PR DESCRIPTION
From February 2021, in order to provide feedback on pull requests, Code Scanning workflows must be configured with both `push` and `pull_request` triggers. This is because Code Scanning compares the results from a pull request against the results for the base branch to tell you only what has changed between the two.

Early in the beta period we supported displaying results on pull requests for workflows with only `push` triggers, but have discontinued support as this proved to be less robust.

See https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#scanning-pull-requests for more information on how best to configure your Code Scanning workflows.
