### PR TITLE
Switch to `libxml2-wasm` to lessen issues with native bindings with `libxmljs`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,6 @@ ARG CYCLONEDX_NPM_VERSION=latest
 RUN npm install -g @cyclonedx/cyclonedx-npm@$CYCLONEDX_NPM_VERSION
 RUN npm run sbom
 
-# workaround for libxmljs startup error
-FROM node:22 AS libxmljs-builder
-WORKDIR /juice-shop
-RUN apt-get update && apt-get install -y build-essential python3
-COPY --from=installer /juice-shop/node_modules ./node_modules
-RUN rm -rf node_modules/libxmljs/build && \
-  cd node_modules/libxmljs && \
-  npm run build
-
 FROM gcr.io/distroless/nodejs22-debian12
 ARG BUILD_DATE
 ARG VCS_REF
@@ -45,7 +36,6 @@ LABEL maintainer="Bjoern Kimminich <bjoern.kimminich@owasp.org>" \
     org.opencontainers.image.created=$BUILD_DATE
 WORKDIR /juice-shop
 COPY --from=installer --chown=65532:0 /juice-shop .
-COPY --chown=65532:0 --from=libxmljs-builder /juice-shop/node_modules/libxmljs ./node_modules/libxmljs
 USER 65532
 EXPOSE 3000
 CMD ["/juice-shop/build/app.js"]

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ For a detailed introduction, full list of features and architecture overview ple
 4. Run `npm start`
 5. Browse to <http://localhost:3000>
 
-> Each packaged distribution includes some binaries for `sqlite3` and
-> `libxmljs` bound to the OS and node.js version which `npm install` was
+> Each packaged distribution includes some binaries for `sqlite3`
+> bound to the OS and node.js version which `npm install` was
 > executed on.
 
 ### Docker Container
@@ -148,8 +148,6 @@ offered accordingly.
 Juice Shop is automatically tested _only on the latest `.x` minor version_ of each node.js version mentioned above!
 There is no guarantee that older minor node.js releases will always work with Juice Shop!
 Please make sure you stay up to date with your chosen version.
-
-\*=:warning: _There are no pre-built binaries for `libxmljs` available for Node.js versions greater than 20.x. In order to build Juice Shop from source locally, you need to have all C++ build tools installed that are needed to compile those binaries locally. In the packaged distributions theses binaries are already included. We are working on a pure JavaScript replacement of `libxmljs` in [#2421](https://github.com/juice-shop/juice-shop/issues/2421). Contributions are highly welcome!_
 
 ### Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "jsonwebtoken": "0.4.0",
     "jssha": "^3.3.1",
     "juicy-chat-bot": "^0.8.0",
-    "libxmljs": "^1.0.11",
+    "libxml2-wasm": "^0.5.0",
     "marsdb": "^0.6.11",
     "median": "^0.0.2",
     "morgan": "^1.10.0",

--- a/test/api/chatBotSpec.ts
+++ b/test/api/chatBotSpec.ts
@@ -307,7 +307,6 @@ describe('/chatbot', () => {
           query: testCommand
         }
       })
-        .inspectResponse()
         .expect('status', 500)
         .promise()
     })

--- a/test/api/fileUploadSpec.ts
+++ b/test/api/fileUploadSpec.ts
@@ -101,7 +101,7 @@ describe('/file-upload', () => {
         body: form
       })
         .expect('status', 410)
-        .expect('bodyContains', 'Detected an entity reference loop')
+        .expect('bodyContains', 'Maximum entity amplification factor exceeded')
     })
 
     it('POST file type XML with Quadratic Blowup attack', () => {


### PR DESCRIPTION
### Description

Closes #2421

Replaces libxml native binding lib with a wasm based alternative which should allow us to suffer less from issues with native binding not being available.

This should also make us compatible with the newest node version.

Unfortunatly due to the sandboxing of wasm some XXE challenge File Access challenges needed to be simiulated / checked using regexes. Not ideal, let me know if anybody has suggestion is this is missing something.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
