### PR TITLE
Fix Bug Causing `GET /snippets` Response To Grow on Every API Call

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "@types/frisby": "^2.0.10",
     "@types/fs-extra": "^9.0.6",
     "@types/glob": "^7.1.3",
+    "@types/graceful-fs": "^4.1.5",
     "@types/i18n": "^0.12.0",
     "@types/jest": "^26.0.20",
     "@types/js-yaml": "^3.12.6",


### PR DESCRIPTION
This changes the `fileSniff` function to call itself recursively instead of writing nested folders in the shared paths array.
Also adds some typesafety to the function :)