### PR TITLE
Fixed Scroll Issue

### DIFF
--- a/frontend/src/app/score-board/score-board.component.html
+++ b/frontend/src/app/score-board/score-board.component.html
@@ -112,7 +112,7 @@
 
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef translate>LABEL_NAME</mat-header-cell>
-        <mat-cell *matCellDef="let challenge">
+        <mat-cell *matCellDef="let challenge" [id]="challenge.name">
           {{challenge.name}}
         </mat-cell>
       </ng-container>

--- a/frontend/src/app/score-board/score-board.component.spec.ts
+++ b/frontend/src/app/score-board/score-board.component.spec.ts
@@ -99,9 +99,14 @@ describe('ScoreBoardComponent', () => {
         { provide: DomSanitizer, useValue: sanitizer },
         { provide: LocalBackupService, useValue: localBackupService },
         { provide: SocketIoService, useValue: socketIoService },
-        { provide: ActivatedRoute, useValue: { snapshot: { 
+        {
+ provide: ActivatedRoute,
+useValue: {
+ snapshot: {
           queryParams: { challenge: 'value' }
-        }}}
+        }
+}
+}
       ]
     })
       .compileComponents()

--- a/frontend/src/app/score-board/score-board.component.spec.ts
+++ b/frontend/src/app/score-board/score-board.component.spec.ts
@@ -31,7 +31,7 @@ import { MatChipsModule } from '@angular/material/chips'
 import { MatDialogModule } from '@angular/material/dialog'
 import { CodeSnippetService } from '../Services/code-snippet.service'
 import { LocalBackupService } from '../Services/local-backup.service'
-
+import { ActivatedRoute, RouterModule } from '@angular/router'
 class MockSocket {
   on (str: string, callback: Function) {
     callback(str)
@@ -87,7 +87,8 @@ describe('ScoreBoardComponent', () => {
         MatIconModule,
         MatSnackBarModule,
         MatChipsModule,
-        MatDialogModule
+        MatDialogModule,
+        RouterModule.forRoot([])
       ],
       declarations: [ScoreBoardComponent, ChallengeStatusBadgeComponent],
       providers: [
@@ -97,7 +98,10 @@ describe('ScoreBoardComponent', () => {
         { provide: ConfigurationService, useValue: configurationService },
         { provide: DomSanitizer, useValue: sanitizer },
         { provide: LocalBackupService, useValue: localBackupService },
-        { provide: SocketIoService, useValue: socketIoService }
+        { provide: SocketIoService, useValue: socketIoService },
+        { provide: ActivatedRoute, useValue: { snapshot: { 
+          queryParams: { challenge: 'value' }
+        }}}
       ]
     })
       .compileComponents()

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -7,9 +7,10 @@ import { MatTableDataSource } from '@angular/material/table'
 import { DomSanitizer } from '@angular/platform-browser'
 import { ChallengeService } from '../Services/challenge.service'
 import { ConfigurationService } from '../Services/configuration.service'
-import { Component, NgZone, OnInit } from '@angular/core'
+import { AfterViewInit, Component, NgZone, OnInit } from '@angular/core'
 import { SocketIoService } from '../Services/socket-io.service'
 import { NgxSpinnerService } from 'ngx-spinner'
+import { ActivatedRoute } from '@angular/router'
 
 import { dom, library } from '@fortawesome/fontawesome-svg-core'
 import { faStar, faTrophy, faPollH } from '@fortawesome/free-solid-svg-icons'
@@ -29,8 +30,8 @@ dom.watch()
   selector: 'app-score-board',
   templateUrl: './score-board.component.html',
   styleUrls: ['./score-board.component.scss']
-  })
-export class ScoreBoardComponent implements OnInit {
+})
+export class ScoreBoardComponent implements OnInit, AfterViewInit {
   public availableDifficulties: number[] = [1, 2, 3, 4, 5, 6]
   public displayedDifficulties: number[] = [1]
   public availableChallengeCategories: string[] = []
@@ -64,7 +65,14 @@ export class ScoreBoardComponent implements OnInit {
   public localBackupEnabled: boolean = true
   public showFeedbackButtons: boolean = true
 
-  constructor (private readonly configurationService: ConfigurationService, private readonly challengeService: ChallengeService, private readonly codeSnippetService: CodeSnippetService, private readonly sanitizer: DomSanitizer, private readonly ngZone: NgZone, private readonly io: SocketIoService, private readonly spinner: NgxSpinnerService, private readonly translate: TranslateService, private readonly localBackupService: LocalBackupService, private readonly dialog: MatDialog) {
+  constructor (private readonly configurationService: ConfigurationService, private readonly challengeService: ChallengeService, private readonly codeSnippetService: CodeSnippetService, private readonly sanitizer: DomSanitizer, private readonly ngZone: NgZone, private readonly io: SocketIoService, private readonly spinner: NgxSpinnerService, private readonly translate: TranslateService, private readonly localBackupService: LocalBackupService, private readonly dialog: MatDialog, private readonly route: ActivatedRoute) {
+  }
+
+  public ngAfterViewInit () {
+    const challenge: string = this.route.snapshot.queryParams.challenge
+    if (challenge) {
+      this.scrollToChallenge(challenge)
+    }
   }
 
   ngOnInit () {
@@ -127,7 +135,7 @@ export class ScoreBoardComponent implements OnInit {
           }
 
           this.spinner.hide()
-        })
+          })
       }, (err) => {
         this.challenges = []
         console.log(err)
@@ -150,6 +158,16 @@ export class ScoreBoardComponent implements OnInit {
         }
       })
     })
+  }
+
+  scrollToChallenge (challengeName: string) {
+      const el = document.getElementById(challengeName)
+      if (!el) {
+        console.log(`Challenge ${challengeName} is not visible!`)
+      } else {
+        console.log(`Scrolling to challenge: ${challengeName}`)
+        el.scrollIntoView({ behavior: 'smooth' })
+    }
   }
 
   augmentHintText (challenge: Challenge) {

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -76,7 +76,7 @@ export class ScoreBoardComponent implements OnInit, AfterViewInit {
       if (target) {
         this.scrollToChallenge(challenge)
       } else {
-        const observer = new MutationObserver( mutationList => {
+        const observer = new MutationObserver(mutationList => {
           for (const mutation of mutationList) {
             if (mutation.type === 'childList') {
               const target = document.getElementById(challenge + '.codingChallengeButton')

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -79,7 +79,7 @@ export class ScoreBoardComponent implements OnInit, AfterViewInit {
         const observer = new MutationObserver(mutationList => {
           for (const mutation of mutationList) {
             if (mutation.type === 'childList') {
-              const target = document.getElementById(challenge + '.codingChallengeButton')
+              const target = document.getElementById(challenge)
               if (target) {
                 this.scrollToChallenge(challenge)
                 observer.disconnect()
@@ -178,7 +178,7 @@ export class ScoreBoardComponent implements OnInit, AfterViewInit {
   }
 
   scrollToChallenge (challengeName: string) {
-      const el = document.getElementById(challengeName + '.codingChallengeButton')
+      const el = document.getElementById(challengeName)
       if (!el) {
         console.log(`Challenge ${challengeName} is not visible!`)
       } else {

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -70,20 +70,20 @@ export class ScoreBoardComponent implements OnInit, AfterViewInit {
 
   public ngAfterViewInit () {
     const challenge: string = this.route.snapshot.queryParams.challenge
-    
+
     if (challenge) {
       const target = document.getElementById(challenge)
       if (target) {
         this.scrollToChallenge(challenge)
       } else {
-        console.log("tettssss")
-        const observer = new MutationObserver( mutationList => {
+        console.log('tettssss')
+        const observer = new MutationObserver(mutationList => {
           for (const mutation of mutationList) {
             if (mutation.type === 'childList') {
-              const target = document.getElementById(challenge + '.codingChallengeButton');
-              if (target){
+              const target = document.getElementById(challenge + '.codingChallengeButton')
+              if (target) {
                 this.scrollToChallenge(challenge)
-                observer.disconnect();
+                observer.disconnect()
               }
             }
           }

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -70,8 +70,26 @@ export class ScoreBoardComponent implements OnInit, AfterViewInit {
 
   public ngAfterViewInit () {
     const challenge: string = this.route.snapshot.queryParams.challenge
+    
     if (challenge) {
-      this.scrollToChallenge(challenge)
+      const target = document.getElementById(challenge)
+      if (target) {
+        this.scrollToChallenge(challenge)
+      } else {
+        console.log("tettssss")
+        const observer = new MutationObserver( mutationList => {
+          for (const mutation of mutationList) {
+            if (mutation.type === 'childList') {
+              const target = document.getElementById(challenge + '.codingChallengeButton');
+              if (target){
+                this.scrollToChallenge(challenge)
+                observer.disconnect();
+              }
+            }
+          }
+        })
+        observer.observe(document.body, { childList: true, subtree: true })
+      }
     }
   }
 
@@ -161,7 +179,7 @@ export class ScoreBoardComponent implements OnInit, AfterViewInit {
   }
 
   scrollToChallenge (challengeName: string) {
-      const el = document.getElementById(challengeName)
+      const el = document.getElementById(challengeName + '.codingChallengeButton')
       if (!el) {
         console.log(`Challenge ${challengeName} is not visible!`)
       } else {

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -76,8 +76,7 @@ export class ScoreBoardComponent implements OnInit, AfterViewInit {
       if (target) {
         this.scrollToChallenge(challenge)
       } else {
-        console.log('tettssss')
-        const observer = new MutationObserver(mutationList => {
+        const observer = new MutationObserver( mutationList => {
           for (const mutation of mutationList) {
             if (mutation.type === 'childList') {
               const target = document.getElementById(challenge + '.codingChallengeButton')


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - see https://pwning.owasp-juice.shop/part3/contribution.html#handling-of-spam-prs for more information 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
I fixed the scrolling issue where ngAfterViewInit() fires long before the DOM is rendered. You might be aware of that but in the current DOM, there is only the coding challenge button that has an id reference to the challenge name. So, currently, it's only possible to scroll to challenges that have been already solved. ( I guess if Juice Shop has to become a reference into OpenCRE it means that we should be able to scroll to any challenges, no matter if they are solved or not, right?!)

Resolved or fixed issue: #1970  https://github.com/juice-shop/juice-shop/tree/feature/%231970/scroll-to-challenge

### Current behavior

https://user-images.githubusercontent.com/82499435/230792448-13a1ac69-dc34-4f16-b6ea-b72393ea7cff.mp4


### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
