### PR TITLE
Split challenge utils to another file

### DIFF
--- a/lib/botUtils.ts
+++ b/lib/botUtils.ts
@@ -6,7 +6,7 @@ import models = require('../models/index')
 import { Product } from '../data/types'
 const fuzz = require('fuzzball')
 const security = require('./insecurity')
-const utils = require('./utils')
+const challengeUtils = require('./challengeUtils')
 const challenges = require('../data/datacache').challenges
 
 async function productPrice (query: string, user: string) {
@@ -21,7 +21,7 @@ async function productPrice (query: string, user: string) {
 }
 
 function couponCode (query: string, user: string) {
-  utils.solveIf(challenges.bullyChatbotChallenge, () => { return true })
+  challengeUtils.solveIf(challenges.bullyChatbotChallenge, () => { return true })
   return {
     action: 'response',
     body: `Oooookay, if you promise to stop nagging me here's a 10% coupon code for you: ${security.generateCoupon(10)}`

--- a/lib/challengeUtils.ts
+++ b/lib/challengeUtils.ts
@@ -1,0 +1,104 @@
+import { Op } from 'sequelize'
+import { ChallengeModel } from '../models/challenge'
+
+const colors = require('colors/safe')
+const config = require('config')
+const challenges = require('../data/datacache').challenges
+const notifications = require('../data/datacache').notifications
+const sanitizeHtml = require('sanitize-html')
+const Entities = require('html-entities').AllHtmlEntities
+const entities = new Entities()
+const webhook = require('./webhook')
+const antiCheat = require('./antiCheat')
+const accuracy = require('./accuracy')
+const utils = require('./utils')
+const logger = require('./logger')
+
+export const solveIf = function (challenge: any, criteria: () => any, isRestore: boolean = false) {
+  if (notSolved(challenge) && criteria()) {
+    solve(challenge, isRestore)
+  }
+}
+
+export const solve = function (challenge: any, isRestore = false) {
+  challenge.solved = true
+  challenge.save().then((solvedChallenge: { difficulty: number, key: string, name: string }) => {
+    logger.info(`${isRestore ? colors.grey('Restored') : colors.green('Solved')} ${solvedChallenge.difficulty}-star ${colors.cyan(solvedChallenge.key)} (${solvedChallenge.name})`)
+    sendNotification(solvedChallenge, isRestore)
+    if (!isRestore) {
+      const cheatScore = antiCheat.calculateCheatScore(challenge)
+      if (process.env.SOLUTIONS_WEBHOOK) {
+        webhook.notify(solvedChallenge, cheatScore).catch((error: unknown) => {
+          logger.error('Webhook notification failed: ' + colors.red(utils.getErrorMessage(error)))
+        })
+      }
+    }
+  })
+}
+
+export const sendNotification = function (challenge: { difficulty?: number, key: any, name: any, description?: any }, isRestore: boolean) {
+  if (!notSolved(challenge)) {
+    const flag = utils.ctfFlag(challenge.name)
+    const notification = {
+      key: challenge.key,
+      name: challenge.name,
+      challenge: challenge.name + ' (' + entities.decode(sanitizeHtml(challenge.description, { allowedTags: [], allowedAttributes: [] })) + ')',
+      flag: flag,
+      hidden: !config.get('challenges.showSolvedNotifications'),
+      isRestore: isRestore
+    }
+    const wasPreviouslyShown = notifications.find(({ key }: { key: string }) => key === challenge.key) !== undefined
+    notifications.push(notification)
+
+    if (global.io && (isRestore || !wasPreviouslyShown)) {
+      // @ts-expect-error
+      global.io.emit('challenge solved', notification)
+    }
+  }
+}
+
+export const notSolved = (challenge: any) => challenge && !challenge.solved
+
+export const findChallengeByName = (challengeName: string) => {
+  for (const c in challenges) {
+    if (Object.prototype.hasOwnProperty.call(challenges, c)) {
+      if (challenges[c].name === challengeName) {
+        return challenges[c]
+      }
+    }
+  }
+  logger.warn('Missing challenge with name: ' + challengeName)
+}
+
+export const findChallengeById = (challengeId: number) => {
+  for (const c in challenges) {
+    if (Object.prototype.hasOwnProperty.call(challenges, c)) {
+      if (challenges[c].id === challengeId) {
+        return challenges[c]
+      }
+    }
+  }
+  logger.warn('Missing challenge with id: ' + challengeId)
+}
+
+export const solveFindIt = async function (key: string, isRestore: boolean) {
+  const solvedChallenge = challenges[key]
+  await ChallengeModel.update({ codingChallengeStatus: 1 }, { where: { key, codingChallengeStatus: { [Op.lt]: 2 } } })
+  logger.info(`${isRestore ? colors.grey('Restored') : colors.green('Solved')} 'Find It' phase of coding challenge ${colors.cyan(solvedChallenge.key)} (${solvedChallenge.name})`)
+  if (!isRestore) {
+    accuracy.storeFindItVerdict(solvedChallenge.key, true)
+    accuracy.calculateFindItAccuracy(solvedChallenge.key)
+    antiCheat.calculateFindItCheatScore(solvedChallenge)
+  }
+}
+
+export const solveFixIt = async function (key: string, isRestore: boolean) {
+  const solvedChallenge = challenges[key]
+  await ChallengeModel.update({ codingChallengeStatus: 2 }, { where: { key } })
+  logger.info(`${isRestore ? colors.grey('Restored') : colors.green('Solved')} 'Fix It' phase of coding challenge ${colors.cyan(solvedChallenge.key)} (${solvedChallenge.name})`)
+  if (!isRestore) {
+    accuracy.storeFixItVerdict(solvedChallenge.key, true)
+    accuracy.calculateFixItAccuracy(solvedChallenge.key)
+    antiCheat.calculateFixItCheatScore(solvedChallenge)
+  }
+}

--- a/lib/startup/registerWebsocketEvents.ts
+++ b/lib/startup/registerWebsocketEvents.ts
@@ -6,6 +6,7 @@
 import config = require('config')
 const notifications = require('../../data/datacache').notifications
 const utils = require('../utils')
+const challengeUtils = require('../challengeUtils')
 const security = require('../insecurity')
 const challenges = require('../../data/datacache').challenges
 let firstConnectedSocket: any = null
@@ -32,12 +33,12 @@ const registerWebsocketEvents = (server: any) => {
     })
 
     socket.on('verifyLocalXssChallenge', (data: any) => {
-      utils.solveIf(challenges.localXssChallenge, () => { return utils.contains(data, '<iframe src="javascript:alert(`xss`)">') })
-      utils.solveIf(challenges.xssBonusChallenge, () => { return utils.contains(data, config.get('challenges.xssBonusPayload')) })
+      challengeUtils.solveIf(challenges.localXssChallenge, () => { return utils.contains(data, '<iframe src="javascript:alert(`xss`)">') })
+      challengeUtils.solveIf(challenges.xssBonusChallenge, () => { return utils.contains(data, config.get('challenges.xssBonusPayload')) })
     })
 
     socket.on('verifySvgInjectionChallenge', (data: any) => {
-      utils.solveIf(challenges.svgInjectionChallenge, () => { return data?.match(/.*\.\.\/\.\.\/\.\.[\w/-]*?\/redirect\?to=https?:\/\/placekitten.com\/(g\/)?[\d]+\/[\d]+.*/) && security.isRedirectAllowed(data) })
+      challengeUtils.solveIf(challenges.svgInjectionChallenge, () => { return data?.match(/.*\.\.\/\.\.\/\.\.[\w/-]*?\/redirect\?to=https?:\/\/placekitten.com\/(g\/)?[\d]+\/[\d]+.*/) && security.isRedirectAllowed(data) })
     })
   })
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,18 +5,10 @@
 
 /* jslint node: true */
 import packageJson from '../package.json'
-import { Op } from 'sequelize'
 import fs = require('fs')
-import { ChallengeModel } from '../models/challenge'
 
-const colors = require('colors/safe')
-const notifications = require('../data/datacache').notifications
-const challenges = require('../data/datacache').challenges
-const sanitizeHtml = require('sanitize-html')
 const jsSHA = require('jssha')
-const Entities = require('html-entities').AllHtmlEntities
 const config = require('config')
-const entities = new Entities()
 const download = require('download')
 const crypto = require('crypto')
 const clarinet = require('clarinet')
@@ -24,9 +16,6 @@ const isDocker = require('is-docker')
 const isHeroku = require('is-heroku')
 const isWindows = require('is-windows')
 const logger = require('./logger')
-const webhook = require('./webhook')
-const antiCheat = require('./antiCheat')
-const accuracy = require('./accuracy')
 
 const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
 
@@ -107,73 +96,6 @@ export const ctfFlag = (text: string) => {
   shaObj.setHMACKey(ctfKey, 'TEXT')
   shaObj.update(text)
   return shaObj.getHMAC('HEX')
-}
-
-export const solveIf = function (challenge: any, criteria: () => any, isRestore: boolean = false) {
-  if (notSolved(challenge) && criteria()) {
-    solve(challenge, isRestore)
-  }
-}
-
-export const solve = function (challenge: any, isRestore = false) {
-  challenge.solved = true
-  challenge.save().then((solvedChallenge: { difficulty: number, key: string, name: string }) => {
-    logger.info(`${isRestore ? colors.grey('Restored') : colors.green('Solved')} ${solvedChallenge.difficulty}-star ${colors.cyan(solvedChallenge.key)} (${solvedChallenge.name})`)
-    sendNotification(solvedChallenge, isRestore)
-    if (!isRestore) {
-      const cheatScore = antiCheat.calculateCheatScore(challenge)
-      if (process.env.SOLUTIONS_WEBHOOK) {
-        webhook.notify(solvedChallenge, cheatScore).catch((error: unknown) => {
-          logger.error('Webhook notification failed: ' + colors.red(getErrorMessage(error)))
-        })
-      }
-    }
-  })
-}
-
-export const sendNotification = function (challenge: { difficulty?: number, key: any, name: any, description?: any }, isRestore: boolean) {
-  if (!notSolved(challenge)) {
-    const flag = ctfFlag(challenge.name)
-    const notification = {
-      key: challenge.key,
-      name: challenge.name,
-      challenge: challenge.name + ' (' + entities.decode(sanitizeHtml(challenge.description, { allowedTags: [], allowedAttributes: [] })) + ')',
-      flag: flag,
-      hidden: !config.get('challenges.showSolvedNotifications'),
-      isRestore: isRestore
-    }
-    const wasPreviouslyShown = notifications.find(({ key }: { key: string }) => key === challenge.key) !== undefined
-    notifications.push(notification)
-
-    if (global.io && (isRestore || !wasPreviouslyShown)) {
-      // @ts-expect-error
-      global.io.emit('challenge solved', notification)
-    }
-  }
-}
-
-export const notSolved = (challenge: any) => challenge && !challenge.solved
-
-export const findChallengeByName = (challengeName: string) => {
-  for (const c in challenges) {
-    if (Object.prototype.hasOwnProperty.call(challenges, c)) {
-      if (challenges[c].name === challengeName) {
-        return challenges[c]
-      }
-    }
-  }
-  logger.warn('Missing challenge with name: ' + challengeName)
-}
-
-export const findChallengeById = (challengeId: number) => {
-  for (const c in challenges) {
-    if (Object.prototype.hasOwnProperty.call(challenges, c)) {
-      if (challenges[c].id === challengeId) {
-        return challenges[c]
-      }
-    }
-  }
-  logger.warn('Missing challenge with id: ' + challengeId)
 }
 
 export const toMMMYY = (date: Date) => {
@@ -272,28 +194,6 @@ export const toSimpleIpAddress = (ipv6: string) => {
 
 export const thaw = (frozenObject: any) => {
   return JSON.parse(JSON.stringify(frozenObject))
-}
-
-export const solveFindIt = async function (key: string, isRestore: boolean) {
-  const solvedChallenge = challenges[key]
-  await ChallengeModel.update({ codingChallengeStatus: 1 }, { where: { key, codingChallengeStatus: { [Op.lt]: 2 } } })
-  logger.info(`${isRestore ? colors.grey('Restored') : colors.green('Solved')} 'Find It' phase of coding challenge ${colors.cyan(solvedChallenge.key)} (${solvedChallenge.name})`)
-  if (!isRestore) {
-    accuracy.storeFindItVerdict(solvedChallenge.key, true)
-    accuracy.calculateFindItAccuracy(solvedChallenge.key)
-    antiCheat.calculateFindItCheatScore(solvedChallenge)
-  }
-}
-
-export const solveFixIt = async function (key: string, isRestore: boolean) {
-  const solvedChallenge = challenges[key]
-  await ChallengeModel.update({ codingChallengeStatus: 2 }, { where: { key } })
-  logger.info(`${isRestore ? colors.grey('Restored') : colors.green('Solved')} 'Fix It' phase of coding challenge ${colors.cyan(solvedChallenge.key)} (${solvedChallenge.name})`)
-  if (!isRestore) {
-    accuracy.storeFixItVerdict(solvedChallenge.key, true)
-    accuracy.calculateFixItAccuracy(solvedChallenge.key)
-    antiCheat.calculateFixItCheatScore(solvedChallenge)
-  }
 }
 
 export const getErrorMessage = (error: unknown) => {

--- a/models/feedback.ts
+++ b/models/feedback.ts
@@ -5,6 +5,7 @@
 
 /* jslint node: true */
 import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 
 import {
   Model,
@@ -43,7 +44,7 @@ const FeedbackModelInit = (sequelize: Sequelize) => {
           let sanitizedComment: string
           if (!utils.disableOnContainerEnv()) {
             sanitizedComment = security.sanitizeHtml(comment)
-            utils.solveIf(challenges.persistedXssFeedbackChallenge, () => {
+            challengeUtils.solveIf(challenges.persistedXssFeedbackChallenge, () => {
               return utils.contains(
                 sanitizedComment,
                 '<iframe src="javascript:alert(`xss`)">'
@@ -60,7 +61,7 @@ const FeedbackModelInit = (sequelize: Sequelize) => {
         allowNull: false,
         set (rating: number) {
           this.setDataValue('rating', rating)
-          utils.solveIf(challenges.zeroStarsChallenge, () => {
+          challengeUtils.solveIf(challenges.zeroStarsChallenge, () => {
             return rating === 0
           })
         }

--- a/models/product.ts
+++ b/models/product.ts
@@ -5,6 +5,7 @@
 
 /* jslint node: true */
 import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import {
   Model,
   InferAttributes,
@@ -43,7 +44,7 @@ const ProductModelInit = (sequelize: Sequelize) => {
         type: DataTypes.STRING,
         set (description: string) {
           if (!utils.disableOnContainerEnv()) {
-            utils.solveIf(challenges.restfulXssChallenge, () => {
+            challengeUtils.solveIf(challenges.restfulXssChallenge, () => {
               return utils.contains(
                 description,
                 '<iframe src="javascript:alert(`xss`)">'

--- a/models/user.ts
+++ b/models/user.ts
@@ -13,6 +13,7 @@ import {
   CreationOptional,
   Sequelize
 } from 'sequelize'
+import challengeUtils = require('../lib/challengeUtils')
 const security = require('../lib/insecurity')
 const utils = require('../lib/utils')
 const challenges = require('../data/datacache').challenges
@@ -58,7 +59,7 @@ const UserModelInit = (sequelize: Sequelize) => {
         unique: true,
         set (email: string) {
           if (!utils.disableOnContainerEnv()) {
-            utils.solveIf(challenges.persistedXssUserChallenge, () => {
+            challengeUtils.solveIf(challenges.persistedXssUserChallenge, () => {
               return utils.contains(
                 email,
                 '<iframe src="javascript:alert(`xss`)">'

--- a/routes/2fa.ts
+++ b/routes/2fa.ts
@@ -7,6 +7,7 @@ import config = require('config')
 import { Request, Response } from 'express'
 import { BasketModel } from '../models/basket'
 import { UserModel } from '../models/user'
+import challengeUtils = require('../lib/challengeUtils')
 
 const security = require('../lib/insecurity')
 const otplib = require('otplib')
@@ -41,7 +42,7 @@ async function verify (req: Request, res: Response) {
     if (!isValid) {
       return res.status(401).send()
     }
-    utils.solveIf(challenges.twoFactorAuthUnsafeSecretStorageChallenge, () => { return user.email === 'wurstbrot@' + config.get('application.domain') })
+    challengeUtils.solveIf(challenges.twoFactorAuthUnsafeSecretStorageChallenge, () => { return user.email === 'wurstbrot@' + config.get('application.domain') })
 
     const [basket] = await BasketModel.findOrCreate({ where: { UserId: userId } })
 

--- a/routes/b2bOrder.ts
+++ b/routes/b2bOrder.ts
@@ -5,6 +5,7 @@
 
 import vm = require('vm')
 import { Request, Response, NextFunction } from 'express'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
@@ -22,11 +23,11 @@ module.exports = function b2bOrder () {
         res.json({ cid: body.cid, orderNo: uniqueOrderNumber(), paymentDue: dateTwoWeeksFromNow() })
       } catch (err) {
         if (utils.getErrorMessage(err).match(/Script execution timed out.*/)) {
-          utils.solveIf(challenges.rceOccupyChallenge, () => { return true })
+          challengeUtils.solveIf(challenges.rceOccupyChallenge, () => { return true })
           res.status(503)
           next(new Error('Sorry, we are temporarily not available! Please try again later.'))
         } else {
-          utils.solveIf(challenges.rceChallenge, () => { return utils.getErrorMessage(err) === 'Infinite loop detected - reached max iterations' })
+          challengeUtils.solveIf(challenges.rceChallenge, () => { return utils.getErrorMessage(err) === 'Infinite loop detected - reached max iterations' })
           next(err)
         }
       }

--- a/routes/basket.ts
+++ b/routes/basket.ts
@@ -6,6 +6,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { ProductModel } from '../models/product'
 import { BasketModel } from '../models/basket'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
@@ -17,7 +18,7 @@ module.exports = function retrieveBasket () {
     BasketModel.findOne({ where: { id }, include: [{ model: ProductModel, paranoid: false, as: 'Products' }] })
       .then((basket: BasketModel | null) => {
         /* jshint eqeqeq:false */
-        utils.solveIf(challenges.basketAccessChallenge, () => {
+        challengeUtils.solveIf(challenges.basketAccessChallenge, () => {
           const user = security.authenticatedUsers.from(req)
           return user && id && id !== 'undefined' && id !== 'null' && id !== 'NaN' && user.bid && user.bid != id // eslint-disable-line eqeqeq
         })

--- a/routes/basketItems.ts
+++ b/routes/basketItems.ts
@@ -6,6 +6,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { BasketItemModel } from '../models/basketitem'
 import { QuantityModel } from '../models/quantity'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const challenges = require('../data/datacache').challenges
@@ -41,7 +42,7 @@ module.exports.addBasketItem = function addBasketItem () {
         BasketId: basketIds[basketIds.length - 1],
         quantity: quantities[quantities.length - 1]
       }
-      utils.solveIf(challenges.basketManipulateChallenge, () => { return user && basketItem.BasketId && basketItem.BasketId !== 'undefined' && user.bid != basketItem.BasketId }) // eslint-disable-line eqeqeq
+      challengeUtils.solveIf(challenges.basketManipulateChallenge, () => { return user && basketItem.BasketId && basketItem.BasketId !== 'undefined' && user.bid != basketItem.BasketId }) // eslint-disable-line eqeqeq
 
       const basketItemInstance = BasketItemModel.build(basketItem)
       basketItemInstance.save().then((addedBasketItem: BasketItemModel) => {
@@ -65,7 +66,7 @@ module.exports.quantityCheckBeforeBasketItemUpdate = function quantityCheckBefor
   return (req: Request, res: Response, next: NextFunction) => {
     BasketItemModel.findOne({ where: { id: req.params.id } }).then((item: BasketItemModel | null) => {
       const user = security.authenticatedUsers.from(req)
-      utils.solveIf(challenges.basketManipulateChallenge, () => { return user && req.body.BasketId && user.bid != req.body.BasketId }) // eslint-disable-line eqeqeq
+      challengeUtils.solveIf(challenges.basketManipulateChallenge, () => { return user && req.body.BasketId && user.bid != req.body.BasketId }) // eslint-disable-line eqeqeq
       if (req.body.quantity) {
         if (!item) {
           throw new Error('No such item found!')

--- a/routes/changePassword.ts
+++ b/routes/changePassword.ts
@@ -5,8 +5,8 @@
 
 import { Request, Response, NextFunction } from 'express'
 import { UserModel } from '../models/user'
+import challengeUtils = require('../lib/challengeUtils')
 
-const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
 const cache = require('../data/datacache')
 const challenges = cache.challenges
@@ -31,7 +31,7 @@ module.exports = function changePassword () {
           UserModel.findByPk(loggedInUser.data.id).then((user: UserModel | null) => {
             if (user) {
               user.update({ password: newPasswordInString }).then((user: UserModel) => {
-                utils.solveIf(challenges.changePasswordBenderChallenge, () => { return user.id === 3 && !currentPassword && user.password === security.hash('slurmCl4ssic') })
+                challengeUtils.solveIf(challenges.changePasswordBenderChallenge, () => { return user.id === 3 && !currentPassword && user.password === security.hash('slurmCl4ssic') })
                 res.json({ user })
               }).catch((error: Error) => {
                 next(error)

--- a/routes/chatbot.ts
+++ b/routes/chatbot.ts
@@ -8,6 +8,7 @@ import { Request, Response, NextFunction } from 'express'
 import { User } from '../data/types'
 import { UserModel } from '../models/user'
 import { JwtPayload, VerifyErrors } from 'jsonwebtoken'
+import challengeUtils = require('../lib/challengeUtils')
 
 const logger = require('../lib/logger')
 const { Bot } = require('juicy-chat-bot')
@@ -98,7 +99,7 @@ async function processQuery (user: User, req: Request, res: Response) {
         body: config.get('application.chatBot.defaultResponse')
       })
     } catch (err) {
-      utils.solveIf(challenges.killChatbotChallenge, () => { return true })
+      challengeUtils.solveIf(challenges.killChatbotChallenge, () => { return true })
       res.status(200).json({
         action: 'response',
         body: `Remember to stay hydrated while I try to recover from "${utils.getErrorMessage(err)}"...`

--- a/routes/createProductReviews.ts
+++ b/routes/createProductReviews.ts
@@ -4,6 +4,7 @@
  */
 
 import { Request, Response } from 'express'
+import challengeUtils = require('../lib/challengeUtils')
 
 const reviews = require('../data/mongodb').reviews
 
@@ -14,7 +15,7 @@ const security = require('../lib/insecurity')
 module.exports = function productReviews () {
   return (req: Request, res: Response) => {
     const user = security.authenticatedUsers.from(req)
-    utils.solveIf(challenges.forgedReviewChallenge, () => { return user && user.data.email !== req.body.author })
+    challengeUtils.solveIf(challenges.forgedReviewChallenge, () => { return user && user.data.email !== req.body.author })
     reviews.insert({
       product: req.params.id,
       message: req.body.message,

--- a/routes/currentUser.ts
+++ b/routes/currentUser.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import { Request, Response } from 'express'
 
 const security = require('../lib/insecurity')
@@ -24,7 +24,7 @@ module.exports = function retrieveLoggedInUser () {
       if (req.query.callback === undefined) {
         res.json(response)
       } else {
-        utils.solveIf(challenges.emailLeakChallenge, () => { return true })
+        challengeUtils.solveIf(challenges.emailLeakChallenge, () => { return true })
         res.jsonp(response)
       }
     }

--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -11,7 +11,7 @@ import { PrivacyRequestModel } from '../models/privacyRequests'
 const insecurity = require('../lib/insecurity')
 
 const challenges = require('../data/datacache').challenges
-const utils = require('../lib/utils')
+const challengeUtils = require('../lib/challengeUtils')
 const router = express.Router()
 
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -77,7 +77,7 @@ router.post('/', async (req: Request<{}, {}, DataErasureRequestParams>, res: Res
           } else {
             const sendlfrResponse: string = html.slice(0, 100) + '......'
             res.send(sendlfrResponse)
-            utils.solve(challenges.lfrChallenge)
+            challengeUtils.solve(challenges.lfrChallenge)
           }
         })
       } else {

--- a/routes/dataExport.ts
+++ b/routes/dataExport.ts
@@ -7,7 +7,7 @@ import { Request, Response, NextFunction } from 'express'
 import { MemoryModel } from '../models/memory'
 import { ProductModel } from '../models/product'
 
-const utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 const security = require('../lib/insecurity')
 const db = require('../data/mongodb')
 const challenges = require('../data/datacache').challenges
@@ -97,7 +97,7 @@ module.exports = function dataExport () {
           }
           const emailHash = security.hash(email).slice(0, 4)
           for (const order of userData.orders) {
-            utils.solveIf(challenges.dataExportChallenge, () => { return order.orderId.split('-')[0] !== emailHash })
+            challengeUtils.solveIf(challenges.dataExportChallenge, () => { return order.orderId.split('-')[0] !== emailHash })
           }
           res.status(200).send({ userData: JSON.stringify(userData, null, 2), confirmation: 'Your data export will open in a new Browser window.' })
         },

--- a/routes/deluxe.ts
+++ b/routes/deluxe.ts
@@ -7,6 +7,7 @@ import { Request, Response, NextFunction } from 'express'
 import { UserModel } from '../models/user'
 import { WalletModel } from '../models/wallet'
 import { CardModel } from '../models/card'
+import challengeUtils = require('../lib/challengeUtils')
 
 const security = require('../lib/insecurity')
 const utils = require('../lib/utils')
@@ -40,7 +41,7 @@ module.exports.upgradeToDeluxe = function upgradeToDeluxe () {
 
       user.update({ role: security.roles.deluxe, deluxeToken: security.deluxeToken(user.email) })
         .then(user => {
-          utils.solveIf(challenges.freeDeluxeChallenge, () => { return security.verify(utils.jwtFrom(req)) && req.body.paymentMode !== 'wallet' && req.body.paymentMode !== 'card' })
+          challengeUtils.solveIf(challenges.freeDeluxeChallenge, () => { return security.verify(utils.jwtFrom(req)) && req.body.paymentMode !== 'wallet' && req.body.paymentMode !== 'card' })
           user = utils.queryResultToJson(user)
           const updatedToken = security.authorize(user)
           security.authenticatedUsers.put(updatedToken, user)

--- a/routes/easterEgg.ts
+++ b/routes/easterEgg.ts
@@ -6,12 +6,12 @@
 import path = require('path')
 import { Request, Response } from 'express'
 
-const utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 const challenges = require('../data/datacache').challenges
 
 module.exports = function serveEasterEgg () {
   return (req: Request, res: Response) => {
-    utils.solveIf(challenges.easterEggLevelTwoChallenge, () => { return true })
+    challengeUtils.solveIf(challenges.easterEggLevelTwoChallenge, () => { return true })
     res.sendFile(path.resolve('frontend/dist/frontend/assets/private/threejs-demo.html'))
   }
 }

--- a/routes/fileServer.ts
+++ b/routes/fileServer.ts
@@ -5,6 +5,7 @@
 
 import path = require('path')
 import { Request, Response, NextFunction } from 'express'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
@@ -26,7 +27,7 @@ module.exports = function servePublicFiles () {
     if (file && (endsWithAllowlistedFileType(file) || (file === 'incident-support.kdbx'))) {
       file = security.cutOffPoisonNullByte(file)
 
-      utils.solveIf(challenges.directoryListingChallenge, () => { return file.toLowerCase() === 'acquisitions.md' })
+      challengeUtils.solveIf(challenges.directoryListingChallenge, () => { return file.toLowerCase() === 'acquisitions.md' })
       verifySuccessfulPoisonNullByteExploit(file)
 
       res.sendFile(path.resolve('ftp/', file))
@@ -37,12 +38,12 @@ module.exports = function servePublicFiles () {
   }
 
   function verifySuccessfulPoisonNullByteExploit (file: string) {
-    utils.solveIf(challenges.easterEggLevelOneChallenge, () => { return file.toLowerCase() === 'eastere.gg' })
-    utils.solveIf(challenges.forgottenDevBackupChallenge, () => { return file.toLowerCase() === 'package.json.bak' })
-    utils.solveIf(challenges.forgottenBackupChallenge, () => { return file.toLowerCase() === 'coupons_2013.md.bak' })
-    utils.solveIf(challenges.misplacedSignatureFileChallenge, () => { return file.toLowerCase() === 'suspicious_errors.yml' })
+    challengeUtils.solveIf(challenges.easterEggLevelOneChallenge, () => { return file.toLowerCase() === 'eastere.gg' })
+    challengeUtils.solveIf(challenges.forgottenDevBackupChallenge, () => { return file.toLowerCase() === 'package.json.bak' })
+    challengeUtils.solveIf(challenges.forgottenBackupChallenge, () => { return file.toLowerCase() === 'coupons_2013.md.bak' })
+    challengeUtils.solveIf(challenges.misplacedSignatureFileChallenge, () => { return file.toLowerCase() === 'suspicious_errors.yml' })
 
-    utils.solveIf(challenges.nullByteChallenge, () => {
+    challengeUtils.solveIf(challenges.nullByteChallenge, () => {
       return challenges.easterEggLevelOneChallenge.solved || challenges.forgottenDevBackupChallenge.solved || challenges.forgottenBackupChallenge.solved ||
         challenges.misplacedSignatureFileChallenge.solved || file.toLowerCase() === 'encrypt.pyc'
     })

--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -5,6 +5,7 @@
 
 import fs = require('fs')
 import { Request, Response, NextFunction } from 'express'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const challenges = require('../data/datacache').challenges
@@ -46,7 +47,7 @@ function handleZipFileUpload ({ file }: Request, res: Response, next: NextFuncti
               .on('entry', function (entry: any) {
                 const fileName = entry.path
                 const absolutePath = path.resolve('uploads/complaints/' + fileName)
-                utils.solveIf(challenges.fileWriteChallenge, () => { return absolutePath === path.resolve('ftp/legal.md') })
+                challengeUtils.solveIf(challenges.fileWriteChallenge, () => { return absolutePath === path.resolve('ftp/legal.md') })
                 if (absolutePath.includes(path.resolve('.'))) {
                   entry.pipe(fs.createWriteStream('uploads/complaints/' + fileName).on('error', function (err) { next(err) }))
                 } else {
@@ -65,14 +66,14 @@ function handleZipFileUpload ({ file }: Request, res: Response, next: NextFuncti
 
 function checkUploadSize ({ file }: Request, res: Response, next: NextFunction) {
   if (file) {
-    utils.solveIf(challenges.uploadSizeChallenge, () => { return file?.size > 100000 })
+    challengeUtils.solveIf(challenges.uploadSizeChallenge, () => { return file?.size > 100000 })
   }
   next()
 }
 
 function checkFileType ({ file }: Request, res: Response, next: NextFunction) {
   const fileType = file?.originalname.substr(file.originalname.lastIndexOf('.') + 1).toLowerCase()
-  utils.solveIf(challenges.uploadTypeChallenge, () => {
+  challengeUtils.solveIf(challenges.uploadTypeChallenge, () => {
     return !(fileType === 'pdf' || fileType === 'xml' || fileType === 'zip')
   })
   next()
@@ -80,7 +81,7 @@ function checkFileType ({ file }: Request, res: Response, next: NextFunction) {
 
 function handleXmlUpload ({ file }: Request, res: Response, next: NextFunction) {
   if (utils.endsWith(file?.originalname.toLowerCase(), '.xml')) {
-    utils.solveIf(challenges.deprecatedInterfaceChallenge, () => { return true })
+    challengeUtils.solveIf(challenges.deprecatedInterfaceChallenge, () => { return true })
     if (file?.buffer && !utils.disableOnContainerEnv()) { // XXE attacks in Docker/Heroku containers regularly cause "segfault" crashes
       const data = file.buffer.toString()
       try {
@@ -88,13 +89,13 @@ function handleXmlUpload ({ file }: Request, res: Response, next: NextFunction) 
         vm.createContext(sandbox)
         const xmlDoc = vm.runInContext('libxml.parseXml(data, { noblanks: true, noent: true, nocdata: true })', sandbox, { timeout: 2000 })
         const xmlString = xmlDoc.toString(false)
-        utils.solveIf(challenges.xxeFileDisclosureChallenge, () => { return (matchesSystemIniFile(xmlString) ?? matchesEtcPasswdFile(xmlString)) })
+        challengeUtils.solveIf(challenges.xxeFileDisclosureChallenge, () => { return (matchesSystemIniFile(xmlString) ?? matchesEtcPasswdFile(xmlString)) })
         res.status(410)
         next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + utils.trunc(xmlString, 400) + ' (' + file.originalname + ')'))
       } catch (err: any) { // TODO: Remove any
         if (utils.contains(err.message, 'Script execution timed out')) {
-          if (utils.notSolved(challenges.xxeDosChallenge)) {
-            utils.solve(challenges.xxeDosChallenge)
+          if (challengeUtils.notSolved(challenges.xxeDosChallenge)) {
+            challengeUtils.solve(challenges.xxeDosChallenge)
           }
           res.status(503)
           next(new Error('Sorry, we are temporarily not available! Please try again later.'))

--- a/routes/likeProductReviews.ts
+++ b/routes/likeProductReviews.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import { Request, Response, NextFunction } from 'express'
 import { Review } from '../data/types'
 
@@ -37,7 +37,7 @@ module.exports = function productReviews () {
                       count++
                     }
                   }
-                  utils.solveIf(challenges.timingAttackChallenge, () => { return count > 2 })
+                  challengeUtils.solveIf(challenges.timingAttackChallenge, () => { return count > 2 })
                   db.reviews.update(
                     { _id: id },
                     { $set: { likedBy: likedBy } }

--- a/routes/login.ts
+++ b/routes/login.ts
@@ -8,6 +8,7 @@ import { Request, Response, NextFunction } from 'express'
 import { User } from '../data/types'
 import { BasketModel } from '../models/basket'
 import { UserModel } from '../models/user'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
@@ -57,23 +58,23 @@ module.exports = function login () {
   // vuln-code-snippet end loginAdminChallenge loginBenderChallenge loginJimChallenge
 
   function verifyPreLoginChallenges (req: Request) {
-    utils.solveIf(challenges.weakPasswordChallenge, () => { return req.body.email === 'admin@' + config.get('application.domain') && req.body.password === 'admin123' })
-    utils.solveIf(challenges.loginSupportChallenge, () => { return req.body.email === 'support@' + config.get('application.domain') && req.body.password === 'J6aVjTgOpRs@?5l!Zkq2AYnCE@RF$P' })
-    utils.solveIf(challenges.loginRapperChallenge, () => { return req.body.email === 'mc.safesearch@' + config.get('application.domain') && req.body.password === 'Mr. N00dles' })
-    utils.solveIf(challenges.loginAmyChallenge, () => { return req.body.email === 'amy@' + config.get('application.domain') && req.body.password === 'K1f.....................' })
-    utils.solveIf(challenges.dlpPasswordSprayingChallenge, () => { return req.body.email === 'J12934@' + config.get('application.domain') && req.body.password === '0Y8rMnww$*9VFYE§59-!Fg1L6t&6lB' })
-    utils.solveIf(challenges.oauthUserPasswordChallenge, () => { return req.body.email === 'bjoern.kimminich@gmail.com' && req.body.password === 'bW9jLmxpYW1nQGhjaW5pbW1pay5ucmVvamI=' })
+    challengeUtils.solveIf(challenges.weakPasswordChallenge, () => { return req.body.email === 'admin@' + config.get('application.domain') && req.body.password === 'admin123' })
+    challengeUtils.solveIf(challenges.loginSupportChallenge, () => { return req.body.email === 'support@' + config.get('application.domain') && req.body.password === 'J6aVjTgOpRs@?5l!Zkq2AYnCE@RF$P' })
+    challengeUtils.solveIf(challenges.loginRapperChallenge, () => { return req.body.email === 'mc.safesearch@' + config.get('application.domain') && req.body.password === 'Mr. N00dles' })
+    challengeUtils.solveIf(challenges.loginAmyChallenge, () => { return req.body.email === 'amy@' + config.get('application.domain') && req.body.password === 'K1f.....................' })
+    challengeUtils.solveIf(challenges.dlpPasswordSprayingChallenge, () => { return req.body.email === 'J12934@' + config.get('application.domain') && req.body.password === '0Y8rMnww$*9VFYE§59-!Fg1L6t&6lB' })
+    challengeUtils.solveIf(challenges.oauthUserPasswordChallenge, () => { return req.body.email === 'bjoern.kimminich@gmail.com' && req.body.password === 'bW9jLmxpYW1nQGhjaW5pbW1pay5ucmVvamI=' })
   }
 
   function verifyPostLoginChallenges (user: { data: User }) {
-    utils.solveIf(challenges.loginAdminChallenge, () => { return user.data.id === users.admin.id })
-    utils.solveIf(challenges.loginJimChallenge, () => { return user.data.id === users.jim.id })
-    utils.solveIf(challenges.loginBenderChallenge, () => { return user.data.id === users.bender.id })
-    utils.solveIf(challenges.ghostLoginChallenge, () => { return user.data.id === users.chris.id })
-    if (utils.notSolved(challenges.ephemeralAccountantChallenge) && user.data.email === 'acc0unt4nt@' + config.get('application.domain') && user.data.role === 'accounting') {
+    challengeUtils.solveIf(challenges.loginAdminChallenge, () => { return user.data.id === users.admin.id })
+    challengeUtils.solveIf(challenges.loginJimChallenge, () => { return user.data.id === users.jim.id })
+    challengeUtils.solveIf(challenges.loginBenderChallenge, () => { return user.data.id === users.bender.id })
+    challengeUtils.solveIf(challenges.ghostLoginChallenge, () => { return user.data.id === users.chris.id })
+    if (challengeUtils.notSolved(challenges.ephemeralAccountantChallenge) && user.data.email === 'acc0unt4nt@' + config.get('application.domain') && user.data.role === 'accounting') {
       UserModel.count({ where: { email: 'acc0unt4nt@' + config.get('application.domain') } }).then((count: number) => {
         if (count === 0) {
-          utils.solve(challenges.ephemeralAccountantChallenge)
+          challengeUtils.solve(challenges.ephemeralAccountantChallenge)
         }
       }).catch(() => {
         throw new Error('Unable to verify challenges! Try again')

--- a/routes/metrics.ts
+++ b/routes/metrics.ts
@@ -11,6 +11,7 @@ import { WalletModel } from '../models/wallet'
 import { FeedbackModel } from '../models/feedback'
 import { ComplaintModel } from '../models/complaint'
 import { Op } from 'sequelize'
+import challengeUtils = require('../lib/challengeUtils')
 
 const Prometheus = require('prom-client')
 const onFinished = require('on-finished')
@@ -65,7 +66,7 @@ exports.observeFileUploadMetricsMiddleware = function observeFileUploadMetricsMi
 
 exports.serveMetrics = function serveMetrics () {
   return (req: Request, res: Response, next: NextFunction) => {
-    utils.solveIf(challenges.exposedMetricsChallenge, () => {
+    challengeUtils.solveIf(challenges.exposedMetricsChallenge, () => {
       const userAgent = req.headers['user-agent'] ?? ''
       return !userAgent.includes('Prometheus')
     })

--- a/routes/order.ts
+++ b/routes/order.ts
@@ -11,6 +11,7 @@ import { BasketItemModel } from '../models/basketitem'
 import { QuantityModel } from '../models/quantity'
 import { DeliveryModel } from '../models/delivery'
 import { WalletModel } from '../models/wallet'
+import challengeUtils = require('../lib/challengeUtils')
 
 const fs = require('fs')
 const PDFDocument = require('pdfkit')
@@ -67,7 +68,7 @@ module.exports = function placeOrder () {
           let totalPoints = 0
           basket.Products?.forEach(({ BasketItem, price, deluxePrice, name, id }) => {
             if (BasketItem) {
-              utils.solveIf(challenges.christmasSpecialChallenge, () => { return BasketItem.ProductId === products.christmasSpecial.id })
+              challengeUtils.solveIf(challenges.christmasSpecialChallenge, () => { return BasketItem.ProductId === products.christmasSpecial.id })
               QuantityModel.findOne({ where: { ProductId: BasketItem.ProductId } }).then((product: any) => {
                 const newQuantity = product.quantity - BasketItem.quantity
                 QuantityModel.update({ quantity: newQuantity }, { where: { ProductId: BasketItem?.ProductId } }).catch((error: unknown) => {
@@ -133,7 +134,7 @@ module.exports = function placeOrder () {
           doc.moveDown()
           doc.font('Times-Roman', 15).text(req.__('Thank you for your order!'))
 
-          utils.solveIf(challenges.negativeOrderChallenge, () => { return totalPrice < 0 })
+          challengeUtils.solveIf(challenges.negativeOrderChallenge, () => { return totalPrice < 0 })
 
           if (req.body.UserId) {
             if (req.body.orderDetails && req.body.orderDetails.paymentId === 'wallet') {
@@ -178,7 +179,7 @@ module.exports = function placeOrder () {
 function calculateApplicableDiscount (basket: BasketModel, req: Request) {
   if (security.discountFromCoupon(basket.coupon)) {
     const discount = security.discountFromCoupon(basket.coupon)
-    utils.solveIf(challenges.forgedCouponChallenge, () => { return discount >= 80 })
+    challengeUtils.solveIf(challenges.forgedCouponChallenge, () => { return discount >= 80 })
     return discount
   } else if (req.body.couponData) {
     const couponData = Buffer.from(req.body.couponData, 'base64').toString().split('-')
@@ -187,7 +188,7 @@ function calculateApplicableDiscount (basket: BasketModel, req: Request) {
     const campaign = campaigns[couponCode as keyof typeof campaigns]
 
     if (campaign && couponDate == campaign.validOn) { // eslint-disable-line eqeqeq
-      utils.solveIf(challenges.manipulateClockChallenge, () => { return campaign.validOn < new Date().getTime() })
+      challengeUtils.solveIf(challenges.manipulateClockChallenge, () => { return campaign.validOn < new Date().getTime() })
       return campaign.discount
     }
   }

--- a/routes/premiumReward.ts
+++ b/routes/premiumReward.ts
@@ -6,12 +6,12 @@
 import path = require('path')
 import { Request, Response } from 'express'
 
-const utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 const challenges = require('../data/datacache').challenges
 
 module.exports = function servePremiumContent () {
   return (req: Request, res: Response) => {
-    utils.solveIf(challenges.premiumPaywallChallenge, () => { return true })
+    challengeUtils.solveIf(challenges.premiumPaywallChallenge, () => { return true })
     res.sendFile(path.resolve('frontend/dist/frontend/assets/private/JuiceShop_Wallpaper_1920x1080_VR.jpg'))
   }
 }

--- a/routes/privacyPolicyProof.ts
+++ b/routes/privacyPolicyProof.ts
@@ -6,12 +6,12 @@
 import path = require('path')
 import { Request, Response } from 'express'
 
-const utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 const challenges = require('../data/datacache').challenges
 
 module.exports = function servePrivacyPolicyProof () {
   return (req: Request, res: Response) => {
-    utils.solveIf(challenges.privacyPolicyProofChallenge, () => { return true })
+    challengeUtils.solveIf(challenges.privacyPolicyProofChallenge, () => { return true })
     res.sendFile(path.resolve('frontend/dist/frontend/assets/private/thank-you.jpg'))
   }
 }

--- a/routes/redirect.ts
+++ b/routes/redirect.ts
@@ -4,6 +4,7 @@
  */
 
 import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import { Request, Response, NextFunction } from 'express'
 
 const security = require('../lib/insecurity')
@@ -13,8 +14,8 @@ module.exports = function performRedirect () {
   return ({ query }: Request, res: Response, next: NextFunction) => {
     const toUrl = query.to
     if (security.isRedirectAllowed(toUrl)) {
-      utils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
-      utils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl as string) })
+      challengeUtils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
+      challengeUtils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl as string) })
       res.redirect(toUrl as string)
     } else {
       res.status(406)

--- a/routes/repeatNotification.ts
+++ b/routes/repeatNotification.ts
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: MIT
  */
 
-import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import { Request, Response } from 'express'
 
 module.exports = function repeatNotification () {
   return ({ query }: Request, res: Response) => {
     const challengeName: string = decodeURIComponent(query.challenge as string)
-    const challenge = utils.findChallengeByName(challengeName)
+    const challenge = challengeUtils.findChallengeByName(challengeName)
 
     if (challenge?.solved) {
-      utils.sendNotification(challenge, true)
+      challengeUtils.sendNotification(challenge, true)
     }
 
     res.sendStatus(200)

--- a/routes/resetPassword.ts
+++ b/routes/resetPassword.ts
@@ -9,7 +9,7 @@ import { Memory } from '../data/types'
 import { SecurityAnswerModel } from '../models/securityAnswer'
 import { UserModel } from '../models/user'
 
-const utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 const challenges = require('../data/datacache').challenges
 const users = require('../data/datacache').users
 const security = require('../lib/insecurity')
@@ -55,13 +55,13 @@ module.exports = function resetPassword () {
 }
 
 function verifySecurityAnswerChallenges (user: UserModel, answer: string) {
-  utils.solveIf(challenges.resetPasswordJimChallenge, () => { return user.id === users.jim.id && answer === 'Samuel' })
-  utils.solveIf(challenges.resetPasswordBenderChallenge, () => { return user.id === users.bender.id && answer === 'Stop\'n\'Drop' })
-  utils.solveIf(challenges.resetPasswordBjoernChallenge, () => { return user.id === users.bjoern.id && answer === 'West-2082' })
-  utils.solveIf(challenges.resetPasswordMortyChallenge, () => { return user.id === users.morty.id && answer === '5N0wb41L' })
-  utils.solveIf(challenges.resetPasswordBjoernOwaspChallenge, () => { return user.id === users.bjoernOwasp.id && answer === 'Zaya' })
-  utils.solveIf(challenges.resetPasswordUvoginChallenge, () => { return user.id === users.uvogin.id && answer === 'Silence of the Lambs' })
-  utils.solveIf(challenges.geoStalkingMetaChallenge, () => {
+  challengeUtils.solveIf(challenges.resetPasswordJimChallenge, () => { return user.id === users.jim.id && answer === 'Samuel' })
+  challengeUtils.solveIf(challenges.resetPasswordBenderChallenge, () => { return user.id === users.bender.id && answer === 'Stop\'n\'Drop' })
+  challengeUtils.solveIf(challenges.resetPasswordBjoernChallenge, () => { return user.id === users.bjoern.id && answer === 'West-2082' })
+  challengeUtils.solveIf(challenges.resetPasswordMortyChallenge, () => { return user.id === users.morty.id && answer === '5N0wb41L' })
+  challengeUtils.solveIf(challenges.resetPasswordBjoernOwaspChallenge, () => { return user.id === users.bjoernOwasp.id && answer === 'Zaya' })
+  challengeUtils.solveIf(challenges.resetPasswordUvoginChallenge, () => { return user.id === users.uvogin.id && answer === 'Silence of the Lambs' })
+  challengeUtils.solveIf(challenges.geoStalkingMetaChallenge, () => {
     const securityAnswer = ((() => {
       const memories: Memory[] = config.get('memories')
       for (let i = 0; i < memories.length; i++) {
@@ -72,7 +72,7 @@ function verifySecurityAnswerChallenges (user: UserModel, answer: string) {
     })())
     return user.id === users.john.id && answer === securityAnswer
   })
-  utils.solveIf(challenges.geoStalkingVisualChallenge, () => {
+  challengeUtils.solveIf(challenges.geoStalkingVisualChallenge, () => {
     const securityAnswer = ((() => {
       const memories: Memory[] = config.get('memories')
       for (let i = 0; i < memories.length; i++) {

--- a/routes/restoreProgress.ts
+++ b/routes/restoreProgress.ts
@@ -7,21 +7,21 @@ import Hashids = require('hashids/cjs')
 import { Request, Response } from 'express'
 
 const challenges = require('../data/datacache').challenges
-const utils = require('../lib/utils')
+const challengeUtils = require('../lib/challengeUtils')
 
 module.exports.restoreProgress = function restoreProgress () {
   return ({ params }: Request, res: Response) => {
     const hashids = new Hashids('this is my salt', 60, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
     const continueCode = params.continueCode
     const ids = hashids.decode(continueCode)
-    if (utils.notSolved(challenges.continueCodeChallenge) && ids.includes(999)) {
-      utils.solve(challenges.continueCodeChallenge)
+    if (challengeUtils.notSolved(challenges.continueCodeChallenge) && ids.includes(999)) {
+      challengeUtils.solve(challenges.continueCodeChallenge)
       res.end()
     } else if (ids.length > 0) {
       for (const name in challenges) {
         if (Object.prototype.hasOwnProperty.call(challenges, name)) {
           if (ids.includes(challenges[name].id)) {
-            utils.solve(challenges[name], true)
+            challengeUtils.solve(challenges[name], true)
           }
         }
       }
@@ -41,7 +41,7 @@ module.exports.restoreProgressFindIt = function restoreProgressFindIt () {
       for (const key in challenges) {
         if (Object.prototype.hasOwnProperty.call(challenges, key)) {
           if (idsFindIt.includes(challenges[key].id)) {
-            await utils.solveFindIt(key, true)
+            await challengeUtils.solveFindIt(key, true)
           }
         }
       }
@@ -61,7 +61,7 @@ module.exports.restoreProgressFixIt = function restoreProgressFixIt () {
       for (const key in challenges) {
         if (Object.prototype.hasOwnProperty.call(challenges, key)) {
           if (idsFixIt.includes(challenges[key].id)) {
-            await utils.solveFixIt(key, true)
+            await challengeUtils.solveFixIt(key, true)
           }
         }
       }

--- a/routes/saveLoginIp.ts
+++ b/routes/saveLoginIp.ts
@@ -5,6 +5,7 @@
 
 import { Request, Response, NextFunction } from 'express'
 import { UserModel } from '../models/user'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
@@ -17,7 +18,7 @@ module.exports = function saveLoginIp () {
     if (loggedInUser !== undefined) {
       let lastLoginIp = req.headers['true-client-ip']
       if (!utils.disableOnContainerEnv()) {
-        utils.solveIf(challenges.httpHeaderXssChallenge, () => { return lastLoginIp === '<iframe src="javascript:alert(`xss`)">' })
+        challengeUtils.solveIf(challenges.httpHeaderXssChallenge, () => { return lastLoginIp === '<iframe src="javascript:alert(`xss`)">' })
       } else {
         lastLoginIp = security.sanitizeSecure(lastLoginIp)
       }

--- a/routes/search.ts
+++ b/routes/search.ts
@@ -8,6 +8,7 @@ import { Request, Response, NextFunction } from 'express'
 import { UserModel } from '../models/user'
 
 const utils = require('../lib/utils')
+const challengeUtils = require('../lib/challengeUtils')
 const challenges = require('../data/datacache').challenges
 
 class ErrorWithParent extends Error {
@@ -22,7 +23,7 @@ module.exports = function searchProducts () {
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {
         const dataString = JSON.stringify(products)
-        if (utils.notSolved(challenges.unionSqlInjectionChallenge)) { // vuln-code-snippet hide-start
+        if (challengeUtils.notSolved(challenges.unionSqlInjectionChallenge)) { // vuln-code-snippet hide-start
           let solved = true
           UserModel.findAll().then(data => {
             const users = utils.queryResultToJson(data)
@@ -34,14 +35,14 @@ module.exports = function searchProducts () {
                 }
               }
               if (solved) {
-                utils.solve(challenges.unionSqlInjectionChallenge)
+                challengeUtils.solve(challenges.unionSqlInjectionChallenge)
               }
             }
           }).catch((error: Error) => {
             next(error)
           })
         }
-        if (utils.notSolved(challenges.dbSchemaChallenge)) {
+        if (challengeUtils.notSolved(challenges.dbSchemaChallenge)) {
           let solved = true
           models.sequelize.query('SELECT sql FROM sqlite_master').then(([data]: any) => {
             const tableDefinitions = utils.queryResultToJson(data)
@@ -53,7 +54,7 @@ module.exports = function searchProducts () {
                 }
               }
               if (solved) {
-                utils.solve(challenges.dbSchemaChallenge)
+                challengeUtils.solve(challenges.dbSchemaChallenge)
               }
             }
           })

--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -4,6 +4,7 @@
  */
 
 import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import { Request, Response, NextFunction } from 'express'
 import { Review } from 'data/types'
 
@@ -32,7 +33,7 @@ module.exports = function productReviews () {
     const t0 = new Date().getTime()
     db.reviews.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
-      utils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
+      challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)
       for (let i = 0; i < reviews.length; i++) {
         if (user === undefined || reviews[i].likedBy.includes(user.data.email)) {

--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -4,6 +4,7 @@
  */
 
 import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import { Request, Response } from 'express'
 
 const challenges = require('../data/datacache').challenges
@@ -13,10 +14,10 @@ module.exports = function trackOrder () {
   return (req: Request, res: Response) => {
     const id = utils.disableOnContainerEnv() ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
 
-    utils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
+    challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
     db.orders.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
       const result = utils.queryResultToJson(order)
-      utils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
+      challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {
         result.data[0] = { orderId: id }
       }

--- a/routes/updateProductReviews.ts
+++ b/routes/updateProductReviews.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import utils = require('../lib/utils')
+import challengeUtils = require('../lib/challengeUtils')
 import { Request, Response, NextFunction } from 'express'
 
 const challenges = require('../data/datacache').challenges
@@ -20,8 +20,8 @@ module.exports = function productReviews () {
       { multi: true } // vuln-code-snippet vuln-line noSqlReviewsChallenge
     ).then(
       (result: { modified: number, original: Array<{ author: any }> }) => {
-        utils.solveIf(challenges.noSqlReviewsChallenge, () => { return result.modified > 1 }) // vuln-code-snippet hide-line
-        utils.solveIf(challenges.forgedReviewChallenge, () => { return user?.data && result.original[0] && result.original[0].author !== user.data.email && result.modified === 1 }) // vuln-code-snippet hide-line
+        challengeUtils.solveIf(challenges.noSqlReviewsChallenge, () => { return result.modified > 1 }) // vuln-code-snippet hide-line
+        challengeUtils.solveIf(challenges.forgedReviewChallenge, () => { return user?.data && result.original[0] && result.original[0].author !== user.data.email && result.modified === 1 }) // vuln-code-snippet hide-line
         res.json(result)
       }, (err: unknown) => {
         res.status(500).json(err)

--- a/routes/updateUserProfile.ts
+++ b/routes/updateUserProfile.ts
@@ -5,6 +5,7 @@
 
 import { Request, Response, NextFunction } from 'express'
 import { UserModel } from '../models/user'
+import challengeUtils = require('../lib/challengeUtils')
 
 const security = require('../lib/insecurity')
 const utils = require('../lib/utils')
@@ -18,7 +19,7 @@ module.exports = function updateUserProfile () {
     if (loggedInUser) {
       UserModel.findByPk(loggedInUser.data.id).then((user: UserModel | null) => {
         if (user) {
-          utils.solveIf(challenges.csrfChallenge, () => {
+          challengeUtils.solveIf(challenges.csrfChallenge, () => {
             return ((req.headers.origin?.includes('://htmledit.squarefree.com')) ??
               (req.headers.referer?.includes('://htmledit.squarefree.com'))) &&
               req.body.username !== user.username

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -7,6 +7,7 @@ import fs = require('fs')
 import { Request, Response, NextFunction } from 'express'
 
 import { UserModel } from '../models/user'
+import challengeUtils = require('../lib/challengeUtils')
 const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
 const challenges = require('../data/datacache').challenges
@@ -54,7 +55,7 @@ module.exports = function getUserProfile () {
           template = template.replace(/_logo_/g, utils.extractFilename(config.get('application.logo')))
           const fn = pug.compile(template)
           const CSP = `img-src 'self' ${user?.profileImage}; script-src 'self' 'unsafe-eval' https://code.getmdl.io http://ajax.googleapis.com`
-          utils.solveIf(challenges.usernameXssChallenge, () => { return user?.profileImage.match(/;[ ]*script-src(.)*'unsafe-inline'/g) !== null && utils.contains(username, '<script>alert(`xss`)</script>') })
+          challengeUtils.solveIf(challenges.usernameXssChallenge, () => { return user?.profileImage.match(/;[ ]*script-src(.)*'unsafe-inline'/g) !== null && utils.contains(username, '<script>alert(`xss`)</script>') })
 
           res.set({
             'Content-Security-Policy': CSP

--- a/routes/verify.ts
+++ b/routes/verify.ts
@@ -9,6 +9,7 @@ import { JwtPayload, VerifyErrors } from 'jsonwebtoken'
 import { FeedbackModel } from '../models/feedback'
 import { ComplaintModel } from '../models/complaint'
 import { Op } from 'sequelize'
+import challengeUtils = require('../lib/challengeUtils')
 
 const utils = require('../lib/utils')
 const security = require('../lib/insecurity')
@@ -20,7 +21,7 @@ const products = cache.products
 const config = require('config')
 
 exports.forgedFeedbackChallenge = () => (req: Request, res: Response, next: NextFunction) => {
-  utils.solveIf(challenges.forgedFeedbackChallenge, () => {
+  challengeUtils.solveIf(challenges.forgedFeedbackChallenge, () => {
     const user = security.authenticatedUsers.from(req)
     const userId = user?.data ? user.data.id : undefined
     return req.body?.UserId && req.body.UserId != userId // eslint-disable-line eqeqeq
@@ -29,10 +30,10 @@ exports.forgedFeedbackChallenge = () => (req: Request, res: Response, next: Next
 }
 
 exports.captchaBypassChallenge = () => (req: Request, res: Response, next: NextFunction) => {
-  if (utils.notSolved(challenges.captchaBypassChallenge)) {
+  if (challengeUtils.notSolved(challenges.captchaBypassChallenge)) {
     if (req.app.locals.captchaReqId >= 10) {
       if ((new Date().getTime() - req.app.locals.captchaBypassReqTimes[req.app.locals.captchaReqId - 10]) <= 10000) {
-        utils.solve(challenges.captchaBypassChallenge)
+        challengeUtils.solve(challenges.captchaBypassChallenge)
       }
     }
     req.app.locals.captchaBypassReqTimes[req.app.locals.captchaReqId - 1] = new Date().getTime()
@@ -42,38 +43,38 @@ exports.captchaBypassChallenge = () => (req: Request, res: Response, next: NextF
 }
 
 exports.registerAdminChallenge = () => (req: Request, res: Response, next: NextFunction) => {
-  utils.solveIf(challenges.registerAdminChallenge, () => { return req.body && req.body.role === security.roles.admin })
+  challengeUtils.solveIf(challenges.registerAdminChallenge, () => { return req.body && req.body.role === security.roles.admin })
   next()
 }
 
 exports.passwordRepeatChallenge = () => (req: Request, res: Response, next: NextFunction) => {
-  utils.solveIf(challenges.passwordRepeatChallenge, () => { return req.body && req.body.passwordRepeat !== req.body.password })
+  challengeUtils.solveIf(challenges.passwordRepeatChallenge, () => { return req.body && req.body.passwordRepeat !== req.body.password })
   next()
 }
 
 exports.accessControlChallenges = () => ({ url }: Request, res: Response, next: NextFunction) => {
-  utils.solveIf(challenges.scoreBoardChallenge, () => { return utils.endsWith(url, '/1px.png') })
-  utils.solveIf(challenges.adminSectionChallenge, () => { return utils.endsWith(url, '/19px.png') })
-  utils.solveIf(challenges.tokenSaleChallenge, () => { return utils.endsWith(url, '/56px.png') })
-  utils.solveIf(challenges.privacyPolicyChallenge, () => { return utils.endsWith(url, '/81px.png') })
-  utils.solveIf(challenges.extraLanguageChallenge, () => { return utils.endsWith(url, '/tlh_AA.json') })
-  utils.solveIf(challenges.retrieveBlueprintChallenge, () => { return utils.endsWith(url, cache.retrieveBlueprintChallengeFile) })
-  utils.solveIf(challenges.securityPolicyChallenge, () => { return utils.endsWith(url, '/security.txt') })
-  utils.solveIf(challenges.missingEncodingChallenge, () => { return utils.endsWith(url.toLowerCase(), '%f0%9f%98%bc-%23zatschi-%23whoneedsfourlegs-1572600969477.jpg') })
-  utils.solveIf(challenges.accessLogDisclosureChallenge, () => { return url.match(/access\.log(0-9-)*/) })
+  challengeUtils.solveIf(challenges.scoreBoardChallenge, () => { return utils.endsWith(url, '/1px.png') })
+  challengeUtils.solveIf(challenges.adminSectionChallenge, () => { return utils.endsWith(url, '/19px.png') })
+  challengeUtils.solveIf(challenges.tokenSaleChallenge, () => { return utils.endsWith(url, '/56px.png') })
+  challengeUtils.solveIf(challenges.privacyPolicyChallenge, () => { return utils.endsWith(url, '/81px.png') })
+  challengeUtils.solveIf(challenges.extraLanguageChallenge, () => { return utils.endsWith(url, '/tlh_AA.json') })
+  challengeUtils.solveIf(challenges.retrieveBlueprintChallenge, () => { return utils.endsWith(url, cache.retrieveBlueprintChallengeFile) })
+  challengeUtils.solveIf(challenges.securityPolicyChallenge, () => { return utils.endsWith(url, '/security.txt') })
+  challengeUtils.solveIf(challenges.missingEncodingChallenge, () => { return utils.endsWith(url.toLowerCase(), '%f0%9f%98%bc-%23zatschi-%23whoneedsfourlegs-1572600969477.jpg') })
+  challengeUtils.solveIf(challenges.accessLogDisclosureChallenge, () => { return url.match(/access\.log(0-9-)*/) })
   next()
 }
 
 exports.errorHandlingChallenge = () => (err: unknown, req: Request, { statusCode }: Response, next: NextFunction) => {
-  utils.solveIf(challenges.errorHandlingChallenge, () => { return err && (statusCode === 200 || statusCode > 401) })
+  challengeUtils.solveIf(challenges.errorHandlingChallenge, () => { return err && (statusCode === 200 || statusCode > 401) })
   next(err)
 }
 
 exports.jwtChallenges = () => (req: Request, res: Response, next: NextFunction) => {
-  if (utils.notSolved(challenges.jwtUnsignedChallenge)) {
+  if (challengeUtils.notSolved(challenges.jwtUnsignedChallenge)) {
     jwtChallenge(challenges.jwtUnsignedChallenge, req, 'none', /jwtn3d@/)
   }
-  if (!utils.disableOnWindowsEnv() && utils.notSolved(challenges.jwtForgedChallenge)) {
+  if (!utils.disableOnWindowsEnv() && challengeUtils.notSolved(challenges.jwtForgedChallenge)) {
     jwtChallenge(challenges.jwtForgedChallenge, req, 'HS256', /rsa_lord@/)
   }
   next()
@@ -81,14 +82,14 @@ exports.jwtChallenges = () => (req: Request, res: Response, next: NextFunction) 
 
 exports.serverSideChallenges = () => (req: Request, res: Response, next: NextFunction) => {
   if (req.query.key === 'tRy_H4rd3r_n0thIng_iS_Imp0ssibl3') {
-    if (utils.notSolved(challenges.sstiChallenge) && req.app.locals.abused_ssti_bug === true) {
-      utils.solve(challenges.sstiChallenge)
+    if (challengeUtils.notSolved(challenges.sstiChallenge) && req.app.locals.abused_ssti_bug === true) {
+      challengeUtils.solve(challenges.sstiChallenge)
       res.status(204).send()
       return
     }
 
-    if (utils.notSolved(challenges.ssrfChallenge) && req.app.locals.abused_ssrf_bug === true) {
-      utils.solve(challenges.ssrfChallenge)
+    if (challengeUtils.notSolved(challenges.ssrfChallenge) && req.app.locals.abused_ssrf_bug === true) {
+      challengeUtils.solve(challenges.ssrfChallenge)
       res.status(204).send()
       return
     }
@@ -102,7 +103,7 @@ function jwtChallenge (challenge: Challenge, req: Request, algorithm: string, em
     const decoded = jws.decode(token) ? jwt.decode(token) : null
     jwt.verify(token, security.publicKey, (err: VerifyErrors | null, verified: JwtPayload) => {
       if (err === null) {
-        utils.solveIf(challenge, () => { return hasAlgorithm(token, algorithm) && hasEmail(decoded, email) })
+        challengeUtils.solveIf(challenge, () => { return hasAlgorithm(token, algorithm) && hasEmail(decoded, email) })
       }
     })
   }
@@ -118,31 +119,31 @@ function hasEmail (token: { data: { email: string } }, email: string | RegExp) {
 }
 
 exports.databaseRelatedChallenges = () => (req: Request, res: Response, next: NextFunction) => {
-  if (utils.notSolved(challenges.changeProductChallenge) && products.osaft) {
+  if (challengeUtils.notSolved(challenges.changeProductChallenge) && products.osaft) {
     changeProductChallenge(products.osaft)
   }
-  if (utils.notSolved(challenges.feedbackChallenge)) {
+  if (challengeUtils.notSolved(challenges.feedbackChallenge)) {
     feedbackChallenge()
   }
-  if (utils.notSolved(challenges.knownVulnerableComponentChallenge)) {
+  if (challengeUtils.notSolved(challenges.knownVulnerableComponentChallenge)) {
     knownVulnerableComponentChallenge()
   }
-  if (utils.notSolved(challenges.weirdCryptoChallenge)) {
+  if (challengeUtils.notSolved(challenges.weirdCryptoChallenge)) {
     weirdCryptoChallenge()
   }
-  if (utils.notSolved(challenges.typosquattingNpmChallenge)) {
+  if (challengeUtils.notSolved(challenges.typosquattingNpmChallenge)) {
     typosquattingNpmChallenge()
   }
-  if (utils.notSolved(challenges.typosquattingAngularChallenge)) {
+  if (challengeUtils.notSolved(challenges.typosquattingAngularChallenge)) {
     typosquattingAngularChallenge()
   }
-  if (utils.notSolved(challenges.hiddenImageChallenge)) {
+  if (challengeUtils.notSolved(challenges.hiddenImageChallenge)) {
     hiddenImageChallenge()
   }
-  if (utils.notSolved(challenges.supplyChainAttackChallenge)) {
+  if (challengeUtils.notSolved(challenges.supplyChainAttackChallenge)) {
     supplyChainAttackChallenge()
   }
-  if (utils.notSolved(challenges.dlpPastebinDataLeakChallenge)) {
+  if (challengeUtils.notSolved(challenges.dlpPastebinDataLeakChallenge)) {
     dlpPastebinDataLeakChallenge()
   }
   next()
@@ -160,7 +161,7 @@ function changeProductChallenge (osaft: Product) {
     if (urlForProductTamperingChallenge) {
       if (!utils.contains(osaft.description, `${urlForProductTamperingChallenge}`)) {
         if (utils.contains(osaft.description, `<a href="${config.get('challenges.overwriteUrlForProductTamperingChallenge')}" target="_blank">More...</a>`)) {
-          utils.solve(challenges.changeProductChallenge)
+          challengeUtils.solve(challenges.changeProductChallenge)
         }
       }
     }
@@ -170,7 +171,7 @@ function changeProductChallenge (osaft: Product) {
 function feedbackChallenge () {
   FeedbackModel.findAndCountAll({ where: { rating: 5 } }).then(({ count }: { count: number }) => {
     if (count === 0) {
-      utils.solve(challenges.feedbackChallenge)
+      challengeUtils.solve(challenges.feedbackChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to retrieve feedback details. Please try again')
@@ -186,7 +187,7 @@ function knownVulnerableComponentChallenge () {
     }
   }).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.knownVulnerableComponentChallenge)
+      challengeUtils.solve(challenges.knownVulnerableComponentChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -199,7 +200,7 @@ function knownVulnerableComponentChallenge () {
     }
   }).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.knownVulnerableComponentChallenge)
+      challengeUtils.solve(challenges.knownVulnerableComponentChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -232,7 +233,7 @@ function weirdCryptoChallenge () {
     }
   }).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.weirdCryptoChallenge)
+      challengeUtils.solve(challenges.weirdCryptoChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -245,7 +246,7 @@ function weirdCryptoChallenge () {
     }
   }).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.weirdCryptoChallenge)
+      challengeUtils.solve(challenges.weirdCryptoChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -266,7 +267,7 @@ function typosquattingNpmChallenge () {
   FeedbackModel.findAndCountAll({ where: { comment: { [Op.like]: '%epilogue-js%' } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.typosquattingNpmChallenge)
+      challengeUtils.solve(challenges.typosquattingNpmChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -274,7 +275,7 @@ function typosquattingNpmChallenge () {
   ComplaintModel.findAndCountAll({ where: { message: { [Op.like]: '%epilogue-js%' } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.typosquattingNpmChallenge)
+      challengeUtils.solve(challenges.typosquattingNpmChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -285,7 +286,7 @@ function typosquattingAngularChallenge () {
   FeedbackModel.findAndCountAll({ where: { comment: { [Op.like]: '%anuglar2-qrcode%' } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.typosquattingAngularChallenge)
+      challengeUtils.solve(challenges.typosquattingAngularChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -293,7 +294,7 @@ function typosquattingAngularChallenge () {
   ComplaintModel.findAndCountAll({ where: { message: { [Op.like]: '%anuglar2-qrcode%' } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.typosquattingAngularChallenge)
+      challengeUtils.solve(challenges.typosquattingAngularChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -304,7 +305,7 @@ function hiddenImageChallenge () {
   FeedbackModel.findAndCountAll({ where: { comment: { [Op.like]: '%pickle rick%' } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.hiddenImageChallenge)
+      challengeUtils.solve(challenges.hiddenImageChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -312,7 +313,7 @@ function hiddenImageChallenge () {
   ComplaintModel.findAndCountAll({ where: { message: { [Op.like]: '%pickle rick%' } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.hiddenImageChallenge)
+      challengeUtils.solve(challenges.hiddenImageChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -323,7 +324,7 @@ function supplyChainAttackChallenge () {
   FeedbackModel.findAndCountAll({ where: { comment: { [Op.or]: eslintScopeVulnIds() } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.supplyChainAttackChallenge)
+      challengeUtils.solve(challenges.supplyChainAttackChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -331,7 +332,7 @@ function supplyChainAttackChallenge () {
   ComplaintModel.findAndCountAll({ where: { message: { [Op.or]: eslintScopeVulnIds() } } }
   ).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.supplyChainAttackChallenge)
+      challengeUtils.solve(challenges.supplyChainAttackChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -352,7 +353,7 @@ function dlpPastebinDataLeakChallenge () {
     }
   }).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.dlpPastebinDataLeakChallenge)
+      challengeUtils.solve(challenges.dlpPastebinDataLeakChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')
@@ -363,7 +364,7 @@ function dlpPastebinDataLeakChallenge () {
     }
   }).then(({ count }: { count: number }) => {
     if (count > 0) {
-      utils.solve(challenges.dlpPastebinDataLeakChallenge)
+      challengeUtils.solve(challenges.dlpPastebinDataLeakChallenge)
     }
   }).catch(() => {
     throw new Error('Unable to get data for known vulnerabilities. Please try again')

--- a/routes/videoHandler.ts
+++ b/routes/videoHandler.ts
@@ -5,6 +5,7 @@
 
 import fs = require('fs')
 import { Request, Response } from 'express'
+import challengeUtils = require('../lib/challengeUtils')
 
 const pug = require('pug')
 const config = require('config')
@@ -53,7 +54,7 @@ exports.promotionVideo = () => {
       let template = buf.toString()
       const subs = getSubsFromFile()
 
-      utils.solveIf(challenges.videoXssChallenge, () => { return utils.contains(subs, '</script><script>alert(`xss`)</script>') })
+      challengeUtils.solveIf(challenges.videoXssChallenge, () => { return utils.contains(subs, '</script><script>alert(`xss`)</script>') })
 
       const theme = themes[config.get('application.theme')]
       template = template.replace(/_title_/g, entities.encode(config.get('application.name')))

--- a/routes/vulnCodeFixes.ts
+++ b/routes/vulnCodeFixes.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express'
 
 const accuracy = require('../lib/accuracy')
-const utils = require('../lib/utils')
+const challengeUtils = require('../lib/challengeUtils')
 const fs = require('fs')
 const yaml = require('js-yaml')
 
@@ -84,7 +84,7 @@ export const checkCorrectFix = () => async (req: Request<{}, {}, VerdictRequestB
       if (selectedFixInfo?.explanation) explanation = res.__(selectedFixInfo.explanation)
     }
     if (selectedFix === fixData.correct) {
-      await utils.solveFixIt(key)
+      await challengeUtils.solveFixIt(key)
       res.status(200).json({
         verdict: true,
         explanation

--- a/routes/vulnCodeSnippet.ts
+++ b/routes/vulnCodeSnippet.ts
@@ -9,6 +9,7 @@ import actualFs from 'fs'
 import yaml from 'js-yaml'
 
 const utils = require('../lib/utils')
+const challengeUtils = require('../lib/challengeUtils')
 const challenges = require('../data/datacache').challenges
 const path = require('path')
 const accuracy = require('../lib/accuracy')
@@ -206,7 +207,7 @@ exports.checkVulnLines = () => async (req: Request<{}, {}, VerdictRequestBody>, 
     }
   }
   if (verdict) {
-    await utils.solveFindIt(key)
+    await challengeUtils.solveFindIt(key)
     res.status(200).json({
       verdict: true
     })


### PR DESCRIPTION
Since the utils.ts file grew a bit large and for easier use of `utils.ts` in the future for imports in Cypress, this PR migrates the following methods from `utils.ts` to a new `challengeUtils.ts`:
- solveIf()
- solve()
- sendNotification()
- notSolved()
- findChallengeByName()
- findChallengeById()
- solveFindIt()
- solveFixIt()

And all the files where these methods were imported have been updated accordingly with the following code snippet skeleton:
```diff
     import utils = require('../lib/utils')
+    import challengeUtils = require('../lib/challengeUtils')

-    utils.notSolved(challenges.xxeDosChallenge)
+    challengeUtils.notSolved(challenges.xxeDosChallenge)
```

Let me know if we should add some more(the CTF ones) or remove anything from here