### PR TITLE
Fix error rendering bug in 'Change Password' form

### DIFF
--- a/frontend/src/app/change-password/change-password.component.ts
+++ b/frontend/src/app/change-password/change-password.component.ts
@@ -59,12 +59,12 @@ export class ChangePasswordComponent {
 
   resetForm () {
     this.passwordControl.setValue('')
-    this.passwordControl.markAsPristine()
-    this.passwordControl.markAsUntouched()
     this.resetPasswords()
   }
 
   resetPasswords () {
+    this.passwordControl.markAsPristine()
+    this.passwordControl.markAsUntouched()
     this.newPasswordControl.setValue('')
     this.newPasswordControl.markAsPristine()
     this.newPasswordControl.markAsUntouched()


### PR DESCRIPTION
Fixes #1733 

The error is not being displayed because the hidden condition is:
https://github.com/juice-shop/juice-shop/blob/57b5d56da23104a7040371eb919147f917386950/frontend/src/app/change-password/change-password.component.html#L17

This condition always remains `true` because `passwordControl.dirty` always remains true. This is due to the fact that whenever the server returns an error, then `resetPasswords()` is  called, which only sets `newPasswordControl` and `repeatNewPasswordControl` to untouched & pristine and not `passwordControl`. Therefore, `passwordControl` always remains dirty.
https://github.com/juice-shop/juice-shop/blob/5315f9c1f77be16b2509ee5b3e770ad987cc48d3/frontend/src/app/change-password/change-password.component.ts#L52-L57

To solve this issue, I shifted lines 62 and 63 to `resetPasswords()`
https://github.com/juice-shop/juice-shop/blob/5315f9c1f77be16b2509ee5b3e770ad987cc48d3/frontend/src/app/change-password/change-password.component.ts#L60-L74

_Tested on:_
OS: Windows 10
Browser: Google Chrome - Version 94.0.4606.81 (Official Build) (64-bit)