### PR TITLE
Fix crash when out-of-alphabet value passed to hashid.decode()

### DIFF
--- a/routes/restoreProgress.ts
+++ b/routes/restoreProgress.ts
@@ -8,11 +8,17 @@ import { type Request, type Response } from 'express'
 import { challenges } from '../data/datacache'
 
 const challengeUtils = require('../lib/challengeUtils')
+const hashidsAlphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
+const hashidRegexp = /^[a-zA-Z0-9]+$/
+const invalidContinueCode = 'Invalid continue code.'
 
 module.exports.restoreProgress = function restoreProgress () {
   return ({ params }: Request, res: Response) => {
-    const hashids = new Hashids('this is my salt', 60, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
+    const hashids = new Hashids('this is my salt', 60, hashidsAlphabet)
     const continueCode = params.continueCode
+    if (!hashidRegexp.test(continueCode)) {
+      return res.status(404).send(invalidContinueCode)
+    }
     const ids = hashids.decode(continueCode)
     if (challengeUtils.notSolved(challenges.continueCodeChallenge) && ids.includes(999)) {
       challengeUtils.solve(challenges.continueCodeChallenge)
@@ -27,15 +33,18 @@ module.exports.restoreProgress = function restoreProgress () {
       }
       res.json({ data: ids.length + ' solved challenges have been restored.' })
     } else {
-      res.status(404).send('Invalid continue code.')
+      res.status(404).send(invalidContinueCode)
     }
   }
 }
 
 module.exports.restoreProgressFindIt = function restoreProgressFindIt () {
   return async ({ params }: Request, res: Response) => {
-    const hashids = new Hashids('this is the salt for findIt challenges', 60, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
+    const hashids = new Hashids('this is the salt for findIt challenges', 60, hashidsAlphabet)
     const continueCodeFindIt = params.continueCode
+    if (!hashidRegexp.test(continueCodeFindIt)) {
+      return res.status(404).send(invalidContinueCode)
+    }
     const idsFindIt = hashids.decode(continueCodeFindIt)
     if (idsFindIt.length > 0) {
       for (const key in challenges) {
@@ -47,15 +56,18 @@ module.exports.restoreProgressFindIt = function restoreProgressFindIt () {
       }
       res.json({ data: idsFindIt.length + ' solved challenges have been restored.' })
     } else {
-      res.status(404).send('Invalid continue code.')
+      res.status(404).send(invalidContinueCode)
     }
   }
 }
 
 module.exports.restoreProgressFixIt = function restoreProgressFixIt () {
-  const hashids = new Hashids('yet another salt for the fixIt challenges', 60, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
+  const hashids = new Hashids('yet another salt for the fixIt challenges', 60, hashidsAlphabet)
   return async ({ params }: Request, res: Response) => {
     const continueCodeFixIt = params.continueCode
+    if (!hashidRegexp.test(continueCodeFixIt)) {
+      return res.status(404).send(invalidContinueCode)
+    }
     const idsFixIt = hashids.decode(continueCodeFixIt)
     if (idsFixIt.length > 0) {
       for (const key in challenges) {
@@ -67,7 +79,7 @@ module.exports.restoreProgressFixIt = function restoreProgressFixIt () {
       }
       res.json({ data: idsFixIt.length + ' solved challenges have been restored.' })
     } else {
-      res.status(404).send('Invalid continue code.')
+      res.status(404).send(invalidContinueCode)
     }
   }
 }

--- a/test/api/challengeApiSpec.ts
+++ b/test/api/challengeApiSpec.ts
@@ -71,8 +71,13 @@ describe('/rest/continue-code', () => {
       .expect('status', 200)
   })
 
-  it('PUT invalid continue code is rejected', () => {
+  it('PUT invalid continue code is rejected (alphanumeric)', () => {
     return frisby.put(REST_URL + '/continue-code/apply/ThisIsDefinitelyNotAValidContinueCode')
+      .expect('status', 404)
+  })
+
+  it('PUT invalid continue code is rejected (non-alphanumeric)', () => {
+    return frisby.put(REST_URL + '/continue-code/apply/%3Cimg%20src=nonexist1%20onerror=alert()%3E')
       .expect('status', 404)
   })
 
@@ -93,8 +98,13 @@ describe('/rest/continue-code-findIt', () => {
       .expect('status', 200)
   })
 
-  it('PUT invalid continue code is rejected', () => {
+  it('PUT invalid continue code is rejected (alphanumeric)', () => {
     return frisby.put(REST_URL + '/continue-code-findIt/apply/ThisIsDefinitelyNotAValidContinueCode')
+      .expect('status', 404)
+  })
+
+  it('PUT completely invalid continue code is rejected (non-alphanumeric)', () => {
+    return frisby.put(REST_URL + '/continue-code-findIt/apply/%3Cimg%20src=nonexist1%20onerror=alert()%3E')
       .expect('status', 404)
   })
 
@@ -110,8 +120,13 @@ describe('/rest/continue-code-fixIt', () => {
       .expect('status', 200)
   })
 
-  it('PUT invalid continue code is rejected', () => {
+  it('PUT invalid continue code is rejected (alphanumeric)', () => {
     return frisby.put(REST_URL + '/continue-code-fixIt/apply/ThisIsDefinitelyNotAValidContinueCode')
+      .expect('status', 404)
+  })
+
+  it('PUT completely invalid continue code is rejected (non-alphanumeric)', () => {
+    return frisby.put(REST_URL + '/continue-code-fixIt/apply/%3Cimg%20src=nonexist1%20onerror=alert()%3E')
       .expect('status', 404)
   })
 


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
Added validation to ensure that continue codes match the alphabet used in `Hashids`. Now, if a continue code contains characters not in the `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890` alphabet, the request will be rejected with a `404` status and the message `"Invalid continue code."`.
My DAST is fuzzing juice-shop with expressive deepness to find such a crashes.
You can try to crash the app with:
`curl -X PUT 'http://your-juice-shop/rest/continue-code-findIt/apply/%3Cimg%20src=nonexist1%20onerror=alert()%3E'`


Validation has been added to three handlers: `restoreProgress`, `restoreProgressFindIt`, and `restoreProgressFixIt`

Resolved or fixed issue: `none`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
