### PR TITLE
update cheat score calculation

### DIFF
--- a/lib/accuracy.ts
+++ b/lib/accuracy.ts
@@ -33,11 +33,11 @@ exports.totalFixItAccuracy = () => {
   return totalAccuracy('fix it')
 }
 
-function getFindItAttempts (challengeKey: string) {
+export function getFindItAttempts (challengeKey: string) {
   return solves[challengeKey] ? solves[challengeKey].attempts['find it'] : 0
 }
 
-function getFixItAttempts (challengeKey: string) {
+export function getFixItAttempts (challengeKey: string) {
   return solves[challengeKey] ? solves[challengeKey].attempts['fix it'] : 0
 }
 

--- a/lib/accuracy.ts
+++ b/lib/accuracy.ts
@@ -33,8 +33,12 @@ exports.totalFixItAccuracy = () => {
   return totalAccuracy('fix it')
 }
 
-exports.getFindItAttempts = (challengeKey: string) => {
+function getFindItAttempts (challengeKey: string) {
   return solves[challengeKey] ? solves[challengeKey].attempts['find it'] : 0
+}
+
+function getFixItAttempts (challengeKey: string) {
+  return solves[challengeKey] ? solves[challengeKey].attempts['fix it'] : 0
 }
 
 function totalAccuracy (phase: Phase) {
@@ -66,4 +70,9 @@ function storeVerdict (challengeKey: string, phase: Phase, verdict: boolean) {
     solves[challengeKey][phase] = verdict
     solves[challengeKey].attempts[phase]++
   }
+}
+
+module.exports = {
+  getFindItAttempts,
+  getFixItAttempts
 }

--- a/lib/antiCheat.ts
+++ b/lib/antiCheat.ts
@@ -7,6 +7,7 @@ import config = require('config')
 import { retrieveCodeSnippet } from '../routes/vulnCodeSnippet'
 import { readFixes } from '../routes/vulnCodeFixes'
 import { Challenge } from '../data/types'
+import { getFindItAttempts, getFixItAttempts } from  './accuracy'
 const colors = require('colors/safe')
 const logger = require('./logger')
 const coupledChallenges = { // TODO prevent also near-identical challenges (e.g. all null byte file access or dom xss + bonus payload etc.) from counting as cheating

--- a/lib/antiCheat.ts
+++ b/lib/antiCheat.ts
@@ -7,7 +7,7 @@ import config = require('config')
 import { retrieveCodeSnippet } from '../routes/vulnCodeSnippet'
 import { readFixes } from '../routes/vulnCodeFixes'
 import { Challenge } from '../data/types'
-import { getFindItAttempts, getFixItAttempts } from  './accuracy'
+import { getFindItAttempts, getFixItAttempts } from './accuracy'
 const colors = require('colors/safe')
 const logger = require('./logger')
 const coupledChallenges = { // TODO prevent also near-identical challenges (e.g. all null byte file access or dom xss + bonus payload etc.) from counting as cheating


### PR DESCRIPTION
### Description

Currently cheat score only considers the time taken between solving the current and previous challenge. This PR intends to also consider the fact whether the challenge was solved in one attempt or not. If yes then it is checked whether or not the previous challenge was related to the current challenge

Resolved or fixed issue: `none`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
