### PR TITLE
continueCode(s) are now fetched from server instead of cookies

### DIFF
--- a/frontend/src/app/Services/local-backup.service.spec.ts
+++ b/frontend/src/app/Services/local-backup.service.spec.ts
@@ -21,7 +21,7 @@ describe('LocalBackupService', () => {
   beforeEach(() => {
     snackBar = jasmine.createSpyObj('MatSnackBar', ['open'])
     snackBar.open.and.returnValue(null)
-    challengeService = jasmine.createSpyObj('ChallengeService', ['restoreProgress'])
+    challengeService = jasmine.createSpyObj('ChallengeService', ['restoreProgress', 'continueCode', 'continueCodeFindIt', 'continueCodeFixIt'])
 
     TestBed.configureTestingModule({
       imports: [

--- a/frontend/src/app/Services/local-backup.service.ts
+++ b/frontend/src/app/Services/local-backup.service.ts
@@ -43,9 +43,20 @@ export class LocalBackupService {
           backup.continueCodeFixIt = continueCodeFixIt
           const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
           saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
-        }, (err) => console.log(err))
-      }, (err) => console.log(err))
-    }, (err) => console.log(err))
+        }, (err) => {
+          console.log(err)
+          backup.continueCodeFixIt = this.cookieService.get('continueCodeFixIt') ? this.cookieService.get('continueCodeFixIt') : undefined
+        })
+      }, (err) => {
+        console.log(err)
+        backup.continueCodeFindIt = this.cookieService.get('continueCodeFindIt') ? this.cookieService.get('continueCodeFindIt') : undefined
+      })
+    }, (err) => {
+      console.log(err)
+      backup.continueCode = this.cookieService.get('continueCode') ? this.cookieService.get('continueCode') : undefined
+      const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
+      saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
+    })
   }
 
   restore (backupFile: File) {

--- a/frontend/src/app/Services/local-backup.service.ts
+++ b/frontend/src/app/Services/local-backup.service.ts
@@ -35,25 +35,21 @@ export class LocalBackupService {
       cookieConsentStatus: this.cookieService.get('cookieconsent_status') ? this.cookieService.get('cookieconsent_status') : undefined
     }
     backup.language = this.cookieService.get('language') ? this.cookieService.get('language') : undefined
-    this.challengeService.continueCode().subscribe((continueCode) => {
+
+    const continueCode = this.challengeService.continueCode()
+    const continueCodeFindIt = this.challengeService.continueCodeFindIt()
+    const continueCodeFixIt = this.challengeService.continueCodeFixIt()
+    forkJoin([continueCode, continueCodeFindIt, continueCodeFixIt]).subscribe(([continueCode, continueCodeFindIt, continueCodeFixIt]) => {
       backup.continueCode = continueCode
-      this.challengeService.continueCodeFindIt().subscribe((continueCodeFindIt) => {
-        backup.continueCodeFindIt = continueCodeFindIt
-        this.challengeService.continueCodeFixIt().subscribe((continueCodeFixIt) => {
-          backup.continueCodeFixIt = continueCodeFixIt
-          const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
-          saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
-        }, (err: Error) => {
-          console.log(`Failed to retrieve continueCodeFixIt for backup from server: ${err.message}. Using value from cookie as fallback.`)
-          backup.continueCodeFixIt = this.cookieService.get('continueCodeFixIt') ? this.cookieService.get('continueCodeFixIt') : undefined
-        })
-      }, (err: Error) => {
-        console.log(`Failed to retrieve continueCodeFindIt for backup from server: ${err.message}. Using value from cookie as fallback.`)
-        backup.continueCodeFindIt = this.cookieService.get('continueCodeFindIt') ? this.cookieService.get('continueCodeFindIt') : undefined
-      })
-    }, (err: Error) => {
-      console.log(`Failed to retrieve continueCode for backup from server: ${err.message}. Using value from cookie as fallback.`)
+      backup.continueCodeFindIt = continueCodeFindIt
+      backup.continueCodeFixIt = continueCodeFixIt
+      const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
+      saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
+    }, () => {
+      console.log('Failed to retrieve continue code(s) for backup from server. Using cookie values as fallback.')
       backup.continueCode = this.cookieService.get('continueCode') ? this.cookieService.get('continueCode') : undefined
+      backup.continueCodeFindIt = this.cookieService.get('continueCodeFindIt') ? this.cookieService.get('continueCodeFindIt') : undefined
+      backup.continueCodeFixIt = this.cookieService.get('continueCodeFixIt') ? this.cookieService.get('continueCodeFixIt') : undefined
       const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
       saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
     })

--- a/frontend/src/app/Services/local-backup.service.ts
+++ b/frontend/src/app/Services/local-backup.service.ts
@@ -35,12 +35,17 @@ export class LocalBackupService {
       cookieConsentStatus: this.cookieService.get('cookieconsent_status') ? this.cookieService.get('cookieconsent_status') : undefined
     }
     backup.language = this.cookieService.get('language') ? this.cookieService.get('language') : undefined
-    backup.continueCode = this.cookieService.get('continueCode') ? this.cookieService.get('continueCode') : undefined
-    backup.continueCodeFindIt = this.cookieService.get('continueCodeFindIt') ? this.cookieService.get('continueCodeFindIt') : undefined
-    backup.continueCodeFixIt = this.cookieService.get('continueCodeFixIt') ? this.cookieService.get('continueCodeFixIt') : undefined
-
-    const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
-    saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
+    this.challengeService.continueCode().subscribe((continueCode) => {
+      backup.continueCode = continueCode
+      this.challengeService.continueCodeFindIt().subscribe((continueCodeFindIt) => {
+        backup.continueCodeFindIt = continueCodeFindIt
+        this.challengeService.continueCodeFixIt().subscribe((continueCodeFixIt) => {
+          backup.continueCodeFixIt = continueCodeFixIt
+          const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
+          saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
+        }, (err) => console.log(err))
+      }, (err) => console.log(err))
+    }, (err) => console.log(err))
   }
 
   restore (backupFile: File) {

--- a/frontend/src/app/Services/local-backup.service.ts
+++ b/frontend/src/app/Services/local-backup.service.ts
@@ -43,16 +43,16 @@ export class LocalBackupService {
           backup.continueCodeFixIt = continueCodeFixIt
           const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
           saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)
-        }, (err) => {
-          console.log(err)
+        }, (err: Error) => {
+          console.log(`Failed to retrieve continueCodeFixIt for backup from server: ${err.message}. Using value from cookie as fallback.`)
           backup.continueCodeFixIt = this.cookieService.get('continueCodeFixIt') ? this.cookieService.get('continueCodeFixIt') : undefined
         })
-      }, (err) => {
-        console.log(err)
+      }, (err: Error) => {
+        console.log(`Failed to retrieve continueCodeFindIt for backup from server: ${err.message}. Using value from cookie as fallback.`)
         backup.continueCodeFindIt = this.cookieService.get('continueCodeFindIt') ? this.cookieService.get('continueCodeFindIt') : undefined
       })
-    }, (err) => {
-      console.log(err)
+    }, (err: Error) => {
+      console.log(`Failed to retrieve continueCode for backup from server: ${err.message}. Using value from cookie as fallback.`)
       backup.continueCode = this.cookieService.get('continueCode') ? this.cookieService.get('continueCode') : undefined
       const blob = new Blob([JSON.stringify(backup)], { type: 'text/plain;charset=utf-8' })
       saveAs(blob, `${fileName}-${new Date().toISOString().split('T')[0]}.json`)


### PR DESCRIPTION
### Description

On saving the progress using the 'Backup' option on score-board page, the continueCode, continueCodeFixIt and continueCodeFindIt are not saved to the JSON File in some scenarios.

### Minimal Reproduction

1. Start a new JuiceShop instance.
2. Solve a task for each of the category (challenge, FindIt, FixIt), the corresponding cookies and values are updated in the browser accordingly.
3. Reconnect to the same instance using a different browser, and check the cookies. The three continueCode(s) are not reflected anymore. 

Since the JSON file backup is configured to fetch the codes from browser cookies, the same won't be reflected in the JSON backup, until a new challenge is solved - which indirectly calculates the codes again and stores it as a cookie.
https://github.com/juice-shop/juice-shop/blob/9cfa32a4125f1498805728b93a4df4f33ffdcccf/routes/continueCode.ts#L14-L26 

### Motivation Scenario (Problem):
Following the above 3 steps, if the user saves the file while assuming all codes are saved by default, and later loses access to the instance, the progress cannot be restored on a new instance using the backup file, thereby making the backup option futile.

### Environment

<!-- run `node -v && npm -v` and paste output below -->
Node: v16.17.0
npm: v8.18.0

### Suggested Fix

As part of this PR, the continueCode(s) for challenge, FindIt and FixIt are fetched from the server itself by sending a GET request. File format generated follows the existing valid format available at [validLocalBackup.json](https://github.com/juice-shop/juice-shop/blob/9cfa32a4125f1498805728b93a4df4f33ffdcccf/test/files/validLocalBackup.json).

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
