### PR TITLE
Replace libxml with libxml2-wasm

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "jsonwebtoken": "0.4.0",
     "jssha": "^3.1.1",
     "juicy-chat-bot": "~0.8.0",
-    "libxmljs": "^1.0.11",
+    "libxml2-wasm": "0.5.0",
     "marsdb": "^0.6.11",
     "median": "^0.0.2",
     "morgan": "^1.10.0",


### PR DESCRIPTION
Tests #2421 

After these changes, I’m encountering TypeScript errors related to the Lodash type definitions

```
node_modules/@types/lodash/common/common.d.ts:262:65 - error TS1005: '?' expected.
node_modules/@types/lodash/common/object.d.ts:1026:46 - error TS1005: '?' expected.
node_modules/@types/lodash/common/object.d.ts:1031:46 - error TS1005: '?' expected.
node_modules/@types/lodash/common/object.d.ts:1041:46 - error TS1005: '?' expected.

Found 4 errors in 2 files.

Errors  Files
     1  node_modules/@types/lodash/common/common.d.ts:262
     3  node_modules/@types/lodash/common/object.d.ts:1026
```

I’m opening this Draft PR to explore potential fixes and to discuss any necessary adjustments