### PR TITLE
Fix Sqlite Issue on ARM & MacOS by Updating sqlite Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16 as installer
 COPY . /juice-shop
 WORKDIR /juice-shop
 RUN npm i -g typescript ts-node
-RUN npm install --production --unsafe-perm
+RUN npm install --omit=dev --unsafe-perm
 RUN npm dedupe
 RUN rm -rf frontend/node_modules
 RUN mkdir logs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ RUN npm i -g typescript ts-node
 RUN npm install --production --unsafe-perm
 RUN npm dedupe
 RUN rm -rf frontend/node_modules
+RUN mkdir logs && \
+    chown -R 65532 logs && \
+    chgrp -R 0 ftp/ frontend/dist/ logs/ data/ i18n/ && \
+    chmod -R g=u ftp/ frontend/dist/ logs/ data/ i18n/
 
-FROM node:16-alpine
+FROM gcr.io/distroless/nodejs:16
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL maintainer="Bjoern Kimminich <bjoern.kimminich@owasp.org>" \
@@ -22,13 +26,7 @@ LABEL maintainer="Bjoern Kimminich <bjoern.kimminich@owasp.org>" \
     org.opencontainers.image.revision=$VCS_REF \
     org.opencontainers.image.created=$BUILD_DATE
 WORKDIR /juice-shop
-RUN addgroup --system --gid 1001 juicer && \
-    adduser juicer --system --uid 1001 --ingroup juicer
-COPY --from=installer --chown=juicer /juice-shop .
-RUN mkdir logs && \
-    chown -R juicer logs && \
-    chgrp -R 0 ftp/ frontend/dist/ logs/ data/ i18n/ && \
-    chmod -R g=u ftp/ frontend/dist/ logs/ data/ i18n/
-USER 1001
+COPY --from=installer --chown=nonroot /juice-shop .
+USER 65532
 EXPOSE 3000
-CMD ["npm", "start"]
+CMD ["/juice-shop/build/app.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN npm i -g typescript ts-node
 RUN npm install --omit=dev --unsafe-perm
 RUN npm dedupe
 RUN rm -rf frontend/node_modules
+RUN rm -rf frontend/.angular
+RUN rm -rf frontend/src/assets
 RUN mkdir logs && \
     chown -R 65532 logs && \
     chgrp -R 0 ftp/ frontend/dist/ logs/ data/ i18n/ && \

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "sequelize": "^6.15.1",
     "serve-index": "^1.9.1",
     "socket.io": "^3.1.0",
-    "sqlite3": "5.0.2",
+    "sqlite3": "5.0.8",
     "svg-captcha": "^1.4.0",
     "swagger-ui-express": "^4.1.4",
     "ts-node-dev": "^1.1.6",

--- a/server.ts
+++ b/server.ts
@@ -673,3 +673,7 @@ export function close (exitCode: number | undefined) {
   }
 }
 // vuln-code-snippet end exposedMetricsChallenge
+
+// stop server on sigint or sigterm signals
+process.on('SIGINT', () => close(0))
+process.on('SIGTERM', () => close(0))


### PR DESCRIPTION
The sqlite3 npm package finally had some fixes which now allows it to be installed without problems on ARM devices and newer MacOS versions.

This would also enable us to get rid of the additional `-arm` docker image tag.

Do we want to do that? Or keep it so that we can easily switch back in case we have similar problems in the future?
I'd prefer to remove it again as so that docker again picks the right image version for me without my involvement.