### PR TITLE
fix csafHashValue

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -79,7 +79,7 @@ challenges:
   xssBonusPayload: '<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/771984076&color=%23ff5500&auto_play=true&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>'
   safetyMode: auto
   showFeedbackButtons: true
-  csafHashValue: 7d679a6a84a1ec0f12f91e2f487b9e89a7282ef775cbbec8baea2fa50eb101b7ee402dadd1bb9df0d8aaeb3ecb93e2892735f44b0c6cfb32c2f70478ae45afb7
+  csafHashValue: 7e7ce7c65db3bf0625fcea4573d25cff41f2f7e3474f2c74334b14fc65bb4fd26af802ad17a3a03bf0eee6827a00fb8f7905f338c31b5e6ea9cb31620242e843
 hackingInstructor:
   isEnabled: true
   avatarImage: JuicyBot.png


### PR DESCRIPTION
In the last update to make CSAF more compliant to the standard, the solution hash value has not been updated.
Currently, the challenge is not not solvable.