### PR TITLE
Fix: Prevent request hang in `ensureFileIsPassed` middleware

### DIFF
--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -18,6 +18,8 @@ const unzipper = require('unzipper')
 function ensureFileIsPassed ({ file }: Request, res: Response, next: NextFunction) {
   if (file != null) {
     next()
+  } else {
+    return res.status(400).json({ error: 'File is not passed' })
   }
 }
 

--- a/test/api/memoryApiSpec.ts
+++ b/test/api/memoryApiSpec.ts
@@ -78,6 +78,57 @@ describe('/rest/memories', () => {
       })
   })
 
+  it('POST new memory image file is not passed - 1', () => {
+    return frisby.post(REST_URL + '/user/login', {
+      headers: jsonHeader,
+      body: {
+        email: 'jim@' + config.get<string>('application.domain'),
+        password: 'ncc-1701'
+      }
+    })
+      .expect('status', 200)
+      .then(({ json: jsonLogin }) => {
+        return frisby.post(REST_URL + '/memories', {
+          headers: {
+            Authorization: 'Bearer ' + jsonLogin.authentication.token
+          }
+        })
+          .expect('status', 400)
+          .expect('json', {
+            error: 'File is not passed'
+          })
+      })
+  })
+
+  it('POST new memory image file is not passed - 2', () => {
+    const form = frisby.formData()
+    form.append('key1', 'value1')
+    form.append('key2', 'value2')
+
+    return frisby.post(REST_URL + '/user/login', {
+      headers: jsonHeader,
+      body: {
+        email: 'jim@' + config.get<string>('application.domain'),
+        password: 'ncc-1701'
+      }
+    })
+      .expect('status', 200)
+      .then(({ json: jsonLogin }) => {
+        return frisby.post(REST_URL + '/memories', {
+          headers: {
+            Authorization: 'Bearer ' + jsonLogin.authentication.token,
+            // @ts-expect-error FIXME form.getHeaders() is not found
+            'Content-Type': form.getHeaders()['content-type']
+          },
+          body: form
+        })
+          .expect('status', 400)
+          .expect('json', {
+            error: 'File is not passed'
+          })
+      })
+  })
+
   it('POST new memory with valid for JPG format image', () => {
     const file = path.resolve(__dirname, '../files/validProfileImage.jpg')
     const form = frisby.formData()


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
This pull request addresses an issue where the `ensureFileIsPassed` middleware was causing requests to hang indefinitely if no file was uploaded. The middleware did not explicitly send a response or call `next()` in the case where no file was found, leading to stalled requests. You can check it with `curl -X POST http://localhost:3000/rest/memories` or any other file-upload related endpoint.

Resolved or fixed issue: none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
