### PR TITLE
fix: handle unhandled promise rejection in basket items

### DIFF
--- a/routes/basketItems.ts
+++ b/routes/basketItems.ts
@@ -52,7 +52,9 @@ module.exports.addBasketItem = function addBasketItem () {
 
 module.exports.quantityCheckBeforeBasketItemAddition = function quantityCheckBeforeBasketItemAddition () {
   return (req, res, next) => {
-    void quantityCheck(req, res, next, req.body.ProductId, req.body.quantity)
+    void quantityCheck(req, res, next, req.body.ProductId, req.body.quantity).catch(error => {
+      next(error)
+    })
   }
 }
 


### PR DESCRIPTION
When calling `/api/BasketItems/` with invalid payload like this:

```json
{
    "ProductId": 44,
    "BasketId": "6",
    "quantity": 1
}
```

The request hangs for ever due to handled promise rejection:

```
(node:15206) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'limitPerUser' of null
    at quantityCheck (/Users/omerlh/dev/juice-shop/build/routes/basketItems.js:76:18)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:15206) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:15206) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This PR added `catch` to one of the function that didn't had it - and now we have nice error:

![image](https://user-images.githubusercontent.com/6730584/116974773-46217800-acc7-11eb-8371-e76e343d7223.png)
