### PR TITLE
Dynamic Recursion to not Bully the chatbot unnecessarily

### DIFF
--- a/cypress/integration/e2e/chatbot.spec.ts
+++ b/cypress/integration/e2e/chatbot.spec.ts
@@ -41,11 +41,19 @@ describe('/chatbot', () => {
 
           cy.get('#message-input').type('hi').type('{enter}')
           cy.get('#message-input').type('...').type('{enter}')
-          for (let i = 0; i < 40; i++) {
+
+          const genArr = Array.from({ length: 40 }, (v, k) => k + 1)
+          cy.wrap(genArr).eachSeries(() => {
             cy.get('#message-input')
               .type(couponIntent.utterances[0])
               .type('{enter}')
-          }
+
+            return cy.get('.speech-bubble-left')
+              .invoke('text')
+              .then((text: string) => {
+                if (text.includes("Oooookay, if you promise to stop nagging me here's a 10% coupon code for you")) return false
+              })
+          })
           cy.expectChallengeSolved({ challenge: 'Bully Chatbot' })
         }
       )

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -74,3 +74,18 @@ Cypress.Commands.add(
     cy.wait(500)
   }
 )
+
+function walkRecursivelyInArray (arr: Number[], cb: Function, index = 0) {
+  if (!arr.length) return
+  const ret = cb(index, arr.shift());
+  // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+  ((ret && ret.chainerId) ? ret : cy.wrap(ret))
+    .then((ret: boolean) => {
+      if (!ret) return
+      return walkRecursivelyInArray(arr, cb, index + 1)
+    })
+}
+
+Cypress.Commands.add('eachSeries', { prevSubject: 'optional' }, (arrayGenerated: Number[], checkFnToBeRunOnEach: Function) => {
+  return walkRecursivelyInArray(arrayGenerated, checkFnToBeRunOnEach)
+})

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -30,6 +30,8 @@ declare global {
         password: string
         totpSecret?: string
       }) => void
+      eachSeries: any
+
     }
   }
 }


### PR DESCRIPTION
### Description
Partially closes #1878 

<!-- ✍️-->
`bullyChatbot.spec.ts` has been our most time-consuming test till now due to it bullying the chatbot 40 times even after sometimes getting the coupon code earlier too. This was a static approach till now. 

Now with this PR, I have basically added a dynamic check after every reply and stops the loop as soon as we get the code.

This involved Recursion and a Cypress Custom command addition just because Cypress chaining of elements is too slow as compared to the JS for loop and again Cypress does not **exactly** support async/await. But yay, this works after a good amount of time spent!

Also, Happy Hacktoberfest 🎃  haha

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
