### PR TITLE
fix tutorial.js being bundled into main.js

### DIFF
--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
@@ -1,8 +1,5 @@
-import { Component, Input } from '@angular/core'
-
+import { Component, Input, type OnInit } from '@angular/core'
 import { EnrichedChallenge } from '../../types/EnrichedChallenge'
-
-import { hasInstructions, startHackingInstructorFor } from '../../../../hacking-instructor'
 import { Config } from 'src/app/Services/configuration.service'
 
 @Component({
@@ -10,7 +7,7 @@ import { Config } from 'src/app/Services/configuration.service'
   templateUrl: './challenge-card.component.html',
   styleUrls: ['./challenge-card.component.scss']
 })
-export class ChallengeCardComponent {
+export class ChallengeCardComponent implements OnInit {
   @Input()
   public challenge: EnrichedChallenge
 
@@ -23,6 +20,12 @@ export class ChallengeCardComponent {
   @Input()
   public applicationConfiguration: Config
 
-  public hasInstructions = hasInstructions
-  public startHackingInstructorFor = startHackingInstructorFor
+  public hasInstructions: (challengeName: string) => boolean = () => false
+  public startHackingInstructorFor: (challengeName: string) => Promise<void> = async () => {}
+
+  async ngOnInit () {
+    const { hasInstructions, startHackingInstructorFor } = await import('../../../../hacking-instructor')
+    this.hasInstructions = hasInstructions
+    this.startHackingInstructorFor = startHackingInstructorFor
+  }
 }

--- a/lib/startup/validatePreconditions.ts
+++ b/lib/startup/validatePreconditions.ts
@@ -30,6 +30,7 @@ const validatePreconditions = async ({ exitOnFailure = true } = {}) => {
     checkIfRequiredFileExists('frontend/dist/frontend/index.html'),
     checkIfRequiredFileExists('frontend/dist/frontend/styles.css'),
     checkIfRequiredFileExists('frontend/dist/frontend/main.js'),
+    checkIfRequiredFileExists('frontend/dist/frontend/tutorial.js'),
     checkIfRequiredFileExists('frontend/dist/frontend/polyfills.js'),
     checkIfRequiredFileExists('frontend/dist/frontend/runtime.js'),
     checkIfRequiredFileExists('frontend/dist/frontend/vendor.js'),


### PR DESCRIPTION
### Description

_Please note that I am not an angular nor a frontend developer so my explanation might not be 100% technically correct. So feel free to edit this PR_

<!-- ✍️-->
Since, after version v15.0.0, the application has been incorrectly bundling tutorial.js within main.js, which is not the intended behavior. To address this issue, changes have been implemented to modify how hacking-isntructor is imported/used inside ChallengeCardComponent.

Previously, the ChallengeCardComponent utilized the imported functions hasInstructions and startHackingInstructorFor during its creation phase. With the change in this PR they are now imported during the component's initialization (init) lifecycle. This adjustment prevents tutorial.js from being bundled inside main.js, ensuring that the files remain separate as expected.

Additionally, tutorial.js has been added to lib/startup/validatePreconditions. This essentially reverts the changes made in this [commit](https://github.com/juice-shop/juice-shop/commit/d5988824bc8580a00cfcd52d4d40a99edfa41bc9). By adding tutorial.js back to the validatePreconditions directory, the application again verifies the presence of tutorial.js during startup. If tutorial.js is not found, the application will fail to start, which ensures that any future changes do not unintentionally cause tutorial.js to be bundled into main.js again without detection.

Resolved or fixed issue: #2317

![CleanShot 2025-01-04 at 02 15 24@2x](https://github.com/user-attachments/assets/63db522f-bf01-45e5-a95c-f75866277344)

![CleanShot 2025-01-04 at 02 24 36@2x](https://github.com/user-attachments/assets/2bf699bf-3f07-4492-854d-241f5e71fa98)





### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines

