### PR TITLE
#2472 FIXED "ERR_INVALID_ARG_TYPE" ERROR

### DIFF
--- a/models/user.ts
+++ b/models/user.ts
@@ -45,7 +45,10 @@ const UserModelInit = (sequelize: Sequelize) => { // vuln-code-snippet start wea
       username: {
         type: DataTypes.STRING,
         defaultValue: '',
-        set (username: string) {
+        set(username: string) {
+          if (!username || typeof username !== 'string') {
+            throw new Error('Invalid username')
+          }
           if (utils.isChallengeEnabled(challenges.persistedXssUserChallenge)) {
             username = security.sanitizeLegacy(username)
           } else {
@@ -57,14 +60,17 @@ const UserModelInit = (sequelize: Sequelize) => { // vuln-code-snippet start wea
       email: {
         type: DataTypes.STRING,
         unique: true,
-        set (email: string) {
+        set(email: string) {
+          if (!email || typeof email !== 'string') {
+            throw new Error('Invalid email')
+          }
           if (utils.isChallengeEnabled(challenges.persistedXssUserChallenge)) {
             challengeUtils.solveIf(challenges.persistedXssUserChallenge, () => {
               return utils.contains(
                 email,
                 '<iframe src="javascript:alert(`xss`)">'
-              )
-            })
+              );
+            });
           } else {
             email = security.sanitizeSecure(email)
           }
@@ -73,7 +79,10 @@ const UserModelInit = (sequelize: Sequelize) => { // vuln-code-snippet start wea
       }, // vuln-code-snippet hide-end
       password: {
         type: DataTypes.STRING,
-        set (clearTextPassword: string) {
+        set(clearTextPassword: string) {
+          if (!clearTextPassword || typeof clearTextPassword !== 'string') {
+            throw new Error('Invalid password');
+          }
           this.setDataValue('password', security.hash(clearTextPassword)) // vuln-code-snippet vuln-line weakPasswordChallenge
         }
       }, // vuln-code-snippet end weakPasswordChallenge

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -24,8 +24,12 @@ module.exports = function getUserProfile () {
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
         UserModel.findByPk(loggedInUser.data.id).then((user: UserModel | null) => {
-          let template = buf.toString()
-          let username = user?.username
+          if (!user) {
+            throw new Error('User not found'); // Handle null user
+          }
+
+          let template = buf.toString();
+          let username = user?.username;
           if (username?.match(/#{(.*)}/) !== null && utils.isChallengeEnabled(challenges.usernameXssChallenge)) {
             req.app.locals.abused_ssti_bug = true
             const code = username?.substring(2, username.length - 1)
@@ -40,23 +44,32 @@ module.exports = function getUserProfile () {
           } else {
             username = '\\' + username
           }
+
           const theme = themes[config.get<string>('application.theme')]
           if (username) {
             template = template.replace(/_username_/g, username)
           }
-          template = template.replace(/_emailHash_/g, security.hash(user?.email))
-          template = template.replace(/_title_/g, entities.encode(config.get<string>('application.name')))
-          template = template.replace(/_favicon_/g, favicon())
-          template = template.replace(/_bgColor_/g, theme.bgColor)
-          template = template.replace(/_textColor_/g, theme.textColor)
-          template = template.replace(/_navColor_/g, theme.navColor)
-          template = template.replace(/_primLight_/g, theme.primLight)
-          template = template.replace(/_primDark_/g, theme.primDark)
-          template = template.replace(/_logo_/g, utils.extractFilename(config.get('application.logo')))
-          const fn = pug.compile(template)
-          const CSP = `img-src 'self' ${user?.profileImage}; script-src 'self' 'unsafe-eval' https://code.getmdl.io http://ajax.googleapis.com`
+
+          // Fix: Ensure email is always a string (fallback to empty)
+          const emailHash = security.hash(user.email || '');
+          template = template.replace(/_emailHash_/g, emailHash);
+
+          template = template.replace(/_title_/g, entities.encode(config.get<string>('application.name')));
+          template = template.replace(/_favicon_/g, favicon());
+          template = template.replace(/_bgColor_/g, theme.bgColor);
+          template = template.replace(/_textColor_/g, theme.textColor);
+          template = template.replace(/_navColor_/g, theme.navColor);
+          template = template.replace(/_primLight_/g, theme.primLight);
+          template = template.replace(/_primDark_/g, theme.primDark);
+          template = template.replace(/_logo_/g, utils.extractFilename(config.get('application.logo')));
+
+          const fn = pug.compile(template);
+          const CSP = `img-src 'self' ${user?.profileImage}; script-src 'self' 'unsafe-eval' https://code.getmdl.io http://ajax.googleapis.com`;
+
           // @ts-expect-error FIXME type issue with string vs. undefined for username
-          challengeUtils.solveIf(challenges.usernameXssChallenge, () => { return user?.profileImage.match(/;[ ]*script-src(.)*'unsafe-inline'/g) !== null && utils.contains(username, '<script>alert(`xss`)</script>') })
+          challengeUtils.solveIf(challenges.usernameXssChallenge, () => {
+            return user?.profileImage.match(/;[ ]*script-src(.)*'unsafe-inline'/g) !== null && utils.contains(username, '<script>alert(`xss`)</script>')
+          })
 
           res.set({
             'Content-Security-Policy': CSP


### PR DESCRIPTION
Fixed the "ERR_INVALID_ARG_TYPE" error in OWASP Juice Shop by ensuring user data is valid before processing. Here’s what changed:

Input Validation in 
user.ts:

Passwords, emails, and usernames are now checked to ensure they’re valid strings. If empty or invalid, the app throws clear errors like "Invalid password" instead of crashing.

Example: If you try to sign up with no password, it now blocks the request and tells you what’s wrong.

Safer Profile Handling in userProfile.ts:

Null user check: If a profile doesn’t exist (e.g., deleted account), the app now throws "User not found" instead of crashing.

Fallback for emails: If a user’s email is missing, it uses an empty string as a placeholder to avoid passing undefined to security functions.

![Screenshot 2025-02-13 221755](https://github.com/user-attachments/assets/b24e53a9-34f0-4225-9596-b2a5b933dea8)
