### PR TITLE
Handling of legacy challenge direct links

### DIFF
--- a/frontend/src/app/score-board/score-board.component.spec.ts
+++ b/frontend/src/app/score-board/score-board.component.spec.ts
@@ -63,7 +63,7 @@ describe('ScoreBoardPreviewComponent', () => {
     ])
 
     mockActivatedRoute = {
-      queryParams: of({ challenge: 'Score Board', searchQuery: null })
+      queryParams: of({})
     }
 
     await TestBed.configureTestingModule({
@@ -213,9 +213,11 @@ describe('ScoreBoardPreviewComponent', () => {
     ).toBe(2)
   })
 
-  it('should update queryParams for OpenCRE', () => {
+  it('should rewrite legacy challenge direct link', () => {
     const spy = spyOn(router, 'navigate') // Spy on the router's navigate method
+    mockActivatedRoute.queryParams = of({ challenge: 'Score Board', searchQuery: null })
     component.ngOnInit()
+
     expect(spy).toHaveBeenCalledWith([], {
       queryParams: {
         challenge: null,

--- a/frontend/src/app/score-board/score-board.component.spec.ts
+++ b/frontend/src/app/score-board/score-board.component.spec.ts
@@ -20,6 +20,7 @@ import { ConfigurationService } from '../Services/configuration.service'
 import { CodeSnippetService } from '../Services/code-snippet.service'
 import { ChallengeService } from '../Services/challenge.service'
 import { type Challenge } from '../Models/challenge.model'
+import { ActivatedRoute, Router } from '@angular/router'
 
 // allows to easily create a challenge with some overwrites
 function createChallenge (challengeOverwrites: Partial<Challenge>): Challenge {
@@ -49,6 +50,8 @@ describe('ScoreBoardPreviewComponent', () => {
   let challengeService
   let codeSnippetService
   let configService
+  let mockActivatedRoute
+  let router: Router
 
   beforeEach(async () => {
     challengeService = jasmine.createSpyObj('ChallengeService', ['find'])
@@ -58,6 +61,11 @@ describe('ScoreBoardPreviewComponent', () => {
     configService = jasmine.createSpyObj('ConfigurationService', [
       'getApplicationConfiguration'
     ])
+
+    mockActivatedRoute = {
+      queryParams: of({ challenge: 'Score Board', searchQuery: null })
+    }
+
     await TestBed.configureTestingModule({
       declarations: [
         ScoreBoardComponent,
@@ -81,7 +89,8 @@ describe('ScoreBoardPreviewComponent', () => {
       providers: [
         { provide: ChallengeService, useValue: challengeService },
         { provide: CodeSnippetService, useValue: codeSnippetService },
-        { provide: ConfigurationService, useValue: configService }
+        { provide: ConfigurationService, useValue: configService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute }
       ]
     }).compileComponents()
 
@@ -127,6 +136,7 @@ describe('ScoreBoardPreviewComponent', () => {
 
     fixture = TestBed.createComponent(ScoreBoardComponent)
     component = fixture.componentInstance
+    router = TestBed.inject(Router) // Get the router from the test bed
     fixture.detectChanges()
   })
 
@@ -201,5 +211,16 @@ describe('ScoreBoardPreviewComponent', () => {
         (challenge) => challenge.key === 'challenge-2'
       ).codingChallengeStatus
     ).toBe(2)
+  })
+
+  it('should update queryParams for OpenCRE', () => {
+    const spy = spyOn(router, 'navigate') // Spy on the router's navigate method
+    component.ngOnInit()
+    expect(spy).toHaveBeenCalledWith([], {
+      queryParams: {
+        challenge: null,
+        searchQuery: 'Score Board'
+      }
+    })
   })
 })

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -184,20 +184,18 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
   }
 
   rewriteLegacyChallengeDirectLink (queryParams): boolean {
-    if (queryParams.challenge && !queryParams.searchQuery) {
-      console.warn('The "challenge=challengeName" URL query parameter is now deprecated, and "searchQuery=challengeName" should be used instead.')
-      this.router.navigate([], {
-        queryParams: {
-          ...queryParams,
-          challenge: null,
-          searchQuery: queryParams.challenge
-        }
-      })
-      return true
-    }
-
-    if (queryParams.challenge && queryParams.searchQuery) {
-      console.warn('The "challenge=challengeName" URL query parameter is now deprecated, and you should only use "searchQuery=challengeName" instead.')
+    if (queryParams.challenge) {
+      console.warn('The "challenge=<name>" URL query parameter is deprecated! You should  use "searchQuery=<name>" instead to link to a challenge directly. See https://pwning.owasp-juice.shop/companion-guide/latest/part4/integration.html#_generating_links_to_juice_shop for details.')
+      if (!queryParams.searchQuery) {
+        this.router.navigate([], {
+          queryParams: {
+            ...queryParams,
+            challenge: null,
+            searchQuery: queryParams.challenge
+          }
+        })
+        return true
+      }
     }
     return false
   }

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -80,7 +80,7 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
 
     const routerSubscription = this.route.queryParams.subscribe((queryParams) => {
       // Fix to keep direct links to challenges stable for OpenCRE and others
-      if (this.updateParamsForOpenCRE(queryParams)) return
+      if (this.rewriteLegacyChallengeDirectLink(queryParams)) return
 
       this.filterSetting = fromQueryParams(queryParams)
       this.filterAndUpdateChallenges()
@@ -183,8 +183,9 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
     await this.challengeService.repeatNotification(encodeURIComponent(challenge.name)).toPromise()
   }
 
-  updateParamsForOpenCRE (queryParams): boolean {
+  rewriteLegacyChallengeDirectLink (queryParams): boolean {
     if (queryParams.challenge && !queryParams.searchQuery) {
+      console.warn('The "challenge=challengeName" URL query parameter is now deprecated, and "searchQuery=challengeName" should be used instead.')
       this.router.navigate([], {
         queryParams: {
           ...queryParams,
@@ -193,6 +194,10 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
         }
       })
       return true
+    }
+
+    if (queryParams.challenge && queryParams.searchQuery) {
+      console.warn('The "challenge=challengeName" URL query parameter is now deprecated, and you should only use "searchQuery=challengeName" instead.')
     }
     return false
   }

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -1,5 +1,5 @@
 import { Component, NgZone, type OnDestroy, type OnInit } from '@angular/core'
-import { ActivatedRoute, Params, Router } from '@angular/router'
+import { ActivatedRoute, Router } from '@angular/router'
 import { DomSanitizer } from '@angular/platform-browser'
 import { MatDialog } from '@angular/material/dialog'
 import { type Subscription, combineLatest } from 'rxjs'
@@ -183,7 +183,7 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
     await this.challengeService.repeatNotification(encodeURIComponent(challenge.name)).toPromise()
   }
 
-  updateParamsForOpenCRE (queryParams: Params): boolean {
+  updateParamsForOpenCRE (queryParams): boolean {
     if (queryParams.challenge && !queryParams.searchQuery) {
       this.router.navigate([], {
         queryParams: {

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -79,6 +79,18 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
     this.subscriptions.push(dataLoaderSubscription)
 
     const routerSubscription = this.route.queryParams.subscribe((queryParams) => {
+      // Fix to keep direct links to challenges stable for OpenCRE and others
+      if (queryParams.challenge && !queryParams.searchQuery) {
+        this.router.navigate([], {
+          queryParams: {
+            ...queryParams,
+            challenge: null,
+            searchQuery: queryParams.challenge
+          }
+        })
+        return
+      }
+
       this.filterSetting = fromQueryParams(queryParams)
       this.filterAndUpdateChallenges()
     })

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -1,5 +1,5 @@
 import { Component, NgZone, type OnDestroy, type OnInit } from '@angular/core'
-import { ActivatedRoute, Router } from '@angular/router'
+import { ActivatedRoute, Params, Router } from '@angular/router'
 import { DomSanitizer } from '@angular/platform-browser'
 import { MatDialog } from '@angular/material/dialog'
 import { type Subscription, combineLatest } from 'rxjs'
@@ -80,16 +80,7 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
 
     const routerSubscription = this.route.queryParams.subscribe((queryParams) => {
       // Fix to keep direct links to challenges stable for OpenCRE and others
-      if (queryParams.challenge && !queryParams.searchQuery) {
-        this.router.navigate([], {
-          queryParams: {
-            ...queryParams,
-            challenge: null,
-            searchQuery: queryParams.challenge
-          }
-        })
-        return
-      }
+      if (this.updateParamsForOpenCRE(queryParams)) return
 
       this.filterSetting = fromQueryParams(queryParams)
       this.filterAndUpdateChallenges()
@@ -190,5 +181,19 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
   async repeatChallengeNotification (challengeKey: string) {
     const challenge = this.allChallenges.find((challenge) => challenge.key === challengeKey)
     await this.challengeService.repeatNotification(encodeURIComponent(challenge.name)).toPromise()
+  }
+
+  updateParamsForOpenCRE (queryParams: Params): boolean {
+    if (queryParams.challenge && !queryParams.searchQuery) {
+      this.router.navigate([], {
+        queryParams: {
+          ...queryParams,
+          challenge: null,
+          searchQuery: queryParams.challenge
+        }
+      })
+      return true
+    }
+    return false
   }
 }


### PR DESCRIPTION

<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description
Keep direct links to challenges stable for OpenCRE and others issue #2149

<!-- ✍️-->
Modify the scoreboard code to incorporate the following proposed solution:

1. If both ?challenge=<name> and ?searchQuery=<name> are query parameters, prioritize ?searchQuery=<name> and ignore ?challenge=<name>.
2. If only ?challenge=<name> is a query parameter (without ?searchQuery=<name>), convert ?challenge=<name> to ?searchQuery=<name> and locally trigger the route without a browser reload.

Additionally, should a test case be included?"

Resolved or fixed issue:  #2149

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
