### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:20-buster as installer
 COPY . /juice-shop
 WORKDIR /juice-shop
 RUN npm i -g typescript ts-node
+ENV NODE_OPTIONS=--max-old-space-size=4096 
 RUN npm install --omit=dev --unsafe-perm
 RUN npm dedupe --omit=dev
 RUN rm -rf frontend/node_modules


### PR DESCRIPTION
### Description

the juice-shop build in docker in docker environment is likely failing at the npm install --omit=dev --unsafe-perm step with the error:

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory npm error code 134

This means the Node.js process is running out of memory during the install, which is common in CI/CD or Docker environments with limited memory.

How to fix:

You can increase the memory available to Node.js during the build by setting the NODE_OPTIONS environment variable.


Resolved or fixed issue: 

could not find a similar issue

### Affirmation

- [ x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
