### PR TITLE
Change hostname in Vagrantfile from juice.sh to test.sh

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -6,7 +6,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/ubuntu2110"
-  config.vm.hostname = "juice.sh"
+  config.vm.hostname = "test.sh"
 
   config.vm.network "private_network", ip: "192.168.56.110"
   config.vm.provision "file", source: "./default.conf", destination: "/tmp/juice-shop/default.conf"


### PR DESCRIPTION
Modified the hostname in Vagrantfile to `test.sh` to reflect updated hostname value. Validation and approval required.