### PR TITLE
Reduce Regex Count match on File Upload

### DIFF
--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -17,12 +17,12 @@ const path = require('path')
 
 function matchesSystemIniFile (text: string) {
   const match = text.match(/(; for 16-bit app support|drivers|mci|driver32|386enh|keyboard|boot|display)/gi)
-  return match && match.length >= 2
+  return match && match.length >= 1
 }
 
 function matchesEtcPasswdFile (text: string) {
   const match = text.match(/\w*:\w*:\d*:\d*:\w*:.*/gi)
-  return match && match.length >= 2
+  return match && match.length >= 1
 }
 
 function ensureFileIsPassed ({ file }: Request, res: Response, next: NextFunction) {


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - see https://pwning.owasp-juice.shop/part3/contribution.html#handling-of-spam-prs for more information 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description
Updates the regex match count to be `>=1` from `>=2` as the XML on Arch Linux only satisfied one regex match and the challenge was failing.
<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
