### PR TITLE
Fix CodeQL Regex warning

### DIFF
--- a/test/cypress/integration/e2e/redirect.spec.ts
+++ b/test/cypress/integration/e2e/redirect.spec.ts
@@ -16,7 +16,7 @@ describe('/redirect', () => {
           failOnStatusCode: false
         }
       )
-      cy.url().should('match', /https:\/\/owasp\.org/)
+      cy.url().should("eq", "https://owasp.org/?trickIndexOf=https://github.com/bkimminich/juice-shop")
       cy.expectChallengeSolved({ challenge: 'Allowlist Bypass' })
     })
   })

--- a/test/cypress/integration/e2e/redirect.spec.ts
+++ b/test/cypress/integration/e2e/redirect.spec.ts
@@ -16,7 +16,7 @@ describe('/redirect', () => {
           failOnStatusCode: false
         }
       )
-      cy.url().should("eq", "https://owasp.org/?trickIndexOf=https://github.com/bkimminich/juice-shop")
+      cy.url().should('eq', 'https://owasp.org/?trickIndexOf=https://github.com/bkimminich/juice-shop')
       cy.expectChallengeSolved({ challenge: 'Allowlist Bypass' })
     })
   })


### PR DESCRIPTION
### Description
Fixes the CodeQL warning for regex by replacing the URL check from regex form to the actual exact URL match.
We face this because the URL we are visiting is `https://owasp.org?trickIndexOf=https://github.com/bkimminich/juice-shop` and the regex check of codeQL throws a failure because we aren't validating the entire URL ie the end.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
