### PR TITLE
Fix zero star feedback challenge not detecting if slider has been moved

### DIFF
--- a/frontend/src/app/contact/contact.component.html
+++ b/frontend/src/app/contact/contact.component.html
@@ -34,8 +34,8 @@
 
         <div class="rating-container">
           <label style="font-weight:500; margin-right: 8px; float:left;" translate>LABEL_RATING</label>
-          <mat-slider id="rating" ngDefaultControl [(ngModel)]="rating" min="1" max="5" step="1" showTickMarks discrete [displayWith]="formatRating" aria-label="Slider for selecting the star rating">
-            <input matSliderThumb />
+          <mat-slider id="rating" min="1" max="5" step="1" showTickMarks discrete [displayWith]="formatRating" aria-label="Slider for selecting the star rating">
+            <input matSliderThumb [(ngModel)]="rating" />
           </mat-slider>
         </div>
 


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
The zero star feedback challenge currently fails to detect if the user moves the slider before enabling the submit button (editing the min value to make selecting zero possible), even though a zero star feedback is persisted in the database. The reason for this is, that the rating variable is bound to the mat-slider (via ngDefaultControl), which causes the value of the rating to be of type string instead of number. This also causes confusion when trying to solve the challenge by modifying the API request, as most users will intuitively keep the type that can be observed in the request normally performed by the frontend.

This PR moves the binding to the sliderThumb, which is the correct place according to the material documentation, resolving the issue.

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
