### PR TITLE
fix: responsive filter dropdowns #2502

### DIFF
--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.html
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.html
@@ -6,10 +6,10 @@
       <input type="search" matInput [value]="filterSetting.searchQuery" (input)="onSearchQueryFilterChange($event.target.value)">
     </mat-form-field>
   </div>
-  <div class="options-group">
-    <mat-form-field>
+  <div class="options-group filter-options-group">
+    <mat-form-field class="filter-select-field">
       <mat-label translate>LABEL_DIFFICULTY</mat-label>
-      <mat-select multiple [value]="filterSetting.difficulties" (selectionChange)="onDifficultyFilterChange($event.value)">
+      <mat-select multiple panelClass="responsive-select" [value]="filterSetting.difficulties" (selectionChange)="onDifficultyFilterChange($event.value)">
         <mat-select-trigger>
           <ng-container *ngIf="filterSetting.difficulties.length === 0">
             {{ "LABEL_DIFFICULTY" | translate }}
@@ -38,18 +38,18 @@
         </mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field>
+    <mat-form-field class="filter-select-field">
       <mat-label translate>LABEL_STATUS</mat-label>
-      <mat-select placeholder="All" [value]="filterSetting.status" (selectionChange)="onStatusFilterChange($event.value)">
+      <mat-select panelClass="responsive-select" placeholder="All" [value]="filterSetting.status" (selectionChange)="onStatusFilterChange($event.value)">
         <mat-option [value]="null" class="mat-body">{{ 'STATUS_ALL' | translate }}</mat-option>
         <mat-option value="unsolved" class="mat-body">{{ 'STATUS_UNSOLVED' | translate }}</mat-option>
         <mat-option value="partially-solved" class="mat-body">{{ 'STATUS_PARTIALLY_SOLVED' | translate }}</mat-option>
         <mat-option value="solved" class="mat-body">{{ 'STATUS_SOLVED' | translate }}</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field>
+    <mat-form-field class="filter-select-field">
       <mat-label translate>LABEL_TAGS</mat-label>
-      <mat-select multiple [value]="filterSetting.tags" (selectionChange)="onTagFilterChange($event.value)">
+      <mat-select multiple panelClass="responsive-select" [value]="filterSetting.tags" (selectionChange)="onTagFilterChange($event.value)">
         <mat-option *ngFor="let tag of tags" [value]="tag" class="mat-body">{{ tag }}</mat-option>
       </mat-select>
     </mat-form-field>

--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
@@ -46,15 +46,6 @@
   }
 }
 
-.reset-filters-label {
-  color: var(--theme-text-fade-30);
-  @media (min-width: 800px) {
-    // hide the reset filters label on large screens
-    // not needed there and the button looks too alone and unexplained on smaller screens without it
-    display: none;
-  }
-}
-
 .additional-settings-wrapper {
   align-items: center;
   display: flex;
@@ -71,5 +62,14 @@
     height: 16px;
     line-height: 16px;
     width: 16px;
+  }
+}
+
+.filter-select-field {
+  width: 100%;
+  @media (max-width: 800px) {
+    mat-select {
+      width: 100%;
+    }
   }
 }


### PR DESCRIPTION
### Description

<!-- ✍️-->
This PR fixes the layout issues with mat-select elements in the Filter Settings Component on small display sizes. The changes resolve merge conflicts between branches (specifically between the original PR and the updates in the angular17 branch) by:

Updating the HTML to correctly apply the placeholder and class attributes for proper styling.
Adjusting the SCSS to ensure that grid layouts and responsive behaviors are maintained on smaller screens.

Resolved or fixed issue: Part of <!--#2437 -->

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
