### PR TITLE
Fixed ForgotPasswordComponent and PasswordStrengthInfoComponent- Part of #2437 

### DIFF
--- a/frontend/src/app/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/forgot-password/forgot-password.component.html
@@ -81,6 +81,7 @@
 
         <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
         <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
+      <div class="advice-container">
         <app-password-strength-info *ngIf="passwordInfoToggle.checked" [passwordComponent]="passwordStrength"
                                     [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
                                     [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
@@ -88,7 +89,7 @@
                                     [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
                                     [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
         </app-password-strength-info>
-
+        </div>
       </div>
 
       <button type="submit" id="resetButton"

--- a/frontend/src/app/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/forgot-password/forgot-password.component.html
@@ -81,14 +81,14 @@
 
         <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
         <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
-      <div class="advice-container">
-        <app-password-strength-info *ngIf="passwordInfoToggle.checked" [passwordComponent]="passwordStrength"
-                                    [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
-                                    [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
-                                    [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
-                                    [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
-                                    [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
-        </app-password-strength-info>
+        <div class="advice-container">
+          <app-password-strength-info *ngIf="passwordInfoToggle.checked" [passwordComponent]="passwordStrength"
+                                      [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
+                                      [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
+                                      [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
+                                      [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
+                                      [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
+          </app-password-strength-info>
         </div>
       </div>
 

--- a/frontend/src/app/forgot-password/forgot-password.component.scss
+++ b/frontend/src/app/forgot-password/forgot-password.component.scss
@@ -26,3 +26,46 @@ button {
   margin-top: 30px;
   width: 60%;
 }
+
+mat-form-field {
+  input {
+    color: #fff !important; 
+  }
+
+  .mat-input-element::placeholder {
+    color: rgba(255, 255, 255, 0.5) !important;
+  }
+}
+
+#forgot-form {
+  mat-hint { 
+    color: #b0b0b0;
+    font-size: 0.8em;
+    font-style: italic; 
+  }
+}
+
+
+.advice-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+  padding-top: 15px;
+  position: relative;
+  
+  &::before {
+    background-color: rgba(255, 0, 0, 0.3);
+    border-radius: 2px;
+    content: '';
+    height: 3px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+  
+  app-password-strength-info {
+    max-width: 400px;
+    width: 100%;
+  }
+}

--- a/frontend/src/app/password-strength-info/password-strength-info.component.scss
+++ b/frontend/src/app/password-strength-info/password-strength-info.component.scss
@@ -1,0 +1,50 @@
+/*!
+ * Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+.info-card {
+  animation: cardEntrance 0.4s ease-out forwards;
+  box-sizing: border-box;
+  margin-top: 1rem;
+  width: 100%;
+
+  mat-card-content {
+    padding: 16px;
+  }
+}
+
+.info-row {
+  align-items: center;
+  animation: rowEntrance 0.3s ease-out forwards;
+  display: flex;
+  gap: 8px;
+  margin: 0.5rem 0;
+  opacity: 0;
+  transform: translateX(-20px);
+    
+  @for $i from 1 through 5 {
+    &:nth-child(#{$i}) {
+      animation-delay: $i * 0.1s;
+    }
+  }
+}
+  
+@keyframes cardEntrance {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+  
+@keyframes rowEntrance {
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
# Fixed ForgotPasswordComponent and PasswordStrengthInfoComponent- Part of #2437 

## Description  
This PR enhances the ForgotPasswordComponent with improved styling, and animations

## Changes  
- 🎨 **Visual Enhancements**  
  - Fixed email input text color to white (`#ffffff`)  
  - Added greyish hint text (`#b0b0b0`) for password requirements (font-size `0.8em`)  
  - Introduced CSS animations just as in demo.owasp-juice.shop:  
    - Card fade-in/slide-down (400ms)  
    - Criteria list staggered entrance (100ms delay per row)  
- 🖼️ **Layout Improvements**  
  - Centered password advice component with wrapper div  
  - Added semi-transparent red top border strip (`rgba(255,0,0,0.3)`)  

## Compliance  
- ✅ No hard-coded text modifications  
- ✅ Pure CSS animations (no JS logic changes)  
- ✅ Passes `npm run lint` and `npm test`  

## Testing  
| **Type**         | **Method**                                  | **Status** |  
|-------------------|--------------------------------------------|------------|  
| Desktop UI       | Side-by-side comparison with `develop`     | ✅ Passed  |  
| Animations       | Manual toggle validation                   | ✅ Passed  |  

## Notes for Reviewers  
- Animations use CSS `@keyframes` for reliability  
- Red top border uses `rgba()` for transparency  
- Subsequent PRs will address remaining components in #2437  

**Visual Comparison in Order (Demo, Before and After Changes) **  
![image](https://github.com/user-attachments/assets/000cbdcd-8088-472c-a1c7-fdfa30133365)
![image](https://github.com/user-attachments/assets/b3937a38-31ba-4680-804f-102409a14834)
![image](https://github.com/user-attachments/assets/835fe384-0fa5-42bf-9869-699408c16d1d)

---

**Signed-off-by:** [Ayushraj Singh Parihar] 