### PR TITLE
Fix DataCreator

### DIFF
--- a/data/datacreator.js
+++ b/data/datacreator.js
@@ -150,7 +150,7 @@ async function createDeliveryMethods () {
   )
 }
 
-function createAddresses (UserId, addresses) {
+async function createAddresses (UserId, addresses) {
   addresses.map((address) => {
     return models.Address.create({
       UserId: UserId,


### PR DESCRIPTION
Issues: An undefined value is used at this 'await' expression. Consider awaiting a 'Promise' object instead or removing the 'await' keyword if async execution was not intended. Note that the undefined value is originated from the return value of 'create addresses()' 

Resolve the data/datacreator.js file 