### PR TITLE
Fix CVE-2022-24434

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "libxmljs2": "^0.30.1",
     "marsdb": "^0.6.11",
     "morgan": "^1.10.0",
-    "multer": "^1.4.2",
+    "multer": "^1.4.5-lts.1",
     "node-pre-gyp": "^0.15.0",
     "notevil": "^1.3.3",
     "on-finished": "^2.3.0",

--- a/test/api/memoryApiSpec.ts
+++ b/test/api/memoryApiSpec.ts
@@ -107,4 +107,16 @@ describe('/rest/memories', () => {
           })
       })
   })
+
+  it('Should not crash the node-js server when sending invalid content like described in CVE-2022-24434', () => {
+    return frisby.post(REST_URL + '/memories', {
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=----WebKitFormBoundaryoo6vortfDzBsDiro',
+        'Content-Length': '145'
+      },
+      body: '------WebKitFormBoundaryoo6vortfDzBsDiro\r\n Content-Disposition: form-data; name="bildbeschreibung"\r\n\r\n\r\n------WebKitFormBoundaryoo6vortfDzBsDiro--'
+    })
+      .expect('status', 500)
+      .expect('bodyContains', 'Error: Malformed part header')
+  })
 })


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - see https://pwning.owasp-juice.shop/part3/contribution.html#handling-of-spam-prs for more information 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

This application is vulnerable to CVE-2022-24434. This means, each api endpoint which handles image uploads can be used to shut down the nodejs-server.
This issues comes in through the package `multer`, which uses another package called `dicer`, in which the vulnerability was found. The newest version of multer (`1.4.5-lts.1`) now includes a fix for this vulnerability (see [https://github.com/expressjs/multer/pull/1097](https://github.com/expressjs/multer/pull/1097)).

#### Exploit example
As a demo, we use the `/rest/memories` endpoint to send the invalid payload
```js
fetch('/rest/memories', {
   method: 'POST',
   headers: {
     ['content-type']: 'multipart/form-data; boundary=----WebKitFormBoundaryoo6vortfDzBsDiro',
     ['content-length']: '145',
   },
   body: '------WebKitFormBoundaryoo6vortfDzBsDiro\r\n Content-Disposition: form-data; name="bildbeschreibung"\r\n\r\n\r\n------WebKitFormBoundaryoo6vortfDzBsDiro--'
 });
```
The result of this is the nodejs-server crashing.


Resolved or fixed issue: none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
