### PR TITLE
Preview ScoreBoard Fixes & Improvements

### DIFF
--- a/frontend/src/app/score-board-preview/components/challenge-card/challenge-card.component.html
+++ b/frontend/src/app/score-board-preview/components/challenge-card/challenge-card.component.html
@@ -39,11 +39,12 @@
     <!-- cheat cheat link-->
     <a
       class="badge not-completable"
-      *ngIf="challenge.mitigationUrl"
+      *ngIf="challenge.mitigationUrl && challenge.solved"
       [href]="challenge.mitigationUrl"
       target="_blank"
       rel="noopener noreferrer"
       [matTooltip]="'INFO_VULNERABILITY_MITIGATION_LINK' | translate"
+      aria-label="Vulnerability mitigation link"
     >
       <mat-icon>policy_outline</mat-icon>
     </a>

--- a/frontend/src/app/score-board-preview/components/challenge-card/challenge-card.component.spec.ts
+++ b/frontend/src/app/score-board-preview/components/challenge-card/challenge-card.component.spec.ts
@@ -41,4 +41,20 @@ describe('ChallengeCard', () => {
   it('should create', () => {
     expect(component).toBeTruthy()
   })
+
+  it('should not show a mitigation link when challenge has it but isnt solved', () => {
+    component.challenge.solved = false
+    component.challenge.mitigationUrl = 'https://owasp.example.com',
+    fixture.detectChanges()
+    expect(fixture.nativeElement.querySelector('[aria-label="Vulnerability mitigation link"]'))
+      .toBeFalsy()
+  })
+
+  it('should show a mitigation link when challenge has it but isnt solved', () => {
+    component.challenge.solved = true
+    component.challenge.mitigationUrl = 'https://owasp.example.com',
+    fixture.detectChanges()
+    expect(fixture.nativeElement.querySelector('[aria-label="Vulnerability mitigation link"]'))
+      .toBeTruthy()
+  })
 })

--- a/frontend/src/app/score-board-preview/components/challenge-card/challenge-card.component.spec.ts
+++ b/frontend/src/app/score-board-preview/components/challenge-card/challenge-card.component.spec.ts
@@ -44,7 +44,7 @@ describe('ChallengeCard', () => {
 
   it('should not show a mitigation link when challenge has it but isnt solved', () => {
     component.challenge.solved = false
-    component.challenge.mitigationUrl = 'https://owasp.example.com',
+    component.challenge.mitigationUrl = 'https://owasp.example.com'
     fixture.detectChanges()
     expect(fixture.nativeElement.querySelector('[aria-label="Vulnerability mitigation link"]'))
       .toBeFalsy()
@@ -52,7 +52,7 @@ describe('ChallengeCard', () => {
 
   it('should show a mitigation link when challenge has it but isnt solved', () => {
     component.challenge.solved = true
-    component.challenge.mitigationUrl = 'https://owasp.example.com',
+    component.challenge.mitigationUrl = 'https://owasp.example.com'
     fixture.detectChanges()
     expect(fixture.nativeElement.querySelector('[aria-label="Vulnerability mitigation link"]'))
       .toBeTruthy()

--- a/frontend/src/app/score-board-preview/components/warning-card/warning-card.component.html
+++ b/frontend/src/app/score-board-preview/components/warning-card/warning-card.component.html
@@ -1,10 +1,14 @@
 <div
   class="warning-container"
 >
-  <ng-content select="[warning-icon]" />
-  <span class="warning-text">
-    <ng-content select="[warning-text]" />
-  </span>
-  <ng-content select="[warning-action]" />
+  <div class="warning-text-icon-group">
+    <ng-content select="[warning-icon]"></ng-content>
+    <span class="warning-text">
+      <ng-content select="[warning-text]"></ng-content>
+    </span>
+  </div>
+  <div class="warning-action">
+    <ng-content select="[warning-action]"></ng-content>
+  </div>
 </div>
 

--- a/frontend/src/app/score-board-preview/components/warning-card/warning-card.component.scss
+++ b/frontend/src/app/score-board-preview/components/warning-card/warning-card.component.scss
@@ -3,7 +3,11 @@
   background-color: var(--theme-background-dark);
   border-radius: 4px;
   display: grid;
-  grid-template-columns: min-content auto min-content;
+  grid-template-columns: auto min-content;
+  @media (max-width: 600px) {
+    grid-template-columns: auto;
+    row-gap: 12px;
+  }
   margin-top: 16px;
   padding: 12px;
 }
@@ -11,4 +15,10 @@
 .warning-text {
   margin-left: 12px;
   padding-right: 8px;
+}
+
+.warning-text-icon-group {
+  display: grid;
+  grid-template-columns: min-content auto;
+  align-items: center;
 }

--- a/frontend/src/app/score-board-preview/components/warning-card/warning-card.component.scss
+++ b/frontend/src/app/score-board-preview/components/warning-card/warning-card.component.scss
@@ -4,12 +4,12 @@
   border-radius: 4px;
   display: grid;
   grid-template-columns: auto min-content;
+  margin-top: 16px;
+  padding: 12px;
   @media (max-width: 600px) {
     grid-template-columns: auto;
     row-gap: 12px;
   }
-  margin-top: 16px;
-  padding: 12px;
 }
 
 .warning-text {
@@ -18,7 +18,7 @@
 }
 
 .warning-text-icon-group {
+  align-items: center;
   display: grid;
   grid-template-columns: min-content auto;
-  align-items: center;
 }

--- a/frontend/src/app/score-board-preview/score-board-preview.component.html
+++ b/frontend/src/app/score-board-preview/score-board-preview.component.html
@@ -14,33 +14,41 @@
 
 <preview-feature-notice [applicationConfig]="applicationConfiguration"></preview-feature-notice>
 
-<challenges-unavailable-warning
-  [challenges]="allChallenges"
-  [filterSetting]="filterSetting"
-  (filterSettingChange)="onFilterSettingUpdate($event)"
-></challenges-unavailable-warning>
-
-<tutorial-mode-warning 
-  [allChallenges]="allChallenges" 
-  [applicationConfig]="applicationConfiguration"
-></tutorial-mode-warning>
-
-<div class="challenges" *ngIf="filteredChallenges.length > 0; else emptyChallenges">
-  <challenge-card
-    *ngFor="let challenge of filteredChallenges; trackBy:getChallengeKey"
-    [challenge]="challenge"
-    [applicationConfiguration]="applicationConfiguration"
-    [openCodingChallengeDialog]="openCodingChallengeDialog.bind(this)"
-    [repeatChallengeNotification]="repeatChallengeNotification.bind(this)"
-    [ngClass]="{ solved: challenge.solved, unsolved: !challenge.solved, disabled: challenge.disabledEnv !== null }"
-  />
+<div *ngIf="isInitialized === false" class="loading-spinner-wrapper">
+  <mat-spinner></mat-spinner>
 </div>
 
-<ng-template #emptyChallenges>
-  <!-- only showing when there are more than 1 challenge in total. not completely loaded otherwise -->
-  <div class="empty-challenges" *ngIf="allChallenges.length > 0">
-    <p>{{ 'NO_CHALLENGES_FOUND' | translate }}</p>
-  </div>
-</ng-template>
+<ng-container *ngIf="isInitialized === true">
+  <challenges-unavailable-warning
+    [challenges]="allChallenges"
+    [filterSetting]="filterSetting"
+    (filterSettingChange)="onFilterSettingUpdate($event)"
+  ></challenges-unavailable-warning>
 
-<img src="assets/public/images/padding/1px.png"/>
+  <tutorial-mode-warning 
+    [allChallenges]="allChallenges" 
+    [applicationConfig]="applicationConfiguration"
+  ></tutorial-mode-warning>
+
+  <div class="challenges" *ngIf="filteredChallenges.length > 0; else emptyChallenges">
+    <challenge-card
+      *ngFor="let challenge of filteredChallenges; trackBy:getChallengeKey"
+      [challenge]="challenge"
+      [applicationConfiguration]="applicationConfiguration"
+      [openCodingChallengeDialog]="openCodingChallengeDialog.bind(this)"
+      [repeatChallengeNotification]="repeatChallengeNotification.bind(this)"
+      [ngClass]="{ solved: challenge.solved, unsolved: !challenge.solved, disabled: challenge.disabledEnv !== null }"
+    />
+  </div>
+
+  <ng-template #emptyChallenges>
+    <!-- only showing when there are more than 1 challenge in total. not completely loaded otherwise -->
+    <div class="empty-challenges" *ngIf="allChallenges.length > 0">
+      <p>{{ 'NO_CHALLENGES_FOUND' | translate }}</p>
+    </div>
+  </ng-template>
+
+  <img src="assets/public/images/padding/1px.png"/>
+
+</ng-container>
+

--- a/frontend/src/app/score-board-preview/score-board-preview.component.scss
+++ b/frontend/src/app/score-board-preview/score-board-preview.component.scss
@@ -68,9 +68,9 @@
 }
 
 .loading-spinner-wrapper {
-  display: flex;
-  width: 100%;
-  justify-content: center;
   align-items: center;
+  display: flex;
+  justify-content: center;
   padding: 64px;
+  width: 100%;
 }

--- a/frontend/src/app/score-board-preview/score-board-preview.component.scss
+++ b/frontend/src/app/score-board-preview/score-board-preview.component.scss
@@ -66,3 +66,11 @@
 
   min-height: 20vh;
 }
+
+.loading-spinner-wrapper {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  padding: 64px;
+}

--- a/frontend/src/app/score-board-preview/score-board-preview.component.spec.ts
+++ b/frontend/src/app/score-board-preview/score-board-preview.component.spec.ts
@@ -1,3 +1,4 @@
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
@@ -73,6 +74,7 @@ describe('ScoreBoardPreviewComponent', () => {
         TranslateModule.forRoot(),
         HttpClientTestingModule,
         RouterTestingModule,
+        MatProgressSpinnerModule,
         MatDialogModule,
         MatIconModule
       ],

--- a/frontend/src/app/score-board-preview/score-board-preview.component.spec.ts
+++ b/frontend/src/app/score-board-preview/score-board-preview.component.spec.ts
@@ -20,35 +20,25 @@ import { CodeSnippetService } from '../Services/code-snippet.service'
 import { ChallengeService } from '../Services/challenge.service'
 import { Challenge } from '../Models/challenge.model'
 
-function createChallenge ({
-  name,
-  key,
-  category,
-  difficulty,
-  solved
-}: {
-  name: string
-  key: string
-  category: string
-  difficulty: 1 | 2 | 3 | 4 | 5 | 6
-  solved: boolean
-}): Challenge {
+// allows to easily create a challenge with some overwrites
+function createChallenge (challengeOverwrites: Partial<Challenge>): Challenge {
   return {
-    name,
-    key,
-    category,
-    difficulty,
+    name: 'foobar',
+    key: 'challenge-1',
+    category: 'category-blue',
+    difficulty: 3,
     description: '',
     hint: '',
     tags: '',
     hintUrl: '',
     disabledEnv: null,
-    solved,
+    solved: false,
     tutorialOrder: null,
     hasTutorial: false,
     hasSnippet: false,
     codingChallengeStatus: 0,
-    mitigationUrl: ''
+    mitigationUrl: '',
+    ...challengeOverwrites
   }
 }
 
@@ -107,13 +97,16 @@ describe('ScoreBoardPreviewComponent', () => {
           key: 'challenge-2',
           category: 'category-blue',
           difficulty: 5,
-          solved: false
+          solved: false,
+          hasSnippet: true,
+          codingChallengeStatus: 1
         }),
         createChallenge({
           name: 'Challenge 3',
           key: 'challenge-3',
           category: 'category-red',
           difficulty: 3,
+          hasSnippet: true,
           solved: false
         })
       ])
@@ -147,7 +140,7 @@ describe('ScoreBoardPreviewComponent', () => {
     ).toBe(true)
   })
 
-  it('should mark challenges as solved on challenge notification webhook', (): void => {
+  it('should mark challenges as solved on "challenge solved" websocket', (): void => {
     expect(
       component.filteredChallenges.find(
         (challenge) => challenge.key === 'challenge-3'
@@ -168,5 +161,43 @@ describe('ScoreBoardPreviewComponent', () => {
         (challenge) => challenge.key === 'challenge-3'
       ).solved
     ).toBeTrue()
+  })
+
+  it('should mark find it code challenges as solved on "code challenge solved" websocket', (): void => {
+    expect(
+      component.filteredChallenges.find(
+        (challenge) => challenge.key === 'challenge-3'
+      ).codingChallengeStatus
+    ).toBe(0)
+
+    component.onCodeChallengeSolvedWebsocket({
+      key: 'challenge-3',
+      codingChallengeStatus: 1
+    })
+
+    expect(
+      component.filteredChallenges.find(
+        (challenge) => challenge.key === 'challenge-3'
+      ).codingChallengeStatus
+    ).toBe(1)
+  })
+
+  it('should mark fix it code challenges as solved on "code challenge solved" websocket', (): void => {
+    expect(
+      component.filteredChallenges.find(
+        (challenge) => challenge.key === 'challenge-2'
+      ).codingChallengeStatus
+    ).toBe(1)
+
+    component.onCodeChallengeSolvedWebsocket({
+      key: 'challenge-2',
+      codingChallengeStatus: 2
+    })
+
+    expect(
+      component.filteredChallenges.find(
+        (challenge) => challenge.key === 'challenge-2'
+      ).codingChallengeStatus
+    ).toBe(2)
   })
 })

--- a/frontend/src/app/score-board-preview/score-board-preview.component.ts
+++ b/frontend/src/app/score-board-preview/score-board-preview.component.ts
@@ -4,17 +4,15 @@ import { DomSanitizer } from '@angular/platform-browser'
 import { MatDialog } from '@angular/material/dialog'
 import { Subscription, combineLatest } from 'rxjs'
 
+import { fromQueryParams, toQueryParams } from './filter-settings/query-params-converters'
+import { DEFAULT_FILTER_SETTING, FilterSetting } from './filter-settings/FilterSetting'
 import { Config, ConfigurationService } from '../Services/configuration.service'
 import { CodeSnippetComponent } from '../code-snippet/code-snippet.component'
 import { CodeSnippetService } from '../Services/code-snippet.service'
 import { ChallengeService } from '../Services/challenge.service'
-import { SocketIoService } from '../Services/socket-io.service'
-
-import { DEFAULT_FILTER_SETTING, FilterSetting } from './filter-settings/FilterSetting'
-import { EnrichedChallenge } from './types/EnrichedChallenge'
-
-import { fromQueryParams, toQueryParams } from './filter-settings/query-params-converters'
 import { filterChallenges } from './helpers/challenge-filtering'
+import { SocketIoService } from '../Services/socket-io.service'
+import { EnrichedChallenge } from './types/EnrichedChallenge'
 import { sortChallenges } from './helpers/challenge-sorting'
 
 interface ChallengeSolvedWebsocket {
@@ -40,6 +38,8 @@ export class ScoreBoardPreviewComponent implements OnInit, OnDestroy {
   public filteredChallenges: EnrichedChallenge[] = []
   public filterSetting: FilterSetting = structuredClone(DEFAULT_FILTER_SETTING)
   public applicationConfiguration: Config | null = null
+
+  public isInitialized: boolean = false
 
   private readonly subscriptions: Subscription[] = []
 
@@ -74,6 +74,7 @@ export class ScoreBoardPreviewComponent implements OnInit, OnDestroy {
       })
       this.allChallenges = transformedChallenges
       this.filterAndUpdateChallenges()
+      this.isInitialized = true
     })
     this.subscriptions.push(dataLoaderSubscription)
 

--- a/frontend/src/app/score-board-preview/score-board-preview.module.ts
+++ b/frontend/src/app/score-board-preview/score-board-preview.module.ts
@@ -1,14 +1,17 @@
 import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { RouterModule } from '@angular/router'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
+import { MatRadioModule } from '@angular/material/radio'
 import { MatSelectModule } from '@angular/material/select'
 import { MatButtonModule } from '@angular/material/button'
 import { MatDialogModule } from '@angular/material/dialog'
 import { MatTooltipModule } from '@angular/material/tooltip'
 import { MatFormFieldModule } from '@angular/material/form-field'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 
 import { ScoreBoardPreviewComponent } from './score-board-preview.component'
 import { ScoreCardComponent } from './components/score-card/score-card.component'
@@ -23,12 +26,10 @@ import { DifficultyOverviewScoreCardComponent } from './components/difficulty-ov
 import { ChallengesUnavailableWarningComponent } from './components/challenges-unavailable-warning/challenges-unavailable-warning.component'
 import { CodingChallengeProgressScoreCardComponent } from './components/coding-challenge-progress-score-card/coding-challenge-progress-score-card.component'
 import { HackingChallengeProgressScoreCardComponent } from './components/hacking-challenge-progress-score-card/hacking-challenge-progress-score-card.component'
+import { ScoreBoardAdditionalSettingsDialogComponent } from './components/filter-settings/components/score-board-additional-settings-dialog/score-board-additional-settings-dialog.component'
 
 import { ChallengeHintPipe } from './pipes/challenge-hint.pipe'
 import { DifficultySelectionSummaryPipe } from './components/filter-settings/pipes/difficulty-selection-summary.pipe'
-import { RouterModule } from '@angular/router'
-import { ScoreBoardAdditionalSettingsDialogComponent } from './components/filter-settings/components/score-board-additional-settings-dialog/score-board-additional-settings-dialog.component'
-import { MatRadioModule } from '@angular/material/radio'
 
 @NgModule({
   declarations: [
@@ -64,6 +65,7 @@ import { MatRadioModule } from '@angular/material/radio'
     ReactiveFormsModule,
     RouterModule,
     TranslateModule,
+    MatProgressSpinnerModule,
   ],
 })
 class ScoreBoardPreviewModule {}

--- a/lib/challengeUtils.ts
+++ b/lib/challengeUtils.ts
@@ -57,6 +57,19 @@ export const sendNotification = function (challenge: { difficulty?: number, key:
   }
 }
 
+export const sendCodingChallengeNotification = function (challenge: { key: string, codingChallengeStatus: 0|1|2 }) {
+  if (challenge.codingChallengeStatus > 0) {
+    const notification = {
+      key: challenge.key,
+      codingChallengeStatus: challenge.codingChallengeStatus
+    }
+    if (global.io) {
+      // @ts-expect-error
+      global.io.emit('code challenge solved', notification)
+    }
+  }
+}
+
 export const notSolved = (challenge: any) => challenge && !challenge.solved
 
 export const findChallengeByName = (challengeName: string) => {
@@ -89,6 +102,7 @@ export const solveFindIt = async function (key: string, isRestore: boolean) {
     accuracy.storeFindItVerdict(solvedChallenge.key, true)
     accuracy.calculateFindItAccuracy(solvedChallenge.key)
     await calculateFindItCheatScore(solvedChallenge)
+    sendCodingChallengeNotification({ key, codingChallengeStatus: 1 })
   }
 }
 
@@ -100,5 +114,6 @@ export const solveFixIt = async function (key: string, isRestore: boolean) {
     accuracy.storeFixItVerdict(solvedChallenge.key, true)
     accuracy.calculateFixItAccuracy(solvedChallenge.key)
     await calculateFixItCheatScore(solvedChallenge)
+    sendCodingChallengeNotification({ key, codingChallengeStatus: 2 })
   }
 }

--- a/test/api/socketSpec.ts
+++ b/test/api/socketSpec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import io = require('socket.io-client')
+import io from 'socket.io-client'
 
 describe('WebSocket', () => {
   let socket: SocketIOClient.Socket

--- a/test/api/vulnCodeFixesSpec.ts
+++ b/test/api/vulnCodeFixesSpec.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+import { expect } from '@jest/globals'
 import frisby = require('frisby')
+import io from 'socket.io-client'
 import { Joi } from 'frisby'
 
 const URL = 'http://localhost:3000'
@@ -28,6 +30,25 @@ describe('/snippets/fixes/:key', () => {
 })
 
 describe('/snippets/fixes', () => {
+  let socket: SocketIOClient.Socket
+
+  beforeEach(done => {
+    socket = io('http://localhost:3000', {
+      reconnectionDelay: 0,
+      forceNew: true
+    })
+    socket.on('connect', () => {
+      done()
+    })
+  })
+
+  afterEach(done => {
+    if (socket.connected) {
+      socket.disconnect()
+    }
+    done()
+  })
+
   it('POST fix for non-existing challenge key throws error', () => {
     return frisby.post(URL + '/snippets/fixes', {
       body: {
@@ -66,8 +87,18 @@ describe('/snippets/fixes', () => {
       })
   })
 
-  it('POST correct fix for existing challenge key gives positive verdict and explanation', () => {
-    return frisby.post(URL + '/snippets/fixes', {
+  it('POST correct fix for existing challenge key gives positive verdict and explanation', async () => {
+    const websocketReceivedPromise = new Promise<void>((resolve) => {
+      socket.once('code challenge solved', (data: any) => {
+        expect(data).toEqual({
+          key: 'resetPasswordBenderChallenge',
+          codingChallengeStatus: 2
+        })
+        resolve()
+      })
+    })
+
+    await frisby.post(URL + '/snippets/fixes', {
       body: {
         key: 'resetPasswordBenderChallenge',
         selectedFix: 1
@@ -78,5 +109,8 @@ describe('/snippets/fixes', () => {
         verdict: true,
         explanation: 'When answered truthfully, all security questions are susceptible to online research (on Facebook, LinkedIn etc.) and often even brute force. If at all, they should not be used as the only factor for a security-relevant function.'
       })
+      .promise()
+
+    await websocketReceivedPromise
   })
 })


### PR DESCRIPTION
### Description

Fixes various smaller issues around the preview score board discovered (primarily by @bkimminich) after the merge.

- Fixed incorrect coding challenge score shown after the dialog is submitted
- Only show mitigation link when the challenge is solved
- Improve styling of warning card (e.g Challenges are unavailable due to docker installation) to look better on mobile devices. This gives the text more room 
- Show a loading spinner for the initial load of challenge, snippet and configuration data

For the coding challenge score I changed the handling pretty substantially, the coding challenges now also send our websockets so that the scoreboard also immediately updates in the background of the modal once the coding challenge has been solved. A bit overkill as to do it like this but this way the challenge updates on the score board are done consistently for bot hacking and coding challenges.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
