### PR TITLE
Display filename of vulnerable code snippet

### DIFF
--- a/frontend/src/app/code-snippet/code-snippet.component.html
+++ b/frontend/src/app/code-snippet/code-snippet.component.html
@@ -9,6 +9,7 @@
   </header>
   <mat-divider></mat-divider>
   <div class="container" fxLayout="column">
+    <h2>{{snippet?.vulnFile}}</h2>
     <div fxLayout="row" fxLayoutGap="10px">
       <div>
         <pre><code [highlight]="snippet?.snippet || ('LOADING_CODE_SNIPPET' | translate)" [lineNumbers]="true"></code></pre>

--- a/routes/vulnCodeSnippet.ts
+++ b/routes/vulnCodeSnippet.ts
@@ -22,7 +22,8 @@ exports.serveCodeSnippet = () => async (req, res, next) => {
       .collect(asArray())
       .find(new RegExp(`vuln-code-snippet start.*${challenge.key}`))
     if (matches[0]) { // TODO Currently only a single source file is supported
-      const source = fs.readFileSync(path.resolve(matches[0].path), 'utf8')
+      const vulnFile = path.resolve(matches[0].path)
+      const source = fs.readFileSync(vulnFile, 'utf8')
       const snippets = source.match(`[/#]{0,2} vuln-code-snippet start.*${challenge.key}([^])*vuln-code-snippet end.*${challenge.key}`)
       if (snippets != null) {
         let snippet = snippets[0] // TODO Currently only a single code snippet is supported
@@ -43,7 +44,7 @@ exports.serveCodeSnippet = () => async (req, res, next) => {
         }
         snippet = snippet.replace(/[/#]{0,2} vuln-code-snippet vuln-line.*/g, '')
 
-        return res.json({ snippet, vulnLines })
+        return res.json({ snippet, vulnLines, vulnFile })
       } else {
         res.status(422).json({ status: 'error', error: 'Broken code snippet boundaries for: ' + challenge.key })
       }

--- a/test/api/vulnCodeSnippetSpec.ts
+++ b/test/api/vulnCodeSnippetSpec.ts
@@ -26,7 +26,8 @@ describe('/snippets/:challenge', () => {
       .expect('status', 200)
       .expect('jsonTypes', {
         snippet: Joi.string(),
-        vulnLines: Joi.array()
+        vulnLines: Joi.array(),
+        vulnFile: Joi.string()
       })
   })
 })


### PR DESCRIPTION
Signed-off-by: chinggg <24590067+chinggg@users.noreply.github.com>

Show filename along with full path above the vulnerable code snippet.

I think showing the filename may come in useful for the upcoming coding challenge in the future