### PR TITLE
Fix for issue #1755 - Database Sync and Metrics Race

### DIFF
--- a/data/static/codefixes/exposedMetricsChallenge_1.ts
+++ b/data/static/codefixes/exposedMetricsChallenge_1.ts
@@ -1,6 +1,6 @@
 /* Serve metrics */
 const Metrics = metrics.observeMetrics()
-const metricsUpdateLoop = Metrics.updateLoop
+const metricsUpdateLoop = Metrics.updateLoop()
 app.get('/metrics', security.denyAll(), metrics.serveMetrics())
 errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
 

--- a/data/static/codefixes/exposedMetricsChallenge_1.ts
+++ b/data/static/codefixes/exposedMetricsChallenge_1.ts
@@ -1,6 +1,6 @@
 /* Serve metrics */
+let metricsUpdateLoop
 const Metrics = metrics.observeMetrics()
-const metricsUpdateLoop = Metrics.updateLoop()
 app.get('/metrics', security.denyAll(), metrics.serveMetrics())
 errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
 
@@ -14,6 +14,8 @@ export async function start (readyCallback: Function) {
   datacreatorEnd()
   const port = process.env.PORT ?? config.get('server.port')
   process.env.BASE_PATH = process.env.BASE_PATH ?? config.get('server.basePath')
+
+  metricsUpdateLoop = Metrics.updateLoop()
 
   server.listen(port, () => {
     logger.info(colors.cyan(`Server listening on port ${colors.bold(port)}`))

--- a/data/static/codefixes/exposedMetricsChallenge_3_correct.ts
+++ b/data/static/codefixes/exposedMetricsChallenge_3_correct.ts
@@ -1,6 +1,6 @@
 /* Serve metrics */
+let metricsUpdateLoop
 const Metrics = metrics.observeMetrics()
-const metricsUpdateLoop = Metrics.updateLoop()
 app.get('/metrics', security.isAdmin(), metrics.serveMetrics())
 errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
 
@@ -14,6 +14,8 @@ export async function start (readyCallback: Function) {
   datacreatorEnd()
   const port = process.env.PORT ?? config.get('server.port')
   process.env.BASE_PATH = process.env.BASE_PATH ?? config.get('server.basePath')
+
+  metricsUpdateLoop = Metrics.updateLoop()
 
   server.listen(port, () => {
     logger.info(colors.cyan(`Server listening on port ${colors.bold(port)}`))

--- a/data/static/codefixes/exposedMetricsChallenge_3_correct.ts
+++ b/data/static/codefixes/exposedMetricsChallenge_3_correct.ts
@@ -1,6 +1,6 @@
 /* Serve metrics */
 const Metrics = metrics.observeMetrics()
-const metricsUpdateLoop = Metrics.updateLoop
+const metricsUpdateLoop = Metrics.updateLoop()
 app.get('/metrics', security.isAdmin(), metrics.serveMetrics())
 errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
 

--- a/routes/metrics.ts
+++ b/routes/metrics.ts
@@ -143,7 +143,7 @@ exports.observeMetrics = function observeMetrics () {
     labelNames: ['type']
   })
 
-  const updateLoop = setInterval(() => {
+  const updateLoop = () => setInterval(() => {
     try {
       const version = utils.version()
       const { major, minor, patch } = version.match(/(?<major>\d+).(?<minor>\d+).(?<patch>\d+)/).groups

--- a/rsn/cache.json
+++ b/rsn/cache.json
@@ -105,7 +105,9 @@
 	},
 	"exposedMetricsChallenge_2.ts": {
 		"added": [
-			34
+			2,
+			19,
+			36
 		],
 		"removed": []
 	},

--- a/server.ts
+++ b/server.ts
@@ -641,7 +641,7 @@ while (!expectedModels.every(model => Object.keys(sequelize.models).includes(mod
 }
 logger.info(`Entity models ${colors.bold(Object.keys(sequelize.models).length)} of ${colors.bold(expectedModels.length)} are initialized (${colors.green('OK')})`)
 
-let metricsUpdateLoop;
+let metricsUpdateLoop
 
 const registerWebsocketEvents = require('./lib/startup/registerWebsocketEvents')
 const customizeApplication = require('./lib/startup/customizeApplication')

--- a/server.ts
+++ b/server.ts
@@ -641,11 +641,16 @@ while (!expectedModels.every(model => Object.keys(sequelize.models).includes(mod
 }
 logger.info(`Entity models ${colors.bold(Object.keys(sequelize.models).length)} of ${colors.bold(expectedModels.length)} are initialized (${colors.green('OK')})`)
 
-let metricsUpdateLoop;
+// vuln-code-snippet start exposedMetricsChallenge
+/* Serve metrics */
+let metricsUpdateLoop
+const Metrics = metrics.observeMetrics() // vuln-code-snippet neutral-line exposedMetricsChallenge
+const customizeEasterEgg = require('./lib/startup/customizeEasterEgg') // vuln-code-snippet hide-line
+app.get('/metrics', metrics.serveMetrics()) // vuln-code-snippet vuln-line exposedMetricsChallenge
+errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
 
 const registerWebsocketEvents = require('./lib/startup/registerWebsocketEvents')
 const customizeApplication = require('./lib/startup/customizeApplication')
-const customizeEasterEgg = require('./lib/startup/customizeEasterEgg') // vuln-code-snippet hide-line
 
 export async function start (readyCallback: Function) {
   const datacreatorEnd = startupGauge.startTimer({ task: 'datacreator' })
@@ -655,12 +660,7 @@ export async function start (readyCallback: Function) {
   const port = process.env.PORT ?? config.get('server.port')
   process.env.BASE_PATH = process.env.BASE_PATH ?? config.get('server.basePath')
 
-  // vuln-code-snippet start exposedMetricsChallenge
-  /* Serve metrics */
-  const Metrics = metrics.observeMetrics() // vuln-code-snippet neutral-line exposedMetricsChallenge
   metricsUpdateLoop = Metrics.updateLoop() // vuln-code-snippet neutral-line exposedMetricsChallenge
-  app.get('/metrics', metrics.serveMetrics()) // vuln-code-snippet vuln-line exposedMetricsChallenge
-  errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
 
   server.listen(port, () => {
     logger.info(colors.cyan(`Server listening on port ${colors.bold(port)}`))

--- a/server.ts
+++ b/server.ts
@@ -641,12 +641,7 @@ while (!expectedModels.every(model => Object.keys(sequelize.models).includes(mod
 }
 logger.info(`Entity models ${colors.bold(Object.keys(sequelize.models).length)} of ${colors.bold(expectedModels.length)} are initialized (${colors.green('OK')})`)
 
-// vuln-code-snippet start exposedMetricsChallenge
-/* Serve metrics */
-const Metrics = metrics.observeMetrics() // vuln-code-snippet neutral-line exposedMetricsChallenge
-const metricsUpdateLoop = Metrics.updateLoop // vuln-code-snippet neutral-line exposedMetricsChallenge
-app.get('/metrics', metrics.serveMetrics()) // vuln-code-snippet vuln-line exposedMetricsChallenge
-errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
+let metricsUpdateLoop;
 
 const registerWebsocketEvents = require('./lib/startup/registerWebsocketEvents')
 const customizeApplication = require('./lib/startup/customizeApplication')
@@ -659,6 +654,13 @@ export async function start (readyCallback: Function) {
   datacreatorEnd()
   const port = process.env.PORT ?? config.get('server.port')
   process.env.BASE_PATH = process.env.BASE_PATH ?? config.get('server.basePath')
+
+  // vuln-code-snippet start exposedMetricsChallenge
+  /* Serve metrics */
+  const Metrics = metrics.observeMetrics() // vuln-code-snippet neutral-line exposedMetricsChallenge
+  metricsUpdateLoop = Metrics.updateLoop() // vuln-code-snippet neutral-line exposedMetricsChallenge
+  app.get('/metrics', metrics.serveMetrics()) // vuln-code-snippet vuln-line exposedMetricsChallenge
+  errorhandler.title = `${config.get('application.name')} (Express ${utils.version('express')})`
 
   server.listen(port, () => {
     logger.info(colors.cyan(`Server listening on port ${colors.bold(port)}`))


### PR DESCRIPTION
### Description

Fixes a race condition between the database startup sync and the metrics loop. Detailed explanation of issue here: https://github.com/juice-shop/juice-shop/issues/1755#issuecomment-1251772864

I tried to take care and catch everything that was needed including updating the coding challenges associate with the "Exposed Metrics" challenge. Please let me know what else I need to cover and how I can improve this PR.

p.s. Thanks for this amazing project. I've really enjoyed using it these last few years with a CTF I help run for local high school students. I also hope to contribute more going forward!

Resolved or fixed issue: 1755

### Affirmation

- [ ✅  ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
