### PR TITLE
Improve Performance (drastically) by Reducing Load from FontAwesome Icons 

### DIFF
--- a/frontend/src/app/about/about.component.ts
+++ b/frontend/src/app/about/about.component.ts
@@ -8,13 +8,12 @@ import { DomSanitizer } from '@angular/platform-browser'
 import { ConfigurationService } from '../Services/configuration.service'
 import { FeedbackService } from '../Services/feedback.service'
 import { IImage } from 'ng-simple-slideshow'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faFacebook, faReddit, faSlack, faTwitter } from '@fortawesome/free-brands-svg-icons'
 import { faNewspaper, faStar } from '@fortawesome/free-regular-svg-icons'
 import { faStar as fasStar, faPalette } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faFacebook, faTwitter, faSlack, faReddit, faNewspaper, faStar, fasStar, faPalette)
-dom.watch()
 
 @Component({
   selector: 'app-about',

--- a/frontend/src/app/accounting/accounting.component.ts
+++ b/frontend/src/app/accounting/accounting.component.ts
@@ -9,13 +9,12 @@ import { MatPaginator } from '@angular/material/paginator'
 import { Subscription } from 'rxjs'
 import { MatTableDataSource } from '@angular/material/table'
 import { QuantityService } from '../Services/quantity.service'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import { OrderHistoryService } from '../Services/order-history.service'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faCheck)
-dom.watch()
 
 interface Order {
   id: string

--- a/frontend/src/app/address/address.component.ts
+++ b/frontend/src/app/address/address.component.ts
@@ -6,7 +6,7 @@
 import { Component, EventEmitter, Input, OnInit, Output, NgZone } from '@angular/core'
 import { AddressService } from '../Services/address.service'
 import { MatTableDataSource } from '@angular/material/table'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faEdit, faTrashAlt } from '@fortawesome/free-regular-svg-icons/'
 import { TranslateService } from '@ngx-translate/core'
 import { Router } from '@angular/router'
@@ -14,7 +14,6 @@ import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { SelectionModel } from '@angular/cdk/collections'
 
 library.add(faEdit, faTrashAlt)
-dom.watch()
 
 @Component({
   selector: 'app-address',

--- a/frontend/src/app/administration/administration.component.ts
+++ b/frontend/src/app/administration/administration.component.ts
@@ -11,12 +11,11 @@ import { MatTableDataSource } from '@angular/material/table'
 import { UserService } from '../Services/user.service'
 import { Component, OnInit, ViewChild } from '@angular/core'
 import { DomSanitizer } from '@angular/platform-browser'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faArchive, faEye, faHome, faTrashAlt, faUser } from '@fortawesome/free-solid-svg-icons'
 import { MatPaginator } from '@angular/material/paginator'
 
 library.add(faUser, faEye, faHome, faArchive, faTrashAlt)
-dom.watch()
 
 @Component({
   selector: 'app-administration',

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -6,6 +6,9 @@
 import { Component, Inject } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { DOCUMENT } from '@angular/common'
+import { dom } from '@fortawesome/fontawesome-svg-core'
+
+dom.watch()
 
 @Component({
   selector: 'app-root',

--- a/frontend/src/app/basket/basket.component.ts
+++ b/frontend/src/app/basket/basket.component.ts
@@ -4,12 +4,11 @@
  */
 
 import { Component, NgZone } from '@angular/core'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCartArrowDown } from '@fortawesome/free-solid-svg-icons'
 import { Router } from '@angular/router'
 
 library.add(faCartArrowDown)
-dom.watch()
 
 @Component({
   selector: 'app-basket',

--- a/frontend/src/app/challenge-status-badge/challenge-status-badge.component.ts
+++ b/frontend/src/app/challenge-status-badge/challenge-status-badge.component.ts
@@ -6,13 +6,12 @@
 import { Component, Input } from '@angular/core'
 import { WindowRefService } from '../Services/window-ref.service'
 import { ChallengeService } from '../Services/challenge.service'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faWindows } from '@fortawesome/free-brands-svg-icons'
 
 import { Challenge } from '../Models/challenge.model'
 
 library.add(faWindows)
-dom.watch()
 
 @Component({
   selector: 'app-challenge-status-badge',

--- a/frontend/src/app/change-password/change-password.component.ts
+++ b/frontend/src/app/change-password/change-password.component.ts
@@ -6,14 +6,13 @@
 import { AbstractControl, UntypedFormControl, Validators } from '@angular/forms'
 import { UserService } from '../Services/user.service'
 import { Component } from '@angular/core'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faSave } from '@fortawesome/free-solid-svg-icons'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
 import { FormSubmitService } from '../Services/form-submit.service'
 import { TranslateService } from '@ngx-translate/core'
 
 library.add(faSave, faEdit)
-dom.watch()
 
 @Component({
   selector: 'app-change-password',

--- a/frontend/src/app/chatbot/chatbot.component.ts
+++ b/frontend/src/app/chatbot/chatbot.component.ts
@@ -7,14 +7,13 @@ import { ChatbotService } from '../Services/chatbot.service'
 import { UserService } from '../Services/user.service'
 import { Component, OnInit } from '@angular/core'
 import { UntypedFormControl } from '@angular/forms'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faBomb } from '@fortawesome/free-solid-svg-icons'
 import { FormSubmitService } from '../Services/form-submit.service'
 import { TranslateService } from '@ngx-translate/core'
 import { CookieService } from 'ngx-cookie'
 
 library.add(faBomb)
-dom.watch()
 
 enum MessageSources {
   user = 'user',

--- a/frontend/src/app/complaint/complaint.component.ts
+++ b/frontend/src/app/complaint/complaint.component.ts
@@ -9,13 +9,12 @@ import { UserService } from '../Services/user.service'
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core'
 import { UntypedFormControl, Validators } from '@angular/forms'
 import { FileUploader } from 'ng2-file-upload'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faBomb } from '@fortawesome/free-solid-svg-icons'
 import { FormSubmitService } from '../Services/form-submit.service'
 import { TranslateService } from '@ngx-translate/core'
 
 library.add(faBomb)
-dom.watch()
 
 @Component({
   selector: 'app-complaint',

--- a/frontend/src/app/contact/contact.component.ts
+++ b/frontend/src/app/contact/contact.component.ts
@@ -8,14 +8,13 @@ import { CaptchaService } from '../Services/captcha.service'
 import { UserService } from '../Services/user.service'
 import { UntypedFormControl, Validators } from '@angular/forms'
 import { Component, OnInit } from '@angular/core'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faPaperPlane, faStar } from '@fortawesome/free-solid-svg-icons'
 import { FormSubmitService } from '../Services/form-submit.service'
 import { TranslateService } from '@ngx-translate/core'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faStar, faPaperPlane)
-dom.watch()
 
 @Component({
   selector: 'app-contact',

--- a/frontend/src/app/delivery-method/delivery-method.component.ts
+++ b/frontend/src/app/delivery-method/delivery-method.component.ts
@@ -10,12 +10,11 @@ import { MatTableDataSource } from '@angular/material/table'
 import { Router } from '@angular/router'
 import { Location } from '@angular/common'
 import { DeliveryMethod } from '../Models/deliveryMethod.model'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faRocket, faShippingFast, faTruck } from '@fortawesome/free-solid-svg-icons'
 import { SelectionModel } from '@angular/cdk/collections'
 
 library.add(faRocket, faShippingFast, faTruck)
-dom.watch()
 
 @Component({
   selector: 'app-delivery-method',

--- a/frontend/src/app/error-page/error-page.component.ts
+++ b/frontend/src/app/error-page/error-page.component.ts
@@ -6,11 +6,10 @@
 import { TranslateService } from '@ngx-translate/core'
 import { Component, OnInit } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faUserSlash, faHandPaper } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faUserSlash, faHandPaper)
-dom.watch()
 
 @Component({
   selector: 'app-error-page',

--- a/frontend/src/app/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/forgot-password/forgot-password.component.ts
@@ -7,14 +7,13 @@ import { UserService } from '../Services/user.service'
 import { SecurityQuestionService } from '../Services/security-question.service'
 import { AbstractControl, UntypedFormControl, Validators } from '@angular/forms'
 import { Component } from '@angular/core'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faSave } from '@fortawesome/free-solid-svg-icons'
 import { faEdit } from '@fortawesome/free-regular-svg-icons'
 import { SecurityQuestion } from '../Models/securityQuestion.model'
 import { TranslateService } from '@ngx-translate/core'
 
 library.add(faSave, faEdit)
-dom.watch()
 
 @Component({
   selector: 'app-forgot-password',

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -8,7 +8,7 @@ import { WindowRefService } from '../Services/window-ref.service'
 import { Router } from '@angular/router'
 import { Component, NgZone, OnInit } from '@angular/core'
 import { UntypedFormControl, Validators } from '@angular/forms'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { UserService } from '../Services/user.service'
 import { faEye, faEyeSlash, faKey } from '@fortawesome/free-solid-svg-icons'
 import { faGoogle } from '@fortawesome/free-brands-svg-icons'
@@ -17,7 +17,6 @@ import { ConfigurationService } from '../Services/configuration.service'
 import { BasketService } from '../Services/basket.service'
 
 library.add(faKey, faEye, faEyeSlash, faGoogle)
-dom.watch()
 
 const oauthProviderUrl = 'https://accounts.google.com/o/oauth2/v2/auth'
 

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -39,12 +39,11 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { faComments } from '@fortawesome/free-regular-svg-icons'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { LoginGuard } from '../app.guard'
 import { roles } from '../roles'
 
 library.add(faLanguage, faSearch, faSignInAlt, faSignOutAlt, faComment, faBomb, faTrophy, faInfoCircle, faShoppingCart, faUserSecret, faRecycle, faMapMarker, faUserCircle, faGithub, faComments, faThermometerEmpty, faThermometerQuarter, faThermometerHalf, faThermometerThreeQuarters, faThermometerFull)
-dom.watch()
 
 @Component({
   selector: 'app-navbar',

--- a/frontend/src/app/order-completion/order-completion.component.ts
+++ b/frontend/src/app/order-completion/order-completion.component.ts
@@ -10,11 +10,10 @@ import { MatTableDataSource } from '@angular/material/table'
 import { BasketService } from '../Services/basket.service'
 import { AddressService } from '../Services/address.service'
 import { ConfigurationService } from '../Services/configuration.service'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faTwitter } from '@fortawesome/free-brands-svg-icons'
 
 library.add(faTwitter)
-dom.watch()
 
 @Component({
   selector: 'app-order-completion',

--- a/frontend/src/app/payment-method/payment-method.component.ts
+++ b/frontend/src/app/payment-method/payment-method.component.ts
@@ -7,14 +7,13 @@ import { UntypedFormControl, Validators } from '@angular/forms'
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
 import { PaymentService } from '../Services/payment.service'
 import { MatTableDataSource } from '@angular/material/table'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons/'
 import { TranslateService } from '@ngx-translate/core'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faPaperPlane, faTrashAlt)
-dom.watch()
 
 @Component({
   selector: 'app-payment-method',

--- a/frontend/src/app/payment/payment.component.ts
+++ b/frontend/src/app/payment/payment.component.ts
@@ -8,7 +8,7 @@ import { Component, NgZone, OnInit } from '@angular/core'
 import { ConfigurationService } from '../Services/configuration.service'
 import { BasketService } from '../Services/basket.service'
 import { TranslateService } from '@ngx-translate/core'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   faCartArrowDown,
   faCoffee,
@@ -33,7 +33,6 @@ import { Location } from '@angular/common'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faCartArrowDown, faGift, faHeart, faLeanpub, faThumbsUp, faTshirt, faStickyNote, faHandHoldingUsd, faCoffee, faTimes, faStripe, faPalette)
-dom.watch()
 
 @Component({
   selector: 'app-payment',

--- a/frontend/src/app/photo-wall/photo-wall.component.ts
+++ b/frontend/src/app/photo-wall/photo-wall.component.ts
@@ -9,12 +9,11 @@ import { mimeType } from './mime-type.validator'
 import { PhotoWallService } from '../Services/photo-wall.service'
 import { IImage } from 'ng-simple-slideshow'
 import { ConfigurationService } from '../Services/configuration.service'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faTwitter } from '@fortawesome/free-brands-svg-icons'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faTwitter)
-dom.watch()
 
 @Component({
   selector: 'app-photo-wall',

--- a/frontend/src/app/product-details/product-details.component.ts
+++ b/frontend/src/app/product-details/product-details.component.ts
@@ -8,7 +8,7 @@ import { UserService } from '../Services/user.service'
 import { ProductReviewService } from '../Services/product-review.service'
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core'
 import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faArrowCircleLeft, faCrown, faPaperPlane, faThumbsUp, faUserEdit } from '@fortawesome/free-solid-svg-icons'
 import { UntypedFormControl, Validators } from '@angular/forms'
 import { MatSnackBar } from '@angular/material/snack-bar'
@@ -17,7 +17,6 @@ import { Review } from '../Models/review.model'
 import { Product } from '../Models/product.model'
 
 library.add(faPaperPlane, faArrowCircleLeft, faUserEdit, faThumbsUp, faCrown)
-dom.watch()
 
 @Component({
   selector: 'app-product-details',

--- a/frontend/src/app/product-review-edit/product-review-edit.component.ts
+++ b/frontend/src/app/product-review-edit/product-review-edit.component.ts
@@ -9,13 +9,12 @@ import { UntypedFormControl, Validators } from '@angular/forms'
 import { ProductReviewService } from '../Services/product-review.service'
 import { MatSnackBar } from '@angular/material/snack-bar'
 
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faArrowCircleLeft, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 import { Review } from '../Models/review.model'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faPaperPlane, faArrowCircleLeft)
-dom.watch()
 
 @Component({
   selector: 'app-product-review-edit',

--- a/frontend/src/app/purchase-basket/purchase-basket.component.ts
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.ts
@@ -6,14 +6,13 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
 import { BasketService } from '../Services/basket.service'
 import { UserService } from '../Services/user.service'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons/'
 import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons'
 import { DeluxeGuard } from '../app.guard'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faTrashAlt, faMinusSquare, faPlusSquare)
-dom.watch()
 
 @Component({
   selector: 'app-purchase-basket',

--- a/frontend/src/app/qr-code/qr-code.component.ts
+++ b/frontend/src/app/qr-code/qr-code.component.ts
@@ -5,11 +5,10 @@
 
 import { MAT_DIALOG_DATA } from '@angular/material/dialog'
 import { Component, Inject, OnInit } from '@angular/core'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faArrowCircleLeft } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faArrowCircleLeft)
-dom.watch()
 
 @Component({
   selector: 'app-qr-code',

--- a/frontend/src/app/recycle/recycle.component.ts
+++ b/frontend/src/app/recycle/recycle.component.ts
@@ -8,7 +8,7 @@ import { UserService } from '../Services/user.service'
 import { RecycleService } from '../Services/recycle.service'
 import { Component, OnInit, ViewChild } from '@angular/core'
 import { UntypedFormControl, Validators } from '@angular/forms'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 import { FormSubmitService } from '../Services/form-submit.service'
 import { AddressComponent } from '../address/address.component'
@@ -16,7 +16,6 @@ import { TranslateService } from '@ngx-translate/core'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faPaperPlane)
-dom.watch()
 
 @Component({
   selector: 'app-recycle',

--- a/frontend/src/app/register/register.component.ts
+++ b/frontend/src/app/register/register.component.ts
@@ -9,7 +9,7 @@ import { AbstractControl, UntypedFormControl, Validators } from '@angular/forms'
 import { Component, NgZone, OnInit } from '@angular/core'
 import { SecurityQuestionService } from '../Services/security-question.service'
 import { Router } from '@angular/router'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { MatSnackBar } from '@angular/material/snack-bar'
 
 import { faExclamationCircle, faUserPlus } from '@fortawesome/free-solid-svg-icons'
@@ -19,7 +19,6 @@ import { TranslateService } from '@ngx-translate/core'
 import { SecurityQuestion } from '../Models/securityQuestion.model'
 
 library.add(faUserPlus, faExclamationCircle)
-dom.watch()
 
 @Component({
   selector: 'app-register',

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -12,7 +12,7 @@ import { SocketIoService } from '../Services/socket-io.service'
 import { NgxSpinnerService } from 'ngx-spinner'
 import { ActivatedRoute } from '@angular/router'
 
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faStar, faTrophy, faPollH } from '@fortawesome/free-solid-svg-icons'
 import { faGem } from '@fortawesome/free-regular-svg-icons'
 import { faBtc, faGithub, faGitter } from '@fortawesome/free-brands-svg-icons'
@@ -24,7 +24,6 @@ import { CodeSnippetComponent } from '../code-snippet/code-snippet.component'
 import { CodeSnippetService } from '../Services/code-snippet.service'
 
 library.add(faStar, faGem, faGitter, faGithub, faBtc, faTrophy, faPollH)
-dom.watch()
 
 @Component({
   selector: 'app-score-board',

--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -17,14 +17,13 @@ import { TranslateService } from '@ngx-translate/core'
 import { SocketIoService } from '../Services/socket-io.service'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCartPlus, faEye } from '@fortawesome/free-solid-svg-icons'
 import { Product } from '../Models/product.model'
 import { QuantityService } from '../Services/quantity.service'
 import { DeluxeGuard } from '../app.guard'
 
 library.add(faEye, faCartPlus)
-dom.watch()
 
 interface TableEntry {
   name: string

--- a/frontend/src/app/token-sale/token-sale.component.ts
+++ b/frontend/src/app/token-sale/token-sale.component.ts
@@ -5,13 +5,12 @@
 
 import { ConfigurationService } from '../Services/configuration.service'
 import { Component, OnInit } from '@angular/core'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faBitcoin } from '@fortawesome/free-brands-svg-icons'
 import { faCommentAlt, faComments, faGraduationCap, faUniversity } from '@fortawesome/free-solid-svg-icons'
 import { faCommentAlt as farCommentAlt, faComments as farComments } from '@fortawesome/free-regular-svg-icons'
 
 library.add(faBitcoin, faUniversity, faGraduationCap, faCommentAlt, faComments, farCommentAlt, farComments)
-dom.watch()
 
 @Component({
   selector: 'app-token-sale',

--- a/frontend/src/app/track-result/track-result.component.ts
+++ b/frontend/src/app/track-result/track-result.component.ts
@@ -8,11 +8,10 @@ import { MatTableDataSource } from '@angular/material/table'
 import { Component, OnInit } from '@angular/core'
 import { TrackOrderService } from '../Services/track-order.service'
 import { DomSanitizer } from '@angular/platform-browser'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faHome, faSync, faTruck, faTruckLoading, faWarehouse } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faWarehouse, faSync, faTruckLoading, faTruck, faHome)
-dom.watch()
 
 export enum Status {
   New,

--- a/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.ts
+++ b/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.ts
@@ -9,11 +9,10 @@ import { TwoFactorAuthService } from '../Services/two-factor-auth-service'
 import { CookieService } from 'ngx-cookie'
 import { UserService } from '../Services/user.service'
 import { Router } from '@angular/router'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faUnlockAlt } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faUnlockAlt)
-dom.watch()
 
 interface TokenEnterFormFields {
   token: string

--- a/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
+++ b/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
@@ -9,7 +9,7 @@ import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms
 import { TwoFactorAuthService } from '../Services/two-factor-auth-service'
 import { ConfigurationService } from '../Services/configuration.service'
 
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faSave, faUnlockAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { forkJoin } from 'rxjs'
@@ -18,7 +18,6 @@ import { MatSnackBar } from '@angular/material/snack-bar'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 library.add(faUnlockAlt, faSave)
-dom.watch()
 
 @Component({
   selector: 'app-two-factor-auth',

--- a/frontend/src/app/user-details/user-details.component.ts
+++ b/frontend/src/app/user-details/user-details.component.ts
@@ -6,11 +6,10 @@
 import { UserService } from '../Services/user.service'
 import { Component, Inject, OnInit } from '@angular/core'
 import { MAT_DIALOG_DATA } from '@angular/material/dialog'
-import { dom, library } from '@fortawesome/fontawesome-svg-core'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faArrowCircleLeft } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faArrowCircleLeft)
-dom.watch()
 
 @Component({
   selector: 'app-user-details',


### PR DESCRIPTION
### Description

Previously a lot of component registered this watch. 
Each of them created a MutationObserver running on dom modifications. 
This slows down the page way more then it needs to as the action this performs is global and should not be triggered more than once.

On my machine this change reduces the time it takes to **all** challenges on scoreboard from hidden to visibile from ~2.2s to ~0.4s. Other pages also feel more response but that might you be me imagining things. 📈 stonks!

Here's a before and after flame graph of me unhiding all challenges on the score-board:

<img width="1992" alt="perf-fix-before" src="https://github.com/juice-shop/juice-shop/assets/13718901/d7520508-7a8c-4fba-b8ea-0a46c0c9fd64">

<img width="1992" alt="perf-fix-after" src="https://github.com/juice-shop/juice-shop/assets/13718901/60faa1da-aada-4895-8ebb-7fb689aa6900">


### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
