### PR TITLE
Fix link to troubleshooting page in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ assignees: ''
 To expedite issue processing please search open and closed issues before submitting a new one.
 Existing issues often contain information about workarounds, resolution, or progress updates.
 
-Please also make sure to check the official [Troubleshooting guide](https://pwning.owasp-juice.shop/appendix/troubleshooting.html) before opening a bug report.
+Please also make sure to check the official [Troubleshooting guide](https://pwning.owasp-juice.shop/companion-guide/latest/part4/troubleshooting.html) before opening a bug report.
 
 🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
 


### PR DESCRIPTION
### Description
The link to the Troubleshooting page in the comments of the Bug Report template was broken. This PR points the link to the correct location.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
