### PR TITLE
Make ignored user agents for /metrics route configurable

### DIFF
--- a/config.schema.yml
+++ b/config.schema.yml
@@ -132,6 +132,8 @@ challenges:
     type: boolean
   csafHashValue:
     type: string
+  metricsIgnoredUserAgents:
+    - type: string
 hackingInstructor:
   isEnabled:
     type: boolean

--- a/config/default.yml
+++ b/config/default.yml
@@ -82,6 +82,11 @@ challenges:
   safetyMode: auto
   showFeedbackButtons: true
   csafHashValue: 7e7ce7c65db3bf0625fcea4573d25cff41f2f7e3474f2c74334b14fc65bb4fd26af802ad17a3a03bf0eee6827a00fb8f7905f338c31b5e6ea9cb31620242e843
+  metricsIgnoredUserAgents:
+    - 'Prometheus'
+    - 'Alloy'
+    - 'promscrape'
+    - 'otelcol'
 hackingInstructor:
   isEnabled: true
   avatarImage: JuicyBot.png

--- a/routes/metrics.ts
+++ b/routes/metrics.ts
@@ -67,7 +67,8 @@ export function serveMetrics () {
   return async (req: Request, res: Response, next: NextFunction) => {
     challengeUtils.solveIf(challenges.exposedMetricsChallenge, () => {
       const userAgent = req.headers['user-agent'] ?? ''
-      return !userAgent.includes('Prometheus')
+      const ignoredUserAgents = config.get<string[]>('challenges.metricsIgnoredUserAgents')
+      return !ignoredUserAgents.some((ignoredUserAgent) => userAgent.includes(ignoredUserAgent))
     })
     res.set('Content-Type', register.contentType)
     res.end(await register.metrics())


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->

Add a configuration option to make ignored useragent fragements for the /metrics challenge configurable, and default to some common monitoring tools.

Resolved or fixed issue: #2625 

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
