### PR TITLE
[New Challenge] Crack image captcha using Padding Oracle Attack

### DIFF
--- a/frontend/src/app/data-export/data-export.component.html
+++ b/frontend/src/app/data-export/data-export.component.html
@@ -29,6 +29,7 @@
           <input #captchaInput [formControl]="captchaControl" type="text" matInput
                  placeholder="{{ 'TYPE_THESE_LETTERS' | translate: {length: '5'} }}" maxlength="5"
                  aria-label="Input for the CAPTCHA">
+          <input #captchaVerifier [formControl]="verifierControl" type="hidden">
           <mat-hint align="end">{{captchaInput.value?.length || 0}}/5</mat-hint>
           <mat-error *ngIf="captchaControl.invalid && captchaControl.errors.required " translate>MANDATORY_CAPTCHA
           </mat-error>

--- a/frontend/src/app/data-export/data-export.component.ts
+++ b/frontend/src/app/data-export/data-export.component.ts
@@ -17,6 +17,7 @@ import { DomSanitizer } from '@angular/platform-browser'
 export class DataExportComponent implements OnInit {
   public captchaControl: UntypedFormControl = new UntypedFormControl('', [Validators.required, Validators.minLength(5)])
   public formatControl: UntypedFormControl = new UntypedFormControl('', [Validators.required])
+  public verifierControl: UntypedFormControl = new UntypedFormControl('', [Validators.required])
   public captcha: any
   private dataRequest: any = undefined
   public confirmation: any
@@ -42,6 +43,7 @@ export class DataExportComponent implements OnInit {
 
   getNewCaptcha () {
     this.imageCaptchaService.getCaptcha().subscribe((data: any) => {
+      this.verifierControl.setValue(data.verifier)
       this.captcha = this.sanitizer.bypassSecurityTrustHtml(data.image)
     })
   }
@@ -50,6 +52,7 @@ export class DataExportComponent implements OnInit {
     if (this.presenceOfCaptcha) {
       this.dataRequest.answer = this.captchaControl.value
     }
+    this.dataRequest.verifier = this.verifierControl.value
     this.dataRequest.format = this.formatControl.value
     this.dataSubjectService.dataExport(this.dataRequest).subscribe((data: any) => {
       this.error = null

--- a/routes/imageCaptcha.ts
+++ b/routes/imageCaptcha.ts
@@ -9,14 +9,24 @@ import { Op } from 'sequelize'
 
 const svgCaptcha = require('svg-captcha')
 const security = require('../lib/insecurity')
+const crypto = require('node:crypto')
+const aesKey = "EA99A61D92D2955B1E9285B55BF2AD4200000000000000000000000000000000"
+  
+function aesEncrypt(plaintext: String) {
+  const iv  = crypto.randomBytes(16).toString("hex")
+  const cipher = crypto.createCipheriv("aes-256-cbc", Buffer.from(aesKey, "hex"), Buffer.from(iv, "hex"))
+  const ciphertext = cipher.update(plaintext, "utf8", "hex") +
+                     cipher.final("hex")
+  return iv + ":" + ciphertext
+}
 
 function imageCaptchas () {
   return (req: Request, res: Response) => {
     const captcha = svgCaptcha.create({ size: 5, noise: 2, color: true })
-
+    
     const imageCaptcha = {
       image: captcha.data,
-      answer: captcha.text,
+      verifier: aesEncrypt(captcha.text),
       UserId: security.authenticatedUsers.from(req).data.id
     }
     const imageCaptchaInstance = ImageCaptchaModel.build(imageCaptcha)
@@ -26,6 +36,13 @@ function imageCaptchas () {
       res.status(400).send(res.__('Unable to create CAPTCHA. Please try again.'))
     })
   }
+}
+
+function aesDecrypt(payload: String) {
+  const [iv,msg] = payload.split(":")
+  const decipher = crypto.createDecipheriv("aes-256-cbc", Buffer.from(aesKey, "hex"), Buffer.from(iv, "hex"))
+  return decipher.update(msg, "hex", "utf8") +
+         decipher.final("utf-8")
 }
 
 imageCaptchas.verifyCaptcha = () => (req: Request, res: Response, next: NextFunction) => {
@@ -41,7 +58,7 @@ imageCaptchas.verifyCaptcha = () => (req: Request, res: Response, next: NextFunc
     },
     order: [['createdAt', 'DESC']]
   }).then(captchas => {
-    if (!captchas[0] || req.body.answer === captchas[0].answer) {
+    if (!captchas[0] || req.body.answer === aesDecrypt(req.body.verifier)) {
       next()
     } else {
       res.status(401).send(res.__('Wrong answer to CAPTCHA. Please try again.'))


### PR DESCRIPTION
This pull request is a work-in-progress, and for now lacks tests to make it a regular challenge.
I would like to hear your thoughts on this type of challenges. I plan to use the modification for my classes on Web Application Security.

### Description

Currently, the image captcha is returned to the user together with the answer. To make it more realistic and to
enable stateless verification, we could encrypt the answer (as verifier) and had it send back together with the user's answer.
If the decrypted verifier matches the user's answer, it is all good.
However, the verification might fail for two reasons:
- the decryption works, but the original answer does not match the user's answer (Wrong answer...)
- the decryption fails, because the ciphertext (or IV) has been altered and now it does not produce a correct padding (Something went wrong...)

This means that the verification endpoint (`/rest/user/data-export`) might work as a padding oracle, where "Something went wrong" means that the padding is incorrect, while "Wrong answer..." means that the padding is CORRECT but the decrypted verifier does not match the answer.

In the current implementation we use AES256 in CBC mode with a static key and PKCS#5 padding scheme (default for Node's Crypto library). If the user alters the verifier (IV and ciphertext separted by a colon) it might result in wrong padding.

### Padding Oracle

Due to the construction of CBC mode, by controlling next to the last block of ciphertext and having a padding oracle we can determine the internal state of the last block. It means sending a modified ciphertext (together with IV) and observing the output. With this attack, the whole internal state of the decipher might be reconstructed and the plaintext message might be recovered. Padding Oracle Attack also allows to ENCRYPTING an arbitrary method with an unknown key.

The original idea comes from: J. Rizzo, T. Duong, "Practical Padding Oracle Attacks", 4th USENIX Workshop on Offensive Technologies (WOOT 10), 2010, URL: https://www.cs.umd.edu/~jkatz/security/downloads/padding-oracle-attacks.pdf 

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
