### PR TITLE
Adding challenge: Exposed token during OAuth2.0 implicit flow

### DIFF
--- a/config.schema.yml
+++ b/config.schema.yml
@@ -723,3 +723,8 @@ ctf:
         type: string
       code:
         type: string
+    oauthImplicitFlowChallenge:
+      name:
+        type: string
+      code:
+        type: string

--- a/config/fbctf.yml
+++ b/config/fbctf.yml
@@ -336,3 +336,6 @@ ctf:
     csafChallenge:
       name: Slovenia
       code: SI
+    oauthImplicitFlowChallenge:
+      name: Montenegro
+      code: ME

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -1231,3 +1231,14 @@
   hintUrl: ''
   mitigationUrl: ~
   key: csafChallenge
+-
+  name: 'Exposed OAuth Access Token'
+  category: 'Broken Authentication'
+  tags:
+    - Good for Demo
+  description: 'Steal your own OAuth access token and publish your sub claim as a product review.'
+  difficulty: 3
+  hint: 'Read up on common OAuth flows and and their flaws.'
+  hintUrl: ''
+  mitigationUrl: ~
+  key: oauthImplicitFlowChallenge

--- a/data/static/codefixes/loginAdminChallenge_1.ts
+++ b/data/static/codefixes/loginAdminChallenge_1.ts
@@ -20,6 +20,9 @@ module.exports = function login () {
     models.sequelize.query(`SELECT * FROM Users WHERE email = '${req.body.email || ''}' AND password = '${security.hash(req.body.password || '')}' AND deletedAt IS NULL`, { model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginAdminChallenge_2.ts
+++ b/data/static/codefixes/loginAdminChallenge_2.ts
@@ -18,6 +18,9 @@ module.exports = function login () {
       { bind: [ req.body.email ], model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginAdminChallenge_3.ts
+++ b/data/static/codefixes/loginAdminChallenge_3.ts
@@ -18,6 +18,9 @@ module.exports = function login () {
       { bind: [ req.body.email, req.body.password ], model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginAdminChallenge_4_correct.ts
+++ b/data/static/codefixes/loginAdminChallenge_4_correct.ts
@@ -18,6 +18,9 @@ module.exports = function login () {
       { bind: [ req.body.email, security.hash(req.body.password) ], model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginBenderChallenge_1.ts
+++ b/data/static/codefixes/loginBenderChallenge_1.ts
@@ -20,6 +20,9 @@ module.exports = function login () {
     models.sequelize.query(`SELECT * FROM Users WHERE email = '${req.body.email || ''}' AND password = '${security.hash(req.body.password || '')}' AND deletedAt IS NULL`, { model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginBenderChallenge_2_correct.ts
+++ b/data/static/codefixes/loginBenderChallenge_2_correct.ts
@@ -18,6 +18,9 @@ module.exports = function login () {
       { bind: { mail: req.body.email, pass: security.hash(req.body.password) }, model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginBenderChallenge_3.ts
+++ b/data/static/codefixes/loginBenderChallenge_3.ts
@@ -18,6 +18,9 @@ module.exports = function login () {
       { replacements: { mail: req.body.email }, model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginBenderChallenge_4.ts
+++ b/data/static/codefixes/loginBenderChallenge_4.ts
@@ -17,6 +17,9 @@ module.exports = function login () {
     models.sequelize.query(`SELECT * FROM Users WHERE email = '${req.body.email || ''}' AND password = '${security.hash(req.body.password || '')}' AND deletedAt IS NULL`, { model: models.User, plain: false })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginJimChallenge_1_correct.ts
+++ b/data/static/codefixes/loginJimChallenge_1_correct.ts
@@ -18,6 +18,9 @@ module.exports = function login () {
       { bind: [ req.body.email, security.hash(req.body.password) ], model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginJimChallenge_2.ts
+++ b/data/static/codefixes/loginJimChallenge_2.ts
@@ -17,6 +17,9 @@ module.exports = function login () {
     models.sequelize.query(`SELECT * FROM Users WHERE email = '${req.body.email || ''}' AND password = '${security.hash(req.body.password || '')}' AND deletedAt IS NULL`, { model: models.User, plain: false })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginJimChallenge_3.ts
+++ b/data/static/codefixes/loginJimChallenge_3.ts
@@ -18,6 +18,9 @@ module.exports = function login () {
       { replacements: [ req.body.email, req.body.password ], model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/data/static/codefixes/loginJimChallenge_4.ts
+++ b/data/static/codefixes/loginJimChallenge_4.ts
@@ -20,6 +20,9 @@ module.exports = function login () {
     models.sequelize.query(`SELECT * FROM Users WHERE email = '${req.body.email || ''}' AND password = '${security.hash(req.body.password || '')}' AND deletedAt IS NULL`, { model: models.User, plain: true })
       .then((authenticatedUser) => {
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/frontend/src/app/oauth/oauth.component.spec.ts
+++ b/frontend/src/app/oauth/oauth.component.spec.ts
@@ -89,7 +89,7 @@ describe('OAuthComponent', () => {
     userService.oauthLogin.and.returnValue(of({ email: 'test@test.com' }))
     userService.save.and.returnValue(throwError({ error: 'Account already exists' }))
     component.ngOnInit()
-    expect(userService.login).toHaveBeenCalledWith({ email: 'test@test.com', password: 'bW9jLnRzZXRAdHNldA==', oauth: true })
+    expect(userService.login).toHaveBeenCalledWith({ email: 'test@test.com', password: 'bW9jLnRzZXRAdHNldA==', oauth: true, subclaim: undefined })
   }))
 
   it('removes authentication token and basket id on failed subsequent regular login attempt', fakeAsync(() => {

--- a/frontend/src/app/oauth/oauth.component.ts
+++ b/frontend/src/app/oauth/oauth.component.ts
@@ -29,7 +29,7 @@ export class OAuthComponent implements OnInit {
   }
 
   login (profile: any) {
-    this.userService.login({ email: profile.email, password: btoa(profile.email.split('').reverse().join('')), oauth: true }).subscribe((authentication) => {
+    this.userService.login({ email: profile.email, password: btoa(profile.email.split('').reverse().join('')), oauth: true, subclaim: profile.id }).subscribe((authentication) => {
       const expires = new Date()
       expires.setHours(expires.getHours() + 8)
       this.cookieService.put('token', authentication.token, { expires })

--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -28,6 +28,7 @@ interface ResponseWithUser {
   iat: number
   exp: number
   bid: number
+  subclaim?: string
 }
 
 interface IAuthenticatedUsers {

--- a/models/user.ts
+++ b/models/user.ts
@@ -32,6 +32,7 @@ InferCreationAttributes<User>
   declare profileImage: CreationOptional<string>
   declare totpSecret: CreationOptional<string>
   declare isActive: CreationOptional<boolean>
+  declare subclaim?: CreationOptional<string>
 }
 
 const UserModelInit = (sequelize: Sequelize) => { // vuln-code-snippet start weakPasswordChallenge
@@ -117,6 +118,10 @@ const UserModelInit = (sequelize: Sequelize) => { // vuln-code-snippet start wea
       isActive: {
         type: DataTypes.BOOLEAN,
         defaultValue: true
+      },
+      subclaim: {
+        type: DataTypes.STRING,
+        defaultValue: ''
       }
     },
     {

--- a/routes/createProductReviews.ts
+++ b/routes/createProductReviews.ts
@@ -16,6 +16,7 @@ module.exports = function productReviews () {
   return (req: Request, res: Response) => {
     const user = security.authenticatedUsers.from(req)
     challengeUtils.solveIf(challenges.forgedReviewChallenge, () => { return user && user.data.email !== req.body.author })
+    challengeUtils.solveIf(challenges.oauthImplicitFlowChallenge, () => { return user && user.data.subclaim === req.body.message })
     reviewsCollection.insert({
       product: req.params.id,
       message: req.body.message,

--- a/routes/login.ts
+++ b/routes/login.ts
@@ -36,6 +36,9 @@ module.exports = function login () {
     models.sequelize.query(`SELECT * FROM Users WHERE email = '${req.body.email || ''}' AND password = '${security.hash(req.body.password || '')}' AND deletedAt IS NULL`, { model: UserModel, plain: true }) // vuln-code-snippet vuln-line loginAdminChallenge loginBenderChallenge loginJimChallenge
       .then((authenticatedUser) => { // vuln-code-snippet neutral-line loginAdminChallenge loginBenderChallenge loginJimChallenge
         const user = utils.queryResultToJson(authenticatedUser)
+        if (user.data && req.body.subclaim) {
+          user.data.subclaim = req.body.subclaim
+        }
         if (user.data?.id && user.data.totpSecret !== '') {
           res.status(401).json({
             status: 'totp_token_required',

--- a/test/api/loginApiSpec.ts
+++ b/test/api/loginApiSpec.ts
@@ -213,7 +213,7 @@ describe('/rest/user/login', () => {
     return frisby.post(REST_URL + '/user/login', {
       header: jsonHeader,
       body: {
-        email: `' UNION SELECT * FROM (SELECT 15 as 'id', '' as 'username', 'acc0unt4nt@${config.get<string>('application.domain')}' as 'email', '12345' as 'password', 'accounting' as 'role', '' as deluxeToken, '1.2.3.4' as 'lastLoginIp' , '/assets/public/images/uploads/default.svg' as 'profileImage', '' as 'totpSecret', 1 as 'isActive', '1999-08-16 14:14:41.644 +00:00' as 'createdAt', '1999-08-16 14:33:41.930 +00:00' as 'updatedAt', null as 'deletedAt')--`,
+        email: `' UNION SELECT * FROM (SELECT 15 as 'id', '' as 'username', 'acc0unt4nt@${config.get<string>('application.domain')}' as 'email', '12345' as 'password', 'accounting' as 'role', '' as deluxeToken, '1.2.3.4' as 'lastLoginIp' , '/assets/public/images/uploads/default.svg' as 'profileImage', '' as 'totpSecret', 1 as 'isActive', '1999-08-16 14:14:41.644 +00:00' as 'createdAt', '1999-08-16 14:33:41.930 +00:00' as 'updatedAt', null as 'deletedAt', '' as subclaim)--`,
         password: undefined
       }
     })


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
The OAuth login of the Juice Shop uses the implicit flow which exposes the token in the url (https://oauth.net/2/grant-types/implicit/). If an attacker gains this token, a call to the identity provider can be made to expose additional information. Depending on how the authorization server is configured, this can lead to sensitive data being stolen.

To keep it simple, I designed the challenge such that a user exposes its own sub claim (sub=subject), which is part of the response to the userinfo endpoint. This way, the authorization server doesn't need to be modified, and no google account is needed with email + pw exposed.

SPOILER

To solve the challenge:

- Login with Google
- Now, you can do one of those two. They lead to the same result: 
1) Get the token from the url using a proxy. Make a request to the userinfo endpoint with the token: https://www.googleapis.com/oauth2/v1/userinfo?access_token=YOUR_TOKEN
2) Check the network tab during login. A request with the token is done by the frontend to the userinfo endpoint. Just check the response.
- While v1 and v2 naming convention is 'id', in v3 it is 'sub'. I think it adds some nice complexity and forces the user to look a bit more into the docs.
- Submit the sub claim as a review on any product you like.

The fact that one can also get the token from the network tabs also showcases well that there are issues when the frontend handles those OAuth calls.

I needed to do minor adjustments to the existing ephemeralAccountant challenge and updated the tests as well. In case this get's merged, the solution for ephemeralAccountant slightly changes and needs to be updated in the corresponding docs.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->
#2295
### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
