### PR TITLE
GWEI fixed - indentation issue persists

### DIFF
--- a/frontend/src/app/web3-sandbox/web3-sandbox.component.html
+++ b/frontend/src/app/web3-sandbox/web3-sandbox.component.html
@@ -56,35 +56,35 @@
       </div>
       <div *ngIf="compiledContracts">
         <h3 class="contracts-title">{{ "TITLE_CONTRACT_DEPLOYMENT" | translate}}</h3>
-      <div class="form-fields-container">
-        <mat-form-field
-          class="contract-selector"
-          appearance="outline"
-          color="accent"
-        >
-          <mat-label>{{ "LABEL_COMPILED_CONTRACTS" | translate}}</mat-label>
-          <select matNativeControl [(ngModel)]="selectedContractName">
-            <option
-              *ngFor="let contractName of contractNames"
-              [value]="contractName"
-            >
-              {{ contractName }}
-            </option>
-          </select>
-        </mat-form-field>
-        <mat-form-field
-          class="gwei-input"
-          appearance="outline"
-          color="accent"
-        >
-          <mat-label>{{ "GWEI_VALUE_FOR_SENDING_ETH" | translate }}</mat-label>
-          <input
-            matInput
-            type="number"
-            [(ngModel)]="commonGweiValue"
-          />
-        </mat-form-field>
-          </div>
+        <div class="form-fields-container">
+          <mat-form-field
+            class="contract-selector"
+            appearance="outline"
+            color="accent"
+          >
+            <mat-label>{{ "LABEL_COMPILED_CONTRACTS" | translate}}</mat-label>
+            <select matNativeControl [(ngModel)]="selectedContractName">
+              <option
+                *ngFor="let contractName of contractNames"
+                [value]="contractName"
+              >
+                {{ contractName }}
+              </option>
+            </select>
+          </mat-form-field>
+          <mat-form-field
+            class="gwei-input"
+            appearance="outline"
+            color="accent"
+          >
+            <mat-label>{{ "GWEI_VALUE_FOR_SENDING_ETH" | translate }}</mat-label>
+            <input
+              matInput
+              type="number"
+              [(ngModel)]="commonGweiValue"
+            />
+          </mat-form-field>
+        </div>
         <button
           mat-raised-button
           type="button"

--- a/frontend/src/app/web3-sandbox/web3-sandbox.component.html
+++ b/frontend/src/app/web3-sandbox/web3-sandbox.component.html
@@ -56,8 +56,9 @@
       </div>
       <div *ngIf="compiledContracts">
         <h3 class="contracts-title">{{ "TITLE_CONTRACT_DEPLOYMENT" | translate}}</h3>
+      <div class="form-fields-container">
         <mat-form-field
-          style="width: 45%; margin-right: 10%"
+          class="contract-selector"
           appearance="outline"
           color="accent"
         >
@@ -71,14 +72,19 @@
             </option>
           </select>
         </mat-form-field>
-        <mat-form-field>
+        <mat-form-field
+          class="gwei-input"
+          appearance="outline"
+          color="accent"
+        >
+          <mat-label>{{ "GWEI_VALUE_FOR_SENDING_ETH" | translate }}</mat-label>
           <input
             matInput
             type="number"
-            [placeholder]="'GWEI_VALUE_FOR_SENDING_ETH' | translate"
             [(ngModel)]="commonGweiValue"
           />
         </mat-form-field>
+          </div>
         <button
           mat-raised-button
           type="button"

--- a/frontend/src/app/web3-sandbox/web3-sandbox.component.scss
+++ b/frontend/src/app/web3-sandbox/web3-sandbox.component.scss
@@ -118,3 +118,21 @@ ul {
   font-weight: 500;
   margin-top: 16px;
 }
+
+.form-fields-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.contract-selector {
+  flex: 1 1 60%;
+  min-width: 200px;
+}
+
+.gwei-input {
+  flex: 1 1 30%;
+  min-width: 150px;
+}


### PR DESCRIPTION
Small fixes because GWEI input element wasn't visible

- The GWEI element input box wasn't visible. The main fix was to change the text (GWEI_VALUE_FOR_SENDING_ETH) from placeholder to a mat-label. 
- Other fixes are just normal CSS which are to make that box a bit more responsive (we can live without it too)
- Indentation is not fixed because the changes won't be clearly visible if I indented it properly (If I indent it, the whole code block was shown as changed so). If these changes get a green light, I will indent it and push it. 

### Affirmation

- [ ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
