### PR TITLE
Fix Chatbot Crash

### DIFF
--- a/routes/chatbot.ts
+++ b/routes/chatbot.ts
@@ -64,7 +64,7 @@ async function processQuery (user: User, req: Request, res: Response, next: Next
         body: bot.greet(`${user.id}`)
       })
     } catch (err) {
-      next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+      next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
     }
     return
   }
@@ -74,7 +74,7 @@ async function processQuery (user: User, req: Request, res: Response, next: Next
     try {
       bot.addUser(`${user.id}`, username)
     } catch (err) {
-      next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+      next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
       return
     }
   }
@@ -189,7 +189,7 @@ module.exports.status = function status () {
           body: bot.training.state ? bot.greet(`${user.id}`) : `${config.get('application.chatBot.name')} isn't ready at the moment, please wait while I set things up`
         })
       } catch (err) {
-        next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+        next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
       }
       return
     }

--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -18,7 +18,7 @@ const router = express.Router()
 router.get('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const loggedInUser = insecurity.authenticatedUsers.get(req.cookies.token)
   if (!loggedInUser) {
-    next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+    next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
     return
   }
   const email = loggedInUser.data.email
@@ -54,7 +54,7 @@ interface DataErasureRequestParams {
 router.post('/', async (req: Request<{}, {}, DataErasureRequestParams>, res: Response, next: NextFunction): Promise<void> => {
   const loggedInUser = insecurity.authenticatedUsers.get(req.cookies.token)
   if (!loggedInUser) {
-    next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+    next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
     return
   }
 

--- a/routes/dataExport.ts
+++ b/routes/dataExport.ts
@@ -109,7 +109,7 @@ module.exports = function dataExport () {
         next(new Error(`Error retrieving orders for ${updatedEmail}`))
       })
     } else {
-      next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+      next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
     }
   }
 }

--- a/routes/orderHistory.ts
+++ b/routes/orderHistory.ts
@@ -18,7 +18,7 @@ module.exports.orderHistory = function orderHistory () {
       const order = await orders.find({ email: updatedEmail })
       res.status(200).json({ status: 'success', data: order })
     } else {
-      next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+      next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
     }
   }
 }

--- a/routes/profileImageFileUpload.ts
+++ b/routes/profileImageFileUpload.ts
@@ -43,7 +43,7 @@ module.exports = function fileUpload () {
           res.location(process.env.BASE_PATH + '/profile')
           res.redirect(process.env.BASE_PATH + '/profile')
         } else {
-          next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+          next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
         }
       } else {
         res.status(415)

--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -33,7 +33,7 @@ module.exports = function profileImageUrlUpload () {
             } else UserModel.findByPk(loggedInUser.data.id).then(async (user: UserModel | null) => { return await user?.update({ profileImage: url }) }).catch((error: Error) => { next(error) })
           })
       } else {
-        next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+        next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
       }
     }
     res.location(process.env.BASE_PATH + '/profile')

--- a/routes/saveLoginIp.ts
+++ b/routes/saveLoginIp.ts
@@ -23,7 +23,7 @@ module.exports = function saveLoginIp () {
         lastLoginIp = security.sanitizeSecure(lastLoginIp)
       }
       if (lastLoginIp === undefined) {
-        lastLoginIp = utils.toSimpleIpAddress(req.connection.remoteAddress)
+        lastLoginIp = utils.toSimpleIpAddress(req.socket.remoteAddress)
       }
       UserModel.findByPk(loggedInUser.data.id).then((user: UserModel | null) => {
         user?.update({ lastLoginIp: lastLoginIp?.toString() }).then((user: UserModel) => {

--- a/routes/updateUserProfile.ts
+++ b/routes/updateUserProfile.ts
@@ -37,7 +37,7 @@ module.exports = function updateUserProfile () {
         next(error)
       })
     } else {
-      next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+      next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
     }
   }
 }

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -66,7 +66,7 @@ module.exports = function getUserProfile () {
           next(error)
         })
       } else {
-        next(new Error('Blocked illegal activity by ' + req.connection.remoteAddress))
+        next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
       }
     })
   }

--- a/test/api/chatBotSpec.ts
+++ b/test/api/chatBotSpec.ts
@@ -55,7 +55,7 @@ describe('/chatbot', () => {
         password: '0Y8rMnww$*9VFYE§59-!Fg1L6t&6lB'
       })
 
-      await void frisby.setup({
+      await frisby.setup({
         request: {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -65,6 +65,7 @@ describe('/chatbot', () => {
       }, true).get(REST_URL + 'chatbot/status')
         .expect('status', 200)
         .expect('json', 'body', /What shall I call you?/)
+        .promise()
     })
   })
 
@@ -77,7 +78,7 @@ describe('/chatbot', () => {
 
       const testCommand = trainingData.data[0].utterances[0]
 
-      await void frisby.setup({
+      await frisby.setup({
         request: {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -94,6 +95,7 @@ describe('/chatbot', () => {
         .expect('status', 200)
         .expect('json', 'action', 'namequery')
         .expect('json', 'body', 'I\'m sorry I didn\'t get your name. What shall I call you?')
+        .promise()
     })
 
     it('Returns greeting if username is defined', async () => {
@@ -105,7 +107,7 @@ describe('/chatbot', () => {
       bot.addUser('1337', 'bkimminich')
       const testCommand = trainingData.data[0].utterances[0]
 
-      await void frisby.setup({
+      await frisby.setup({
         request: {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -122,6 +124,7 @@ describe('/chatbot', () => {
         .expect('status', 200)
         .expect('json', 'action', 'response')
         .expect('json', 'body', bot.greet('1337'))
+        .promise()
     })
 
     it('Returns proper response for registered user', async () => {
@@ -131,7 +134,7 @@ describe('/chatbot', () => {
       })
       bot.addUser('12345', 'bkimminich')
       const testCommand = trainingData.data[0].utterances[0]
-      await void frisby.setup({
+      await frisby.setup({
         request: {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -152,6 +155,7 @@ describe('/chatbot', () => {
           }
         })
         .expect('status', 200)
+        .promise()
         .then(({ json }) => {
           // @ts-expect-error
           expect(trainingData.data[0].answers).toContainEqual(json)
@@ -163,28 +167,29 @@ describe('/chatbot', () => {
         email: 'bjoern.kimminich@gmail.com',
         password: 'bW9jLmxpYW1nQGhjaW5pbW1pay5ucmVvamI='
       })
-      await void frisby.get(API_URL + '/Products/1')
+      const { json } = await frisby.get(API_URL + '/Products/1')
         .expect('status', 200)
-        .then(({ json }) => {
-          return frisby.setup({
-            request: {
-              headers: {
-                Authorization: `Bearer ${token}`,
-                'Content-Type': 'application/json'
-              }
-            }
-          }, true)
-            .post(REST_URL + 'chatbot/respond', {
-              body: {
-                action: 'query',
-                query: 'How much is ' + json.data.name + '?'
-              }
-            })
-            .expect('status', 200)
-            .expect('json', 'action', 'response')
-            .then(({ body = json.body }) => {
-              expect(body).toContain(`${json.data.name} costs ${json.data.price}¤`)
-            })
+        .promise()
+
+      await frisby.setup({
+        request: {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
+        }
+      }, true)
+        .post(REST_URL + 'chatbot/respond', {
+          body: {
+            action: 'query',
+            query: 'How much is ' + json.data.name + '?'
+          }
+        })
+        .expect('status', 200)
+        .expect('json', 'action', 'response')
+        .promise()
+        .then(({ body = json.body }) => {
+          expect(body).toContain(`${json.data.name} costs ${json.data.price}¤`)
         })
     })
 
@@ -193,7 +198,7 @@ describe('/chatbot', () => {
         email: `stan@${config.get('application.domain')}`,
         password: 'ship coffin krypt cross estate supply insurance asbestos souvenir'
       })
-      await void frisby.setup({
+      await frisby.setup({
         request: {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -210,6 +215,7 @@ describe('/chatbot', () => {
         .expect('status', 200)
         .expect('json', 'action', 'response')
         .expect('json', 'body', /NotGuybrushThreepwood/)
+        .promise()
     })
 
     it('POST returns error for unauthenticated user', () => {
@@ -239,7 +245,7 @@ describe('/chatbot', () => {
       })
       const testCommand = functionTest[0].utterances[0]
       const testResponse = '3be2e438b7f3d04c89d7749f727bb3bd'
-      await void frisby.setup({
+      await frisby.setup({
         request: {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -262,6 +268,7 @@ describe('/chatbot', () => {
         .expect('status', 200)
         .expect('json', 'action', 'response')
         .expect('json', 'body', testResponse)
+        .promise()
     })
 
     it('Returns a 500 when the user name is set to crash request', async () => {

--- a/test/api/deluxeApiSpec.ts
+++ b/test/api/deluxeApiSpec.ts
@@ -105,21 +105,22 @@ describe('/rest/deluxe-membership', () => {
       password: 'OhG0dPlease1nsertLiquor!'
     })
 
-    await void frisby.get(API_URL + '/Cards', {
+    const { json } = await frisby.get(API_URL + '/Cards', {
       headers: { Authorization: 'Bearer ' + token, 'content-type': 'application/json' }
     })
       .expect('status', 200)
-      .then(({ json }) => {
-        return frisby.post(REST_URL + '/deluxe-membership', {
-          headers: { Authorization: 'Bearer ' + token, 'content-type': 'application/json' },
-          body: {
-            paymentMode: 'card',
-            paymentId: json.data[0].id.toString()
-          }
-        })
-          .expect('status', 200)
-          .expect('json', 'status', 'success')
-      })
+      .promise()
+
+    await frisby.post(REST_URL + '/deluxe-membership', {
+      headers: { Authorization: 'Bearer ' + token, 'content-type': 'application/json' },
+      body: {
+        paymentMode: 'card',
+        paymentId: json.data[0].id.toString()
+      }
+    })
+      .expect('status', 200)
+      .expect('json', 'status', 'success')
+      .promise()
   })
 
   it('POST deluxe membership status with wrong card id throws error', async () => {
@@ -128,7 +129,7 @@ describe('/rest/deluxe-membership', () => {
       password: 'ncc-1701'
     })
 
-    await void frisby.post(REST_URL + '/deluxe-membership', {
+    await frisby.post(REST_URL + '/deluxe-membership', {
       headers: { Authorization: 'Bearer ' + token, 'content-type': 'application/json' },
       body: {
         paymentMode: 'card',
@@ -137,6 +138,7 @@ describe('/rest/deluxe-membership', () => {
     })
       .expect('status', 400)
       .expect('json', 'error', 'Invalid Card')
+      .promise()
   })
 
   it('POST deluxe membership status for deluxe members throws error', () => {


### PR DESCRIPTION
### Description

Resolved or fixed issue: #1909

Endpoints are now returning a 500 "illegal activity" error: 81926db7419ff9f234423bd8efbfe9394f9f7015

Also fix:

- Replaced req.connection with req.socket (Deprecated since Node.js 13): 6bf81954c5d93ebabfe5d1ef5bb88764f6f0117c
- Fixed async / await errors in the api tests not properly awaiting the requests. (found this as i tried to reuse the section in the chatbot tests): c99dbff55a382a4888f6f95bed80cfd548f9b8b9

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
