### PR TITLE
refactoring waitForDevTool helper function

### DIFF
--- a/frontend/src/hacking-instructor/helpers/helpers.ts
+++ b/frontend/src/hacking-instructor/helpers/helpers.ts
@@ -178,22 +178,14 @@ export function waitForLogOut () {
 
 /**
  * see https://stackoverflow.com/questions/7798748/find-out-whether-chrome-console-is-open/48287643#48287643
+ * does detect when devtools are opened horizontally or vertically but not when undocked or open on page load
  */
 export function waitForDevTools () {
-  let checkStatus = false
-
-  const element = new Image()
-  Object.defineProperty(element, 'id', {
-    get: function () {
-      checkStatus = true
-    }
-  })
-
+  const initialInnerHeight = window.innerHeight
+  const initialInnerWidth = window.innerWidth
   return async () => {
     while (true) {
-      console.dir(element)
-      console.clear()
-      if (checkStatus) {
+      if (window.innerHeight !== initialInnerHeight || window.innerWidth !== initialInnerWidth) {
         break
       }
       await sleep(100)


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
This PR refactors the helper function to detect if devtools are open. The previous solution doesn't work anymore since Chrome 90. Unfortunately, there is no one solution that reliably detects if devtools are open, so it is about trade-offs. The proposed solution detects if devtools is open on different browsers, horizontally and vertically. I also prefer it as it doesn't interfer with user experience like solutions including the debugger. The stack overflow article linked in the issue and code explains the options and trade-offs well. For transparency, the submitted solution doesn't work if:
1) devtools are open on page load
2) undocked

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->
#2274 
### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
