### PR TITLE
Migrated templates to the new Angular control flow syntax.

### DIFF
--- a/frontend/src/app/about/about.component.html
+++ b/frontend/src/app/about/about.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-elevation-z6">

--- a/frontend/src/app/about/about.component.html
+++ b/frontend/src/app/about/about.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" class="mat-elevation-z6">
   <div class="mdc-card">
@@ -35,45 +35,65 @@
 
       <h3><span>{{"SECTION_CUSTOMER_FEEDBACK" | translate}}</span></h3>
       <gallery id="feedback-gallery"
-               style="height: 300px;"
-               [autoPlay]="true"
-               [thumb]="false"
-               [counter]="false"
-               [imageSize]="'cover'"
-               >
-                <ng-container *galleryImageDef="let item; let active = active">
-                  <div *ngIf="active" class="item-text">
-                    <div class="caption" [innerHTML]="item?.args"></div>
-                  </div>
-                </ng-container>
+        style="height: 300px;"
+        [autoPlay]="true"
+        [thumb]="false"
+        [counter]="false"
+        [imageSize]="'cover'"
+        >
+        <ng-container *galleryImageDef="let item; let active = active">
+          @if (active) {
+            <div class="item-text">
+              <div class="caption" [innerHTML]="item?.args"></div>
+            </div>
+          }
+        </ng-container>
       </gallery>
-      <div *ngIf="blueSkyUrl || mastodonUrl || twitterUrl || facebookUrl || slackUrl || redditUrl || pressKitUrl || nftUrl" class="social">
-        <h3><span>{{"SECTION_SOCIAL_MEDIA" | translate }}</span></h3>
-      <a *ngIf="blueSkyUrl" [href]="blueSkyUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 0px;" aria-label="Button for the BlueSky page of the shop">
-        <button mat-raised-button color="accent"><i class="fas fa-bold fa-lg"></i> BlueSky</button>
-      </a>
-      <a *ngIf="mastodonUrl" [href]="mastodonUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 0px;" aria-label="Button for the Mastodon page of the shop">
-        <button mat-raised-button color="accent"><i class="fab fa-mastodon fa-lg"></i> Mastodon</button>
-      </a>
-        <a *ngIf="twitterUrl" [href]="twitterUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 0px;" aria-label="Button for the Twitter page of the shop">
-          <button mat-raised-button color="accent"><i class="fab fa-twitter fa-lg"></i> Twitter</button>
-        </a>
-        <a *ngIf="facebookUrl" [href]="facebookUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the Facebook page of the shop">
-          <button mat-raised-button color="accent"><i class="fab fa-facebook fa-lg"></i> Facebook</button>
-        </a>
-        <a *ngIf="slackUrl" [href]="slackUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the Slack page of the shop">
-          <button mat-raised-button color="accent"><i class="fab fa-slack fa-lg"></i> Slack</button>
-        </a>
-        <a *ngIf="redditUrl" [href]="redditUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the Reddit page of the shop">
-          <button mat-raised-button color="accent"><i class="fab fa-reddit fa-lg"></i> Reddit</button>
-        </a>
-        <a *ngIf="pressKitUrl" [href]="pressKitUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the PressKit page of the shop">
-          <button mat-raised-button color="accent"><i class="far fa-newspaper fa-lg"></i> Press Kit</button>
-        </a>
-        <a *ngIf="nftUrl" [href]="nftUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the NFT of the shop">
-          <button mat-raised-button color="accent"><i class="fas fa-palette fa-lg"></i> NFT</button>
-        </a>
-      </div>
+      @if (blueSkyUrl || mastodonUrl || twitterUrl || facebookUrl || slackUrl || redditUrl || pressKitUrl || nftUrl) {
+        <div class="social">
+          <h3><span>{{"SECTION_SOCIAL_MEDIA" | translate }}</span></h3>
+          @if (blueSkyUrl) {
+            <a [href]="blueSkyUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 0px;" aria-label="Button for the BlueSky page of the shop">
+              <button mat-raised-button color="accent"><i class="fas fa-bold fa-lg"></i> BlueSky</button>
+            </a>
+          }
+          @if (mastodonUrl) {
+            <a [href]="mastodonUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 0px;" aria-label="Button for the Mastodon page of the shop">
+              <button mat-raised-button color="accent"><i class="fab fa-mastodon fa-lg"></i> Mastodon</button>
+            </a>
+          }
+          @if (twitterUrl) {
+            <a [href]="twitterUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 0px;" aria-label="Button for the Twitter page of the shop">
+              <button mat-raised-button color="accent"><i class="fab fa-twitter fa-lg"></i> Twitter</button>
+            </a>
+          }
+          @if (facebookUrl) {
+            <a [href]="facebookUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the Facebook page of the shop">
+              <button mat-raised-button color="accent"><i class="fab fa-facebook fa-lg"></i> Facebook</button>
+            </a>
+          }
+          @if (slackUrl) {
+            <a [href]="slackUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the Slack page of the shop">
+              <button mat-raised-button color="accent"><i class="fab fa-slack fa-lg"></i> Slack</button>
+            </a>
+          }
+          @if (redditUrl) {
+            <a [href]="redditUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the Reddit page of the shop">
+              <button mat-raised-button color="accent"><i class="fab fa-reddit fa-lg"></i> Reddit</button>
+            </a>
+          }
+          @if (pressKitUrl) {
+            <a [href]="pressKitUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the PressKit page of the shop">
+              <button mat-raised-button color="accent"><i class="far fa-newspaper fa-lg"></i> Press Kit</button>
+            </a>
+          }
+          @if (nftUrl) {
+            <a [href]="nftUrl" target="_blank" rel="noopener noreferrer" aria-label="Button for the NFT of the shop">
+              <button mat-raised-button color="accent"><i class="fas fa-palette fa-lg"></i> NFT</button>
+            </a>
+          }
+        </div>
+      }
     </section>
   </div>
 </mat-card>

--- a/frontend/src/app/about/about.component.ts
+++ b/frontend/src/app/about/about.component.ts
@@ -15,7 +15,7 @@ import { faStar as fasStar, faPalette, faBold } from '@fortawesome/free-solid-sv
 import { catchError } from 'rxjs/operators'
 import { EMPTY } from 'rxjs'
 import { MatButtonModule } from '@angular/material/button'
-import { NgIf } from '@angular/common'
+
 import { TranslateModule } from '@ngx-translate/core'
 import { MatCardModule } from '@angular/material/card'
 
@@ -25,7 +25,7 @@ library.add(faFacebook, faTwitter, faSlack, faReddit, faNewspaper, faStar, fasSt
   selector: 'app-about',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss'],
-  imports: [MatCardModule, TranslateModule, GalleryComponent, GalleryImageDef, NgIf, MatButtonModule]
+  imports: [MatCardModule, TranslateModule, GalleryComponent, GalleryImageDef, MatButtonModule]
 })
 export class AboutComponent implements OnInit {
   public blueSkyUrl?: string

--- a/frontend/src/app/accounting/accounting.component.html
+++ b/frontend/src/app/accounting/accounting.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" class="mat-elevation-z6 mat-own-card">
   <div class="mdc-card">
@@ -26,28 +26,36 @@
           <ng-container matColumnDef="Status">
             <mat-header-cell *matHeaderCellDef translate="LABEL_STATUS" style="max-width: 96px;"></mat-header-cell>
             <mat-cell *matCellDef="let element" style="max-width: 96px;">
-              <div *ngIf="!element.delivered" class="error" translate>LABEL_IN_TRANSIT</div>
-              <div *ngIf="element.delivered" class="confirmation" translate>LABEL_DELIVERED</div>
+              @if (!element.delivered) {
+                <div class="error" translate>LABEL_IN_TRANSIT</div>
+              }
+              @if (element.delivered) {
+                <div class="confirmation" translate>LABEL_DELIVERED</div>
+              }
             </mat-cell>
           </ng-container>
 
           <ng-container matColumnDef="StatusButton">
             <mat-header-cell *matHeaderCellDef style="max-width: 96px;"></mat-header-cell>
             <mat-cell *matCellDef="let element" style="max-width: 96px;">
-              <button *ngIf="element.delivered" mat-icon-button aria-label="Print order confirmation"
-                      matTooltip="{{ 'LABEL_MARK_AS_TRANSIT' | translate }}" matTooltipPosition="below"
-                      (click)="changeDeliveryStatus(element.delivered, element.id)">
-                <mat-icon>
-                  cached
-                </mat-icon>
-              </button>
-              <button *ngIf="!element.delivered" mat-icon-button aria-label="Print order confirmation"
-                      matTooltip="{{ 'LABEL_MARK_AS_DELIVERED' | translate }}" matTooltipPosition="below"
-                      (click)="changeDeliveryStatus(element.delivered, element.id)">
-                <mat-icon>
-                  check_circle
-                </mat-icon>
-              </button>
+              @if (element.delivered) {
+                <button mat-icon-button aria-label="Print order confirmation"
+                  matTooltip="{{ 'LABEL_MARK_AS_TRANSIT' | translate }}" matTooltipPosition="below"
+                  (click)="changeDeliveryStatus(element.delivered, element.id)">
+                  <mat-icon>
+                    cached
+                  </mat-icon>
+                </button>
+              }
+              @if (!element.delivered) {
+                <button mat-icon-button aria-label="Print order confirmation"
+                  matTooltip="{{ 'LABEL_MARK_AS_DELIVERED' | translate }}" matTooltipPosition="below"
+                  (click)="changeDeliveryStatus(element.delivered, element.id)">
+                  <mat-icon>
+                    check_circle
+                  </mat-icon>
+                </button>
+              }
             </mat-cell>
           </ng-container>
 
@@ -57,9 +65,9 @@
         </mat-table>
 
         <mat-paginator #paginatorOrderHistory
-                      [pageSize]="10"
-                      class="mat-elevation-z0"
-                      color="accent">
+          [pageSize]="10"
+          class="mat-elevation-z0"
+          color="accent">
         </mat-paginator>
       </div>
 
@@ -79,35 +87,35 @@
               <mat-form-field class="input-field">
                 <input #price matInput type="number" value="{{ element.price }}">
                 <button mat-icon-button (click)="modifyPrice(element.id, price.value)" matSuffix><i
-                  class="fas fa-check"></i>
-                </button>
-              </mat-form-field>
-            </mat-cell>
-          </ng-container>
+                class="fas fa-check"></i>
+              </button>
+            </mat-form-field>
+          </mat-cell>
+        </ng-container>
 
-          <ng-container matColumnDef="Quantity">
-            <mat-header-cell *matHeaderCellDef translate="LABEL_QUANTITY"></mat-header-cell>
-            <mat-cell *matCellDef="let element">
-              <mat-form-field class="input-field">
-                <input #quanitity matInput type="number" value="{{ quantityMap[element.id].quantity }}">
-                <button mat-icon-button (click)="modifyQuantity(quantityMap[element.id].id, quanitity.value)" matSuffix>
-                  <i class="fas fa-check"></i>
-                </button>
-              </mat-form-field>
-            </mat-cell>
-          </ng-container>
+        <ng-container matColumnDef="Quantity">
+          <mat-header-cell *matHeaderCellDef translate="LABEL_QUANTITY"></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <mat-form-field class="input-field">
+              <input #quanitity matInput type="number" value="{{ quantityMap[element.id].quantity }}">
+              <button mat-icon-button (click)="modifyQuantity(quantityMap[element.id].id, quanitity.value)" matSuffix>
+                <i class="fas fa-check"></i>
+              </button>
+            </mat-form-field>
+          </mat-cell>
+        </ng-container>
 
-          <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-          <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
 
-        </mat-table>
+      </mat-table>
 
-        <mat-paginator #paginator
-                      [pageSize]="10"
-                      class="mat-elevation-z0"
-                      color="accent">
-        </mat-paginator>
-      </div>
+      <mat-paginator #paginator
+        [pageSize]="10"
+        class="mat-elevation-z0"
+        color="accent">
+      </mat-paginator>
     </div>
   </div>
+</div>
 </mat-card>

--- a/frontend/src/app/accounting/accounting.component.html
+++ b/frontend/src/app/accounting/accounting.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-elevation-z6 mat-own-card">

--- a/frontend/src/app/accounting/accounting.component.html
+++ b/frontend/src/app/accounting/accounting.component.html
@@ -26,11 +26,10 @@
           <ng-container matColumnDef="Status">
             <mat-header-cell *matHeaderCellDef translate="LABEL_STATUS" style="max-width: 96px;"></mat-header-cell>
             <mat-cell *matCellDef="let element" style="max-width: 96px;">
-              @if (!element.delivered) {
-                <div class="error" translate>LABEL_IN_TRANSIT</div>
-              }
               @if (element.delivered) {
-                <div class="confirmation" translate>LABEL_DELIVERED</div>
+              <div class="confirmation" translate>LABEL_DELIVERED</div>
+              } @else {
+              <div class="error" translate>LABEL_IN_TRANSIT</div>
               }
             </mat-cell>
           </ng-container>
@@ -46,8 +45,7 @@
                     cached
                   </mat-icon>
                 </button>
-              }
-              @if (!element.delivered) {
+              } @else {
                 <button mat-icon-button aria-label="Print order confirmation"
                   matTooltip="{{ 'LABEL_MARK_AS_DELIVERED' | translate }}" matTooltipPosition="below"
                   (click)="changeDeliveryStatus(element.delivered, element.id)">
@@ -87,35 +85,35 @@
               <mat-form-field class="input-field">
                 <input #price matInput type="number" value="{{ element.price }}">
                 <button mat-icon-button (click)="modifyPrice(element.id, price.value)" matSuffix><i
-                class="fas fa-check"></i>
-              </button>
-            </mat-form-field>
-          </mat-cell>
-        </ng-container>
+                    class="fas fa-check"></i>
+                </button>
+              </mat-form-field>
+            </mat-cell>
+          </ng-container>
 
-        <ng-container matColumnDef="Quantity">
-          <mat-header-cell *matHeaderCellDef translate="LABEL_QUANTITY"></mat-header-cell>
-          <mat-cell *matCellDef="let element">
-            <mat-form-field class="input-field">
-              <input #quanitity matInput type="number" value="{{ quantityMap[element.id].quantity }}">
-              <button mat-icon-button (click)="modifyQuantity(quantityMap[element.id].id, quanitity.value)" matSuffix>
-                <i class="fas fa-check"></i>
-              </button>
-            </mat-form-field>
-          </mat-cell>
-        </ng-container>
+          <ng-container matColumnDef="Quantity">
+            <mat-header-cell *matHeaderCellDef translate="LABEL_QUANTITY"></mat-header-cell>
+            <mat-cell *matCellDef="let element">
+              <mat-form-field class="input-field">
+                <input #quanitity matInput type="number" value="{{ quantityMap[element.id].quantity }}">
+                <button mat-icon-button (click)="modifyQuantity(quantityMap[element.id].id, quanitity.value)" matSuffix>
+                  <i class="fas fa-check"></i>
+                </button>
+              </mat-form-field>
+            </mat-cell>
+          </ng-container>
 
-        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-        <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+          <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
 
-      </mat-table>
+        </mat-table>
 
       <mat-paginator #paginator
         [pageSize]="10"
         class="mat-elevation-z0"
         color="accent">
-      </mat-paginator>
+        </mat-paginator>
+      </div>
     </div>
   </div>
-</div>
 </mat-card>

--- a/frontend/src/app/accounting/accounting.component.ts
+++ b/frontend/src/app/accounting/accounting.component.ts
@@ -18,7 +18,6 @@ import { MatFormFieldModule, MatSuffix } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconButton } from '@angular/material/button'
-import { NgIf } from '@angular/common'
 
 import { TranslateModule } from '@ngx-translate/core'
 import { MatCardModule } from '@angular/material/card'
@@ -36,7 +35,7 @@ interface Order {
   selector: 'app-accounting',
   templateUrl: './accounting.component.html',
   styleUrls: ['./accounting.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, NgIf, MatIconButton, MatTooltip, MatIconModule, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatPaginator, MatFormFieldModule, MatInputModule, MatSuffix]
+  imports: [MatCardModule, TranslateModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatIconButton, MatTooltip, MatIconModule, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatPaginator, MatFormFieldModule, MatInputModule, MatSuffix]
 })
 export class AccountingComponent implements AfterViewInit, OnDestroy {
   public orderHistoryColumns = ['OrderId', 'Price', 'Status', 'StatusButton']

--- a/frontend/src/app/address-create/address-create.component.html
+++ b/frontend/src/app/address-create/address-create.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="page-center">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -12,40 +12,49 @@
         <mat-form-field appearance="outline" color="accent">
           <mat-label>{{ 'LABEL_COUNTRY' | translate }}</mat-label>
           <input [formControl]="countryControl" type="text" [placeholder]="'MANDATORY_COUNTRY' | translate" matInput>
-          <mat-error *ngIf="countryControl.invalid && countryControl.errors.required">
-            {{ 'MANDATORY_COUNTRY' | translate }}
-          </mat-error>
+          @if (countryControl.invalid && countryControl.errors.required) {
+            <mat-error>
+              {{ 'MANDATORY_COUNTRY' | translate }}
+            </mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline" color="accent">
           <mat-label>{{ 'LABEL_NAME' | translate }}</mat-label>
           <input [formControl]="nameControl" type="text" [placeholder]="'MANDATORY_NAME' | translate" matInput>
-          <mat-error *ngIf="nameControl.invalid && nameControl.errors.required">
-            {{ 'MANDATORY_NAME' | translate }}
-          </mat-error>
+          @if (nameControl.invalid && nameControl.errors.required) {
+            <mat-error>
+              {{ 'MANDATORY_NAME' | translate }}
+            </mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline" color="accent">
           <mat-label>{{ 'LABEL_MOBILE_NUMBER' | translate }}</mat-label>
           <input [formControl]="numberControl" type="number" [placeholder]="'MANDATORY_NUMBER' | translate" matInput>
-          <mat-error *ngIf="numberControl.invalid && numberControl.errors.required">
-            {{ 'MANDATORY_NUMBER' | translate }}
-          </mat-error>
-          <mat-error
-            *ngIf="numberControl.invalid && (numberControl.errors.min || numberControl.errors.max)"
-            [translateParams]="{range: '1000000-9999999999'}"
-          >
-            {{ 'INVALID_MOBILE_NUMBER' | translate }}
-          </mat-error>
+          @if (numberControl.invalid && numberControl.errors.required) {
+            <mat-error>
+              {{ 'MANDATORY_NUMBER' | translate }}
+            </mat-error>
+          }
+          @if (numberControl.invalid && (numberControl.errors.min || numberControl.errors.max)) {
+            <mat-error
+              [translateParams]="{range: '1000000-9999999999'}"
+              >
+              {{ 'INVALID_MOBILE_NUMBER' | translate }}
+            </mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline" color="accent">
           <mat-label>{{ 'LABEL_ZIP_CODE' | translate }}</mat-label>
           <input #pin [formControl]="pinControl" type="text" [placeholder]="'MANDATORY_ZIP' | translate" matInput>
           <mat-hint align="end">{{ pin.value?.length || 0 }}/8</mat-hint>
-          <mat-error *ngIf="pinControl.invalid && pinControl.errors.required">
-            {{ 'MANDATORY_ZIP' | translate }}
-          </mat-error>
+          @if (pinControl.invalid && pinControl.errors.required) {
+            <mat-error>
+              {{ 'MANDATORY_ZIP' | translate }}
+            </mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline" color="accent" class="textarea-field">
@@ -67,17 +76,21 @@
             <em style="margin-left:5px;">{{ 'MAX_TEXTAREA_LENGTH' | translate: { length: '160' } }}</em>
           </mat-hint>
           <mat-hint align="end">{{ adress.value?.length || 0 }}/160</mat-hint>
-          <mat-error *ngIf="addressControl.invalid && addressControl.errors.required">
-            {{ 'MANDATORY_ADDRESS' | translate }}
-          </mat-error>
+          @if (addressControl.invalid && addressControl.errors.required) {
+            <mat-error>
+              {{ 'MANDATORY_ADDRESS' | translate }}
+            </mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline" color="accent">
           <mat-label>{{ 'LABEL_CITY' | translate }}</mat-label>
           <input [formControl]="cityControl" type="text" [placeholder]="'MANDATORY_CITY' | translate" matInput>
-          <mat-error *ngIf="cityControl.invalid && cityControl.errors.required">
-            {{ 'MANDATORY_CITY' | translate }}
-          </mat-error>
+          @if (cityControl.invalid && cityControl.errors.required) {
+            <mat-error>
+              {{ 'MANDATORY_CITY' | translate }}
+            </mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline" color="accent">
@@ -99,7 +112,7 @@
           color="primary"
           [disabled]="countryControl.invalid || nameControl.invalid || numberControl.invalid || pinControl.invalid || addressControl.invalid || cityControl.invalid"
           (click)="save()"
-        >
+          >
           <mat-icon>send</mat-icon>
           {{ 'BTN_SUBMIT' | translate }}
         </button>

--- a/frontend/src/app/address-create/address-create.component.html
+++ b/frontend/src/app/address-create/address-create.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="page-center">

--- a/frontend/src/app/address-create/address-create.component.ts
+++ b/frontend/src/app/address-create/address-create.component.ts
@@ -8,7 +8,7 @@ import { Component, type OnInit } from '@angular/core'
 import { FormSubmitService } from '../Services/form-submit.service'
 import { AddressService } from '../Services/address.service'
 import { ActivatedRoute, type ParamMap, Router } from '@angular/router'
-import { Location, NgIf } from '@angular/common'
+import { Location } from '@angular/common'
 import { TranslateService, TranslateModule } from '@ngx-translate/core'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { MatIconModule } from '@angular/material/icon'
@@ -21,7 +21,7 @@ import { MatCardModule } from '@angular/material/card'
   selector: 'app-address-create',
   templateUrl: './address-create.component.html',
   styleUrls: ['./address-create.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, NgIf, MatError, MatHint, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatHint, MatButtonModule, MatIconModule]
 })
 export class AddressCreateComponent implements OnInit {
   public countryControl: UntypedFormControl = new UntypedFormControl('', [Validators.required])

--- a/frontend/src/app/address/address.component.html
+++ b/frontend/src/app/address/address.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" [class.div-boundary]="!addNewAddressDiv" class="mat-elevation-z6">

--- a/frontend/src/app/address/address.component.html
+++ b/frontend/src/app/address/address.component.html
@@ -7,8 +7,7 @@
   <div class="mdc-card">
     @if (showNextButton) {
       <h1>{{ 'TITLE_SELECT_ADDRESS' | translate }}</h1>
-    }
-    @if (!showNextButton) {
+    } @else {
       <h1>{{ 'MY_SAVED_ADRESSES' | translate }}</h1>
     }
 

--- a/frontend/src/app/address/address.component.html
+++ b/frontend/src/app/address/address.component.html
@@ -1,95 +1,99 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" [class.div-boundary]="!addNewAddressDiv" class="mat-elevation-z6">
   <div class="mdc-card">
-    <h1 *ngIf="showNextButton">{{ 'TITLE_SELECT_ADDRESS' | translate }}</h1>
-    <h1 *ngIf="!showNextButton">{{ 'MY_SAVED_ADRESSES' | translate }}</h1>
+    @if (showNextButton) {
+      <h1>{{ 'TITLE_SELECT_ADDRESS' | translate }}</h1>
+    }
+    @if (!showNextButton) {
+      <h1>{{ 'MY_SAVED_ADRESSES' | translate }}</h1>
+    }
 
-    <mat-table [dataSource]="dataSource" *ngIf="addressExist" class="address-table">
-      <ng-container matColumnDef="Selection">
-        <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-        <mat-cell *matCellDef="let element; let row">
-          <mat-radio-button
-            (click)="emitSelectionToParent(element.id)"
-            [checked]="selection.isSelected(row)"
-            (change)="$event ? selection.toggle(row) : null">
-          </mat-radio-button>
-        </mat-cell>
-      </ng-container>
+    @if (addressExist) {
+      <mat-table [dataSource]="dataSource" class="address-table">
+        <ng-container matColumnDef="Selection">
+          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-cell *matCellDef="let element; let row">
+            <mat-radio-button
+              (click)="emitSelectionToParent(element.id)"
+              [checked]="selection.isSelected(row)"
+              (change)="$event ? selection.toggle(row) : null">
+            </mat-radio-button>
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Name">
+          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            {{ element?.fullName }}
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Address">
+          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            {{ element?.streetAddress }}, {{ element?.city }}, {{ element?.state }}, {{ element?.zipCode }}
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Country">
+          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            {{ element?.country }}
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Edit">
+          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <button mat-icon-button routerLink="/address/edit/{{ element.id }}">
+              <i class="far fa-edit"></i>
+            </button>
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Remove">
+          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <button mat-icon-button (click)="deleteAddress(element.id)">
+              <i class="far fa-trash-alt"></i>
+            </button>
+          </mat-cell>
+        </ng-container>
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row
+          *matRowDef="let row; columns: displayedColumns; let element"
+          (click)="selection.toggle(row); emitSelectionToParent(element.id)">
+        </mat-row>
+      </mat-table>
+    }
 
-      <ng-container matColumnDef="Name">
-        <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          {{ element?.fullName }}
-        </mat-cell>
-      </ng-container>
+    @if (addNewAddressDiv) {
+      <div class="add-new-address">
+        <button
+          mat-raised-button
+          mat-button
+          class="btn btn-new-address"
+          color="primary"
+          aria-label="Add a new address"
+          routerLink="/address/create">
+          <mat-icon>add</mat-icon>
+          <span>{{ 'ADD_NEW_ADDRESS' | translate }}</span>
+        </button>
+      </div>
+    }
 
-      <ng-container matColumnDef="Address">
-        <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          {{ element?.streetAddress }}, {{ element?.city }}, {{ element?.state }}, {{ element?.zipCode }}
-        </mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="Country">
-        <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          {{ element?.country }}
-        </mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="Edit">
-        <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          <button mat-icon-button routerLink="/address/edit/{{ element.id }}">
-            <i class="far fa-edit"></i>
-          </button>
-        </mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="Remove">
-        <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          <button mat-icon-button (click)="deleteAddress(element.id)">
-            <i class="far fa-trash-alt"></i>
-          </button>
-        </mat-cell>
-      </ng-container>
-
-      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row
-        *matRowDef="let row; columns: displayedColumns; let element"
-        (click)="selection.toggle(row); emitSelectionToParent(element.id)">
-      </mat-row>
-    </mat-table>
-
-    <div class="add-new-address" *ngIf="addNewAddressDiv">
+    @if (showNextButton) {
       <button
         mat-raised-button
         mat-button
-        class="btn btn-new-address"
+        class="btn btn-next"
         color="primary"
-        aria-label="Add a new address"
-        routerLink="/address/create">
-        <mat-icon>add</mat-icon>
-        <span>{{ 'ADD_NEW_ADDRESS' | translate }}</span>
+        aria-label="Proceed to payment selection"
+        [disabled]="addressId === undefined"
+        (click)="chooseAddress()"
+        >
+        <mat-icon>navigate_next</mat-icon>
+        <span translate>{{ 'LABEL_CONTINUE' | translate }}</span>
       </button>
-    </div>
-
-    <button
-      mat-raised-button
-      mat-button
-      class="btn btn-next"
-      color="primary"
-      aria-label="Proceed to payment selection"
-      [disabled]="addressId === undefined"
-      (click)="chooseAddress()"
-      *ngIf="showNextButton">
-      <mat-icon>navigate_next</mat-icon>
-      <span translate>{{ 'LABEL_CONTINUE' | translate }}</span>
-    </button>
+    }
   </div>
 </mat-card>

--- a/frontend/src/app/address/address.component.ts
+++ b/frontend/src/app/address/address.component.ts
@@ -16,7 +16,6 @@ import { MatIconModule } from '@angular/material/icon'
 import { MatIconButton, MatButtonModule } from '@angular/material/button'
 import { MatRadioButton } from '@angular/material/radio'
 
-import { NgIf } from '@angular/common'
 import { MatCardModule } from '@angular/material/card'
 
 library.add(faEdit, faTrashAlt)
@@ -25,7 +24,7 @@ library.add(faEdit, faTrashAlt)
   selector: 'app-address',
   templateUrl: './address.component.html',
   styleUrls: ['./address.component.scss'],
-  imports: [MatCardModule, NgIf, TranslateModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatRadioButton, MatIconButton, RouterLink, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatRadioButton, MatIconButton, RouterLink, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatButtonModule, MatIconModule]
 })
 export class AddressComponent implements OnInit {
   @Output() emitSelection = new EventEmitter()

--- a/frontend/src/app/administration/administration.component.html
+++ b/frontend/src/app/administration/administration.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" class="mat-elevation-z6 mat-own-card">
   <div class="mdc-card">
@@ -15,7 +15,9 @@
           <ng-container matColumnDef="user">
             <mat-header-cell *matHeaderCellDef></mat-header-cell>
             <mat-cell *matCellDef="let user" style="vertical-align: middle">
-              <i *ngIf="doesUserHaveAnActiveSession(user)" class="fas fa-user fa-lg confirmation"></i>
+              @if (doesUserHaveAnActiveSession(user)) {
+                <i class="fas fa-user fa-lg confirmation"></i>
+              }
             </mat-cell>
           </ng-container>
 
@@ -36,10 +38,10 @@
 
         </mat-table>
         <mat-paginator #paginatorUsers
-                      [pageSize]="10"
-                      [length]="resultsLengthUser"
-                      class="mat-elevation-z0"
-                      color="accent">
+          [pageSize]="10"
+          [length]="resultsLengthUser"
+          class="mat-elevation-z0"
+          color="accent">
         </mat-paginator>
       </div>
       <div class="customer-table">
@@ -62,9 +64,11 @@
           <ng-container matColumnDef="rating">
             <mat-header-cell *matHeaderCellDef translate></mat-header-cell>
             <mat-cell *matCellDef="let feedback">
-              <mat-icon *ngFor="let i of times(feedback.rating)">
-                star_rate
-              </mat-icon>
+              @for (i of times(feedback.rating); track i) {
+                <mat-icon>
+                  star_rate
+                </mat-icon>
+              }
             </mat-cell>
           </ng-container>
 
@@ -79,10 +83,10 @@
           <mat-row *matRowDef="let row; columns: feedbackColumns;"></mat-row>
         </mat-table>
         <mat-paginator #paginatorFeedb
-                      [pageSize]="10"
-                      [length]="resultsLengthFeedback"
-                      class="mat-elevation-z0"
-                      color="accent">
+          [pageSize]="10"
+          [length]="resultsLengthFeedback"
+          class="mat-elevation-z0"
+          color="accent">
         </mat-paginator>
       </div>
     </div>

--- a/frontend/src/app/administration/administration.component.html
+++ b/frontend/src/app/administration/administration.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-elevation-z6 mat-own-card">

--- a/frontend/src/app/administration/administration.component.ts
+++ b/frontend/src/app/administration/administration.component.ts
@@ -17,7 +17,6 @@ import { MatPaginator } from '@angular/material/paginator'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatButtonModule } from '@angular/material/button'
-import { NgIf, NgFor } from '@angular/common'
 
 import { TranslateModule } from '@ngx-translate/core'
 import { MatCardModule } from '@angular/material/card'
@@ -28,7 +27,7 @@ library.add(faUser, faEye, faHome, faArchive, faTrashAlt)
   selector: 'app-administration',
   templateUrl: './administration.component.html',
   styleUrls: ['./administration.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, NgIf, MatButtonModule, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatPaginator, MatTooltip, NgFor, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatButtonModule, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatPaginator, MatTooltip, MatIconModule]
 })
 export class AdministrationComponent implements OnInit {
   public userDataSource: any

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="container challenge-solved-toast mat-elevation-z4">

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="container challenge-solved-toast mat-elevation-z4">
   @for (notification of notifications; track notification.key) {
@@ -18,17 +18,25 @@
               <span [hidden]="notification.copied">{{"COPY_TO_CLIPBOARD" | translate}}</span>
             </button>
             <br/>
-            <span *ngIf="showCtfCountryDetailsInNotifications !== 'none'" class="icon-box">
-              <span
-                class="fi fi-{{notification.country.code | lowercase}}"
-                *ngIf="showCtfCountryDetailsInNotifications === 'flag' || showCtfCountryDetailsInNotifications === 'both'">
-              </span>
-              <mat-icon *ngIf="showCtfCountryDetailsInNotifications === 'name'">my_location</mat-icon>&nbsp;
-              <span *ngIf="showCtfCountryDetailsInNotifications === 'name' || showCtfCountryDetailsInNotifications === 'both'">{{notification.country.name}}</span>
-            </span>
-          </div>
-        }
-      </div>
-    </mat-card>
-  }
-</div>
+            @if (showCtfCountryDetailsInNotifications !== 'none') {
+              <span class="icon-box">
+                @if (showCtfCountryDetailsInNotifications === 'flag' || showCtfCountryDetailsInNotifications === 'both') {
+                  <span
+                    class="fi fi-{{notification.country.code | lowercase}}"
+                    >
+                  </span>
+                }
+                @if (showCtfCountryDetailsInNotifications === 'name') {
+                  <mat-icon>my_location</mat-icon>
+                  }&nbsp;
+                  @if (showCtfCountryDetailsInNotifications === 'name' || showCtfCountryDetailsInNotifications === 'both') {
+                    <span>{{notification.country.name}}</span>
+                  }
+                </span>
+              }
+            </div>
+          }
+        </div>
+      </mat-card>
+    }
+  </div>

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -14,7 +14,7 @@ import { ClipboardModule } from 'ngx-clipboard'
 import { MatIconModule } from '@angular/material/icon'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
-import { NgIf, LowerCasePipe } from '@angular/common'
+import { LowerCasePipe } from '@angular/common'
 import { firstValueFrom } from 'rxjs'
 
 interface ChallengeSolvedMessage {
@@ -37,7 +37,7 @@ interface ChallengeSolvedNotification {
   selector: 'app-challenge-solved-notification',
   templateUrl: './challenge-solved-notification.component.html',
   styleUrls: ['./challenge-solved-notification.component.scss'],
-  imports: [MatCardModule, MatButtonModule, MatIconModule, ClipboardModule, NgIf, LowerCasePipe, TranslateModule]
+  imports: [MatCardModule, MatButtonModule, MatIconModule, ClipboardModule, LowerCasePipe, TranslateModule]
 })
 export class ChallengeSolvedNotificationComponent implements OnInit {
   public notifications: ChallengeSolvedNotification[] = []

--- a/frontend/src/app/challenge-status-badge/challenge-status-badge.component.html
+++ b/frontend/src/app/challenge-status-badge/challenge-status-badge.component.html
@@ -1,35 +1,45 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
-<button *ngIf="!challenge.disabledEnv && challenge.solved"
-        [id]="challenge.name + '.solved'"
-        mat-raised-button color="accent"
-        (click)="repeatNotification()"
-        [matTooltip]="allowRepeatNotifications ? ('NOTIFICATION_RESEND_INSTRUCTIONS' | translate) : null"
-        matTooltipPosition="above">
-            <mat-icon [hidden]="!allowRepeatNotifications">flag</mat-icon>
-            <mat-icon [hidden]="allowRepeatNotifications">check_box</mat-icon>
-            <span class="status-label">{{'STATUS_SOLVED' | translate}}</span>
-</button>
+@if (!challenge.disabledEnv && challenge.solved) {
+  <button
+    [id]="challenge.name + '.solved'"
+    mat-raised-button color="accent"
+    (click)="repeatNotification()"
+    [matTooltip]="allowRepeatNotifications ? ('NOTIFICATION_RESEND_INSTRUCTIONS' | translate) : null"
+    matTooltipPosition="above">
+    <mat-icon [hidden]="!allowRepeatNotifications">flag</mat-icon>
+    <mat-icon [hidden]="allowRepeatNotifications">check_box</mat-icon>
+    <span class="status-label">{{'STATUS_SOLVED' | translate}}</span>
+  </button>
+}
 
-<button *ngIf="!challenge.disabledEnv && !challenge.solved"
-        [id]="challenge.name + '.notSolved'"
-        mat-raised-button color="primary"
-        (click)="openHint()"
-        [matTooltip]="showChallengeHints ? challenge.hint : null"
-        matTooltipPosition="above">
-            <mat-icon [hidden]="!showChallengeHints || !challenge.hintUrl">book</mat-icon>
-            <mat-icon [hidden]="showChallengeHints && challenge.hintUrl">check_box_outline_blank</mat-icon>
-            <span class="status-label">{{'STATUS_UNSOLVED' | translate}}</span>
-</button>
+@if (!challenge.disabledEnv && !challenge.solved) {
+  <button
+    [id]="challenge.name + '.notSolved'"
+    mat-raised-button color="primary"
+    (click)="openHint()"
+    [matTooltip]="showChallengeHints ? challenge.hint : null"
+    matTooltipPosition="above">
+    <mat-icon [hidden]="!showChallengeHints || !challenge.hintUrl">book</mat-icon>
+    <mat-icon [hidden]="showChallengeHints && challenge.hintUrl">check_box_outline_blank</mat-icon>
+    <span class="status-label">{{'STATUS_UNSOLVED' | translate}}</span>
+  </button>
+}
 
-<button *ngIf="challenge.disabledEnv" [id]="challenge.name + '.unavailable'" mat-raised-button
-        [matTooltip]="challenge.hint" matTooltipPosition="above">
-  <span>
-    <i *ngIf="challenge.disabledEnv !== 'Windows'" class="{{ 'icon-' + challenge.disabledEnv?.toString().toLowerCase() }}"></i>
-    <i *ngIf="challenge.disabledEnv === 'Windows'" class="{{ 'fab fa-' + challenge.disabledEnv?.toString().toLowerCase() }}"></i>
-    {{'STATUS_UNAVAILABLE' | translate}}
-  </span>
-</button>
+@if (challenge.disabledEnv) {
+  <button [id]="challenge.name + '.unavailable'" mat-raised-button
+    [matTooltip]="challenge.hint" matTooltipPosition="above">
+    <span>
+      @if (challenge.disabledEnv !== 'Windows') {
+        <i class="{{ 'icon-' + challenge.disabledEnv?.toString().toLowerCase() }}"></i>
+      }
+      @if (challenge.disabledEnv === 'Windows') {
+        <i class="{{ 'fab fa-' + challenge.disabledEnv?.toString().toLowerCase() }}"></i>
+      }
+      {{'STATUS_UNAVAILABLE' | translate}}
+    </span>
+  </button>
+}

--- a/frontend/src/app/challenge-status-badge/challenge-status-badge.component.html
+++ b/frontend/src/app/challenge-status-badge/challenge-status-badge.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 @if (!challenge.disabledEnv && challenge.solved) {

--- a/frontend/src/app/challenge-status-badge/challenge-status-badge.component.html
+++ b/frontend/src/app/challenge-status-badge/challenge-status-badge.component.html
@@ -33,11 +33,10 @@
   <button [id]="challenge.name + '.unavailable'" mat-raised-button
     [matTooltip]="challenge.hint" matTooltipPosition="above">
     <span>
-      @if (challenge.disabledEnv !== 'Windows') {
-        <i class="{{ 'icon-' + challenge.disabledEnv?.toString().toLowerCase() }}"></i>
-      }
       @if (challenge.disabledEnv === 'Windows') {
         <i class="{{ 'fab fa-' + challenge.disabledEnv?.toString().toLowerCase() }}"></i>
+      } @else {
+        <i class="{{ 'icon-' + challenge.disabledEnv?.toString().toLowerCase() }}"></i>
       }
       {{'STATUS_UNAVAILABLE' | translate}}
     </span>

--- a/frontend/src/app/challenge-status-badge/challenge-status-badge.component.ts
+++ b/frontend/src/app/challenge-status-badge/challenge-status-badge.component.ts
@@ -15,7 +15,6 @@ import { TranslateModule } from '@ngx-translate/core'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatButtonModule } from '@angular/material/button'
-import { NgIf } from '@angular/common'
 
 library.add(faWindows)
 
@@ -23,7 +22,7 @@ library.add(faWindows)
   selector: 'app-challenge-status-badge',
   templateUrl: './challenge-status-badge.component.html',
   styleUrls: ['./challenge-status-badge.component.scss'],
-  imports: [NgIf, MatButtonModule, MatTooltip, MatIconModule, TranslateModule]
+  imports: [MatButtonModule, MatTooltip, MatIconModule, TranslateModule]
 })
 export class ChallengeStatusBadgeComponent {
   @Input() public challenge: Challenge = { } as Challenge

--- a/frontend/src/app/change-password/change-password.component.html
+++ b/frontend/src/app/change-password/change-password.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/change-password/change-password.component.html
+++ b/frontend/src/app/change-password/change-password.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6" style="margin-bottom: 20px;">
@@ -10,12 +10,12 @@
       <h1 >{{"TITLE_CHANGE_PASSWORD" | translate }}</h1>
 
       <div class="confirmation"
-          [hidden]="!(confirmation && !passwordControl.dirty && !newPasswordControl.dirty && !repeatNewPasswordControl.dirty)">
+        [hidden]="!(confirmation && !passwordControl.dirty && !newPasswordControl.dirty && !repeatNewPasswordControl.dirty)">
         {{ confirmation }}
       </div>
 
       <div class="error"
-          [hidden]="!(error && !passwordControl.dirty && !newPasswordControl.dirty && !repeatNewPasswordControl.dirty)">
+        [hidden]="!(error && !passwordControl.dirty && !newPasswordControl.dirty && !repeatNewPasswordControl.dirty)">
         {{ error }}
       </div>
 
@@ -24,49 +24,58 @@
         <mat-form-field appearance="outline" color="accent">
           <mat-label >{{"LABEL_CURRENT_PASSWORD" | translate }}</mat-label>
           <input id="currentPassword" [formControl]="passwordControl" type="password" matInput
-                aria-label="Field to enter the current password"
-                placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}">
-          <mat-error *ngIf="passwordControl.invalid" >{{"MANDATORY_CURRENT_PASSWORD" | translate }}</mat-error>
-        </mat-form-field>
+            aria-label="Field to enter the current password"
+            placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}">
+            @if (passwordControl.invalid) {
+              <mat-error >{{"MANDATORY_CURRENT_PASSWORD" | translate }}</mat-error>
+            }
+          </mat-form-field>
 
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label >{{"LABEL_NEW_PASSWORD" | translate }}</mat-label>
-          <input #password id="newPassword" [formControl]="newPasswordControl" type="password" matInput
-                aria-label="Field for the new password">
-          <mat-hint translate>
-            <i class="fas fa-exclamation-circle"></i>
-            <em style="margin-left:5px;" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
-          </mat-hint>
-          <mat-hint align="end">{{password.value?.length || 0}}/40</mat-hint>
-          <mat-error *ngIf="newPasswordControl?.invalid && newPasswordControl?.errors.required">
-            {{"MANDATORY_NEW_PASSWORD" | translate }}
-          </mat-error>
-          <mat-error
-            *ngIf="newPasswordControl?.invalid && (newPasswordControl?.errors.minlength || newPasswordControl?.errors.maxlength)"
-            translate [translateParams]="{length: '5-40'}">{{"INVALID_PASSWORD_LENGTH"| translate }}
-          </mat-error>
-        </mat-form-field>
+          <mat-form-field appearance="outline" color="accent">
+            <mat-label >{{"LABEL_NEW_PASSWORD" | translate }}</mat-label>
+            <input #password id="newPassword" [formControl]="newPasswordControl" type="password" matInput
+              aria-label="Field for the new password">
+              <mat-hint translate>
+                <i class="fas fa-exclamation-circle"></i>
+                <em style="margin-left:5px;" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
+              </mat-hint>
+              <mat-hint align="end">{{password.value?.length || 0}}/40</mat-hint>
+              @if (newPasswordControl?.invalid && newPasswordControl?.errors.required) {
+                <mat-error>
+                  {{"MANDATORY_NEW_PASSWORD" | translate }}
+                </mat-error>
+              }
+              @if (newPasswordControl?.invalid && (newPasswordControl?.errors.minlength || newPasswordControl?.errors.maxlength)) {
+                <mat-error
+                  translate [translateParams]="{length: '5-40'}">{{"INVALID_PASSWORD_LENGTH"| translate }}
+                </mat-error>
+              }
+            </mat-form-field>
 
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label>{{"LABEL_REPEAT_NEW_PASSWORD"| translate }}</mat-label>
-          <input #passwordRepeat id="newPasswordRepeat" [formControl]="repeatNewPasswordControl" type="password" matInput
+            <mat-form-field appearance="outline" color="accent">
+              <mat-label>{{"LABEL_REPEAT_NEW_PASSWORD"| translate }}</mat-label>
+              <input #passwordRepeat id="newPasswordRepeat" [formControl]="repeatNewPasswordControl" type="password" matInput
                 aria-label="Field to repeat the new password">
-          <mat-hint align="end">{{passwordRepeat.value?.length || 0}}/20</mat-hint>
-          <mat-error *ngIf="repeatNewPasswordControl.invalid && repeatNewPasswordControl.errors.required" translate>MANDATORY_PASSWORD_REPEAT</mat-error>
-          <mat-error *ngIf="repeatNewPasswordControl.invalid && repeatNewPasswordControl.errors.notSame" translate>
-            {{"PASSWORDS_NOT_MATCHING" | translate }}
-          </mat-error>
-        </mat-form-field>
+                <mat-hint align="end">{{passwordRepeat.value?.length || 0}}/20</mat-hint>
+                @if (repeatNewPasswordControl.invalid && repeatNewPasswordControl.errors.required) {
+                  <mat-error translate>MANDATORY_PASSWORD_REPEAT</mat-error>
+                }
+                @if (repeatNewPasswordControl.invalid && repeatNewPasswordControl.errors.notSame) {
+                  <mat-error translate>
+                    {{"PASSWORDS_NOT_MATCHING" | translate }}
+                  </mat-error>
+                }
+              </mat-form-field>
 
-      </div>
+            </div>
 
-      <button type="submit" id="changeButton"
+            <button type="submit" id="changeButton"
               [disabled]="passwordControl.invalid || newPasswordControl.invalid || repeatNewPasswordControl.invalid"
               mat-raised-button color="primary" (click)="changePassword()" aria-label="Button to confirm the change">
-        <i class="far fa-edit fa-lg" aria-hidden="true"></i>
-        {{'BTN_CHANGE' | translate}}
-      </button>
+              <i class="far fa-edit fa-lg" aria-hidden="true"></i>
+              {{'BTN_CHANGE' | translate}}
+            </button>
 
-    </div>
-  </mat-card>
-</div>
+          </div>
+        </mat-card>
+      </div>

--- a/frontend/src/app/change-password/change-password.component.ts
+++ b/frontend/src/app/change-password/change-password.component.ts
@@ -18,7 +18,7 @@ import { faEdit } from '@fortawesome/free-regular-svg-icons'
 import { FormSubmitService } from '../Services/form-submit.service'
 import { TranslateService, TranslateModule } from '@ngx-translate/core'
 import { MatButtonModule } from '@angular/material/button'
-import { NgIf } from '@angular/common'
+
 import { MatInputModule } from '@angular/material/input'
 import {
   MatFormFieldModule,
@@ -35,7 +35,6 @@ library.add(faSave, faEdit)
   templateUrl: './change-password.component.html',
   styleUrls: ['./change-password.component.scss'],
   imports: [
-
     MatCardModule,
     TranslateModule,
     MatFormFieldModule,
@@ -43,7 +42,6 @@ library.add(faSave, faEdit)
     MatInputModule,
     FormsModule,
     ReactiveFormsModule,
-    NgIf,
     MatError,
     MatHint,
     MatButtonModule

--- a/frontend/src/app/chatbot/chatbot.component.html
+++ b/frontend/src/app/chatbot/chatbot.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/chatbot/chatbot.component.html
+++ b/frontend/src/app/chatbot/chatbot.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -12,13 +12,19 @@
           <mat-card appearance="outlined" id="chat-box">
             <div class="mdc-card chat-content">
               <div id="chat-window">
-                <div *ngFor="let message of messages; index as index" class="message-container">
-                  <img *ngIf="message.author == 'bot'" src="{{juicyImageSrc}}" class="juicy-chat-bot-image"/>
-                  <img *ngIf="message.author == 'user'" src="{{profileImageSrc}}" class="profile-image"/>
-                  <div class="{{message.author == 'user' ? 'speech-bubble-right' : 'speech-bubble-left'}}">
-                    {{message.body}}
+                @for (message of messages; track message; let index = $index) {
+                  <div class="message-container">
+                    @if (message.author == 'bot') {
+                      <img src="{{juicyImageSrc}}" class="juicy-chat-bot-image"/>
+                    }
+                    @if (message.author == 'user') {
+                      <img src="{{profileImageSrc}}" class="profile-image"/>
+                    }
+                    <div class="{{message.author == 'user' ? 'speech-bubble-right' : 'speech-bubble-left'}}">
+                      {{message.body}}
+                    </div>
                   </div>
-                </div>
+                }
               </div>
 
               <div class="message-box-container">
@@ -26,15 +32,15 @@
                   <mat-form-field color="accent" appearance="outline">
                     <mat-label translate>LABEL_MESSAGE</mat-label>
                     <input id="message-input" #message name="message" [formControl]="messageControl"
-                            matInput placeholder="{{ 'ASK_ME_ANYTHING_PLACEHOLDER' | translate}}"
-                            aria-label="Text field for a chat message" (keyup.enter)="sendMessage()">
-                  </mat-form-field>
+                      matInput placeholder="{{ 'ASK_ME_ANYTHING_PLACEHOLDER' | translate}}"
+                      aria-label="Text field for a chat message" (keyup.enter)="sendMessage()">
+                    </mat-form-field>
+                  </div>
                 </div>
               </div>
-            </div>
-          </mat-card>
-        </div>
-      </mat-card>
-    </div>
-  </mat-card>
-</div>
+            </mat-card>
+          </div>
+        </mat-card>
+      </div>
+    </mat-card>
+  </div>

--- a/frontend/src/app/chatbot/chatbot.component.ts
+++ b/frontend/src/app/chatbot/chatbot.component.ts
@@ -14,7 +14,7 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core'
 import { CookieService } from 'ngy-cookie'
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field'
-import { NgFor, NgIf } from '@angular/common'
+
 import { MatCardModule } from '@angular/material/card'
 
 library.add(faBomb)
@@ -38,7 +38,7 @@ interface MessageActions {
   selector: 'app-chatbot',
   templateUrl: './chatbot.component.html',
   styleUrls: ['./chatbot.component.scss'],
-  imports: [MatCardModule, NgFor, NgIf, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, ReactiveFormsModule]
+  imports: [MatCardModule, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, ReactiveFormsModule]
 })
 export class ChatbotComponent implements OnInit, OnDestroy {
   public messageControl: UntypedFormControl = new UntypedFormControl()

--- a/frontend/src/app/code-area/code-area.component.html
+++ b/frontend/src/app/code-area/code-area.component.html
@@ -1,7 +1,7 @@
 <div id="code-area">
-  <pre id="code"><div id="emphasize"><div *ngFor="let marker of lineMarkers" class="lineMarker" [id]="'line' + marker.lineNumber" (click)="selectLines(marker.lineNumber)">{{ marker.marked ? '✅' : '🔲'}}</div>
-  </div><code
-    [highlight]="code" [lineNumbers]="true"
-    [languages]="langs"
-    ></code></pre>
+  <pre id="code"><div id="emphasize">@for (marker of lineMarkers; track marker) {<div class="lineMarker" [id]="'line' + marker.lineNumber" (click)="selectLines(marker.lineNumber)">{{ marker.marked ? '✅' : '🔲'}}</div>}
+</div><code
+[highlight]="code" [lineNumbers]="true"
+[languages]="langs"
+></code></pre>
 </div>

--- a/frontend/src/app/code-area/code-area.component.ts
+++ b/frontend/src/app/code-area/code-area.component.ts
@@ -6,7 +6,6 @@ import {
   EventEmitter
 } from '@angular/core'
 import { HighlightModule } from 'ngx-highlightjs'
-import { NgFor } from '@angular/common'
 
 interface LineMarker {
   marked: boolean
@@ -17,7 +16,7 @@ interface LineMarker {
   selector: 'app-code-area',
   templateUrl: './code-area.component.html',
   styleUrls: ['./code-area.component.scss'],
-  imports: [NgFor, HighlightModule]
+  imports: [HighlightModule]
 })
 export class CodeAreaComponent implements OnInit {
   private _code: string = ''

--- a/frontend/src/app/code-fixes/code-fixes.component.html
+++ b/frontend/src/app/code-fixes/code-fixes.component.html
@@ -1,4 +1,6 @@
 @for (fix of randomFixes;  track fix.index) {
-    <td-ngx-text-diff *ngIf="selectedFix === $index" [left]="snippet" [right]="fix?.fix" [format]="format" #codeComponent>
+  @if (selectedFix === $index) {
+    <td-ngx-text-diff [left]="snippet" [right]="fix?.fix" [format]="format" #codeComponent>
     </td-ngx-text-diff>
+  }
 }

--- a/frontend/src/app/code-fixes/code-fixes.component.ts
+++ b/frontend/src/app/code-fixes/code-fixes.component.ts
@@ -4,13 +4,12 @@ import { NgxTextDiffComponent, NgxTextDiffModule } from '@winarg/ngx-text-diff'
 import { CookieService } from 'ngy-cookie'
 import { type RandomFixes } from '../code-snippet/code-snippet.component'
 import { type DiffTableFormat } from '@winarg/ngx-text-diff/lib/ngx-text-diff.model'
-import { NgIf } from '@angular/common'
 
 @Component({
   selector: 'app-code-fixes',
   templateUrl: './code-fixes.component.html',
   styleUrls: ['./code-fixes.component.scss'],
-  imports: [NgIf, NgxTextDiffModule]
+  imports: [NgxTextDiffModule]
 })
 export class CodeFixesComponent implements OnInit, DoCheck {
   differ: KeyValueDiffer<string, DiffTableFormat>

--- a/frontend/src/app/code-snippet/code-snippet.component.html
+++ b/frontend/src/app/code-snippet/code-snippet.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 <h2 mat-dialog-title>{{'TITLE_CODING_CHALLENGE' | translate}}: {{dialogData.name}}</h2>
 <mat-dialog-content>

--- a/frontend/src/app/code-snippet/code-snippet.component.html
+++ b/frontend/src/app/code-snippet/code-snippet.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 <h2 mat-dialog-title>{{'TITLE_CODING_CHALLENGE' | translate}}: {{dialogData.name}}</h2>
 <mat-dialog-content>
   <mat-tab-group mat-stretch-tabs [selectedIndex]="tab.value" (selectedIndexChange)="toggleTab($event)">
@@ -21,45 +21,59 @@
         <span class="tab-header-text">{{'TAB_FIX_IT' | translate}}</span>
         <mat-icon class="materaial-icons-outlined" [color]="lockColor()">{{lockIcon()}}</mat-icon>
       </ng-template>
-      <app-code-fixes *ngIf="snippet !== null && fixes !== null" [snippet]="snippet?.snippet" [fixes]="fixes"
+      @if (snippet !== null && fixes !== null) {
+        <app-code-fixes [snippet]="snippet?.snippet" [fixes]="fixes"
         [randomFixes]="randomFixes" [selectedFix]="selectedFix"></app-code-fixes>
+      }
     </mat-tab>
   </mat-tab-group>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <mat-card appearance="outlined" *ngIf="hint && tab.value === 0" class="primary-notification">
-    <div class="mdc-card">{{hint}}</div>
-  </mat-card>
-  <mat-card appearance="outlined" *ngIf="explanation && tab.value === 1"
-    [class]="resultColor() === 'warn' ? 'warn-notification' : 'accent-notification'">
-    <div class="mdc-card">{{explanation}}</div>
-  </mat-card>
+  @if (hint && tab.value === 0) {
+    <mat-card appearance="outlined" class="primary-notification">
+      <div class="mdc-card">{{hint}}</div>
+    </mat-card>
+  }
+  @if (explanation && tab.value === 1) {
+    <mat-card appearance="outlined"
+      [class]="resultColor() === 'warn' ? 'warn-notification' : 'accent-notification'">
+      <div class="mdc-card">{{explanation}}</div>
+    </mat-card>
+  }
   <div class="button-row">
     @if (tab.value === 0) {
       <!-- empty div to still have the space-between work -->
       <!-- size of the div is fixed to 78.25px which is the height of the select. this ensures the layout doesn't jump when switching tabs -->
       <div style="height: 78.25px;"></div>
     } @else {
-      <mat-form-field *ngIf="tab.value === 1" appearance="fill">
-        <mat-label translate>LABEL_CORRECT_FIX</mat-label>
-        <select matNativeControl (change)="changeFix($event)">
-          <option *ngFor="let fix of randomFixes; index as i" [value]="i" [selected]="selectedFix === i">Fix {{ i+1 }}
-          </option>
-        </select>
-      </mat-form-field>
+      @if (tab.value === 1) {
+        <mat-form-field appearance="fill">
+          <mat-label translate>LABEL_CORRECT_FIX</mat-label>
+          <select matNativeControl (change)="changeFix($event)">
+            @for (fix of randomFixes; track fix; let i = $index) {
+              <option [value]="i" [selected]="selectedFix === i">Fix {{ i+1 }}
+              </option>
+            }
+          </select>
+        </mat-form-field>
+      }
     }
 
     <div class="button-group">
-      <a *ngIf="this.showFeedbackButtons && this.solved.fixIt"
-        [href]="'https://docs.google.com/forms/d/e/1FAIpQLSdaNEuz0dzFA2sexCa0AJ4QOb2OYdEL04eQOLFD2Y4T-BW6ag/viewform?usp=pp_url&entry.384948954=' + dialogData.name + '&entry.435235279=Coding+Challenge&entry.1734944650=Yes'"
-        target="_blank">
-        <button mat-icon-button><mat-icon color="accent">thumb_up</mat-icon></button>
-      </a>
-      <a *ngIf="this.showFeedbackButtons && this.solved.fixIt"
-        [href]="'https://docs.google.com/forms/d/e/1FAIpQLSdaNEuz0dzFA2sexCa0AJ4QOb2OYdEL04eQOLFD2Y4T-BW6ag/viewform?usp=pp_url&entry.384948954=' + dialogData.name + '&entry.435235279=Coding+Challenge&entry.1734944650=No'"
-        target="_blank">
-        <button mat-icon-button><mat-icon color="warn">thumb_down</mat-icon></button>
-      </a>
+      @if (this.showFeedbackButtons && this.solved.fixIt) {
+        <a
+          [href]="'https://docs.google.com/forms/d/e/1FAIpQLSdaNEuz0dzFA2sexCa0AJ4QOb2OYdEL04eQOLFD2Y4T-BW6ag/viewform?usp=pp_url&entry.384948954=' + dialogData.name + '&entry.435235279=Coding+Challenge&entry.1734944650=Yes'"
+          target="_blank">
+          <button mat-icon-button><mat-icon color="accent">thumb_up</mat-icon></button>
+        </a>
+      }
+      @if (this.showFeedbackButtons && this.solved.fixIt) {
+        <a
+          [href]="'https://docs.google.com/forms/d/e/1FAIpQLSdaNEuz0dzFA2sexCa0AJ4QOb2OYdEL04eQOLFD2Y4T-BW6ag/viewform?usp=pp_url&entry.384948954=' + dialogData.name + '&entry.435235279=Coding+Challenge&entry.1734944650=No'"
+          target="_blank">
+          <button mat-icon-button><mat-icon color="warn">thumb_down</mat-icon></button>
+        </a>
+      }
 
       <button mat-stroked-button mat-dialog-close class="close-dialog buttons" aria-label="Close Dialog"
         [mat-dialog-close]="solved" id="findItCloseButton">
@@ -67,21 +81,25 @@
         <span>{{'BTN_CLOSE' | translate}}</span>
       </button>
 
-      <button *ngIf="tab.value === 0" mat-stroked-button (click)="checkLines()" [disabled]="this.solved.findIt"
-        id="findItSubmitButton">
-        <span>{{'BTN_SUBMIT' | translate}}</span>
-        <mat-icon [color]="resultColor()">
-          {{ resultIcon() }}
-        </mat-icon>
-      </button>
+      @if (tab.value === 0) {
+        <button mat-stroked-button (click)="checkLines()" [disabled]="this.solved.findIt"
+          id="findItSubmitButton">
+          <span>{{'BTN_SUBMIT' | translate}}</span>
+          <mat-icon [color]="resultColor()">
+            {{ resultIcon() }}
+          </mat-icon>
+        </button>
+      }
 
-      <button *ngIf="tab.value === 1" mat-stroked-button (click)="checkFix()" [disabled]="this.solved.fixIt"
-        id="fixItSubmitButton">
-        <span>{{'BTN_SUBMIT' | translate}}</span>
-        <mat-icon [color]="resultColor()">
-          {{ resultIcon() }}
-        </mat-icon>
-      </button>
+      @if (tab.value === 1) {
+        <button mat-stroked-button (click)="checkFix()" [disabled]="this.solved.fixIt"
+          id="fixItSubmitButton">
+          <span>{{'BTN_SUBMIT' | translate}}</span>
+          <mat-icon [color]="resultColor()">
+            {{ resultIcon() }}
+          </mat-icon>
+        </button>
+      }
     </div>
   </div>
 </mat-dialog-actions>

--- a/frontend/src/app/code-snippet/code-snippet.component.ts
+++ b/frontend/src/app/code-snippet/code-snippet.component.ts
@@ -23,7 +23,6 @@ import { CodeFixesComponent } from '../code-fixes/code-fixes.component'
 import { MatIconModule } from '@angular/material/icon'
 import { TranslateModule } from '@ngx-translate/core'
 import { CodeAreaComponent } from '../code-area/code-area.component'
-import { NgIf, NgFor } from '@angular/common'
 
 import { MatTabGroup, MatTab, MatTabLabel } from '@angular/material/tabs'
 
@@ -48,7 +47,7 @@ export interface RandomFixes {
   templateUrl: './code-snippet.component.html',
   styleUrls: ['./code-snippet.component.scss'],
   host: { class: 'code-snippet' },
-  imports: [MatDialogTitle, MatDialogContent, MatTabGroup, MatTab, NgIf, CodeAreaComponent, TranslateModule, MatTabLabel, MatIconModule, CodeFixesComponent, MatDialogActions, MatCardModule, MatFormFieldModule, MatLabel, MatInputModule, NgFor, FormsModule, MatIconButton, MatButtonModule, MatDialogClose]
+  imports: [MatDialogTitle, MatDialogContent, MatTabGroup, MatTab, CodeAreaComponent, TranslateModule, MatTabLabel, MatIconModule, CodeFixesComponent, MatDialogActions, MatCardModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, MatIconButton, MatButtonModule, MatDialogClose]
 })
 export class CodeSnippetComponent implements OnInit {
   public snippet: CodeSnippet = null

--- a/frontend/src/app/complaint/complaint.component.html
+++ b/frontend/src/app/complaint/complaint.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -11,12 +11,16 @@
 
       <div class="confirmation" [hidden]="!(confirmation && !messageControl.dirty)">{{ confirmation }}</div>
 
-      <div class="error fileUploadError" *ngIf="(fileUploadError && fileUploadError.name == 'mimeType')">{{
-        "INVALID_FILE_TYPE" | translate: { type: 'PDF, ZIP' } }}
-      </div>
-      <div class="error fileUploadError" *ngIf="(fileUploadError && fileUploadError.name == 'fileSize')">{{
-        "INVALID_FILE_SIZE" | translate: { size: '100 KB' } }}
-      </div>
+      @if ((fileUploadError && fileUploadError.name == 'mimeType')) {
+        <div class="error fileUploadError">{{
+          "INVALID_FILE_TYPE" | translate: { type: 'PDF, ZIP' } }}
+        </div>
+      }
+      @if ((fileUploadError && fileUploadError.name == 'fileSize')) {
+        <div class="error fileUploadError">{{
+          "INVALID_FILE_SIZE" | translate: { size: '100 KB' } }}
+        </div>
+      }
 
       <div class="form-container" id="complaint-form">
 
@@ -32,12 +36,14 @@
             <em style="margin-left:5px;">{{ 'MAX_TEXTAREA_LENGTH' | translate: {length: '160'} }}</em>
           </mat-hint>
           <textarea #complaintMessage id="complaintMessage" [formControl]="messageControl" matAutosizeMinRows="4" matAutosizeMaxRows="4"
-                    matTextareaAutosize cols="50" maxlength="160" matInput
-                    placeholder="{{ 'WRITE_MESSAGE_PLACEHOLDER' | translate}}"
-                    aria-label="Field for entering the complaint"></textarea>
-          <mat-error *ngIf="messageControl.invalid && messageControl?.errors.required">{{"MANDATORY_MESSAGE" |
-            translate}}
-          </mat-error>
+            matTextareaAutosize cols="50" maxlength="160" matInput
+            placeholder="{{ 'WRITE_MESSAGE_PLACEHOLDER' | translate}}"
+          aria-label="Field for entering the complaint"></textarea>
+          @if (messageControl.invalid && messageControl?.errors.required) {
+            <mat-error>{{"MANDATORY_MESSAGE" |
+              translate}}
+            </mat-error>
+          }
           <mat-hint align="end">{{complaintMessage.value?.length || 0}}/160</mat-hint>
         </mat-form-field>
 
@@ -49,7 +55,7 @@
       </div>
 
       <button type="submit" id="submitButton" [disabled]="messageControl.invalid || fileUploadError" (click)="save()"
-              mat-raised-button color="primary" aria-label="Button to send the complaint">
+        mat-raised-button color="primary" aria-label="Button to send the complaint">
         <mat-icon>
           send
         </mat-icon>

--- a/frontend/src/app/complaint/complaint.component.html
+++ b/frontend/src/app/complaint/complaint.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/complaint/complaint.component.ts
+++ b/frontend/src/app/complaint/complaint.component.ts
@@ -16,7 +16,7 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core'
 import { MatButtonModule } from '@angular/material/button'
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatHint, MatError } from '@angular/material/form-field'
-import { NgIf } from '@angular/common'
+
 import { MatCardModule } from '@angular/material/card'
 
 import { MatIconModule } from '@angular/material/icon'
@@ -27,7 +27,7 @@ library.add(faBomb)
   selector: 'app-complaint',
   templateUrl: './complaint.component.html',
   styleUrls: ['./complaint.component.scss'],
-  imports: [MatCardModule, TranslateModule, NgIf, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatHint, MatError, FileUploadModule, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatHint, MatError, FileUploadModule, MatButtonModule, MatIconModule]
 })
 export class ComplaintComponent implements OnInit {
   public customerControl: UntypedFormControl = new UntypedFormControl({ value: '', disabled: true }, [])

--- a/frontend/src/app/contact/contact.component.html
+++ b/frontend/src/app/contact/contact.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/contact/contact.component.html
+++ b/frontend/src/app/contact/contact.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -24,12 +24,14 @@
             <em style="margin-left:5px;" translate>{{ 'MAX_TEXTAREA_LENGTH' | translate: {length: '160'} }}</em>
           </mat-hint>
           <textarea #comment id="comment" ngDefaultControl [formControl]="feedbackControl" matInput
-                    matAutosizeMinRows="4" matAutosizeMaxRows="4" matTextareaAutosize cols="50" maxlength="160"
-                    placeholder="{{ 'WRITE_REVIEW_PLACEHOLDER' | translate}}"
-                    aria-label="Field for entering the comment or the feedback"></textarea>
+            matAutosizeMinRows="4" matAutosizeMaxRows="4" matTextareaAutosize cols="50" maxlength="160"
+            placeholder="{{ 'WRITE_REVIEW_PLACEHOLDER' | translate}}"
+          aria-label="Field for entering the comment or the feedback"></textarea>
           <mat-hint align="end">{{comment.value?.length || 0}}/160</mat-hint>
-          <mat-error *ngIf="feedbackControl.invalid && feedbackControl.errors.required" translate>MANDATORY_COMMENT
-          </mat-error>
+          @if (feedbackControl.invalid && feedbackControl.errors.required) {
+            <mat-error translate>MANDATORY_COMMENT
+            </mat-error>
+          }
         </mat-form-field>
 
         <div class="rating-container">
@@ -41,29 +43,33 @@
 
         <div style="margin-bottom: 10px; margin-top: 10px; ">
           <label style="font-weight:500;">CAPTCHA:</label>&nbsp;&nbsp;<span style="font-size:small;"
-                                                                            translate>LABEL_WHAT_IS</span>&nbsp;
-          <code id="captcha" aria-label="CAPTCHA code which must be solved">{{captcha}}</code>&nbsp;<label
-          style="font-size:small;">?</label>
-        </div>
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_RESULT</mat-label>
-          <input id="captchaControl" ngDefaultControl [formControl]="captchaControl" matInput type="text"
-                placeholder="{{ 'MANDATORY_CAPTCHA' | translate}}"
-                aria-label="Field for the result of the CAPTCHA code" pattern="-?[\d]*">
-          <mat-error *ngIf="captchaControl.invalid && captchaControl.errors.required" translate>MANDATORY_CAPTCHA
-          </mat-error>
-          <mat-error *ngIf="captchaControl.invalid && captchaControl.errors.pattern" translate>INVALID_CAPTCHA
-          </mat-error>
-        </mat-form-field>
-
-      </div>
-
-      <button type="submit" id="submitButton" mat-raised-button color="primary"
-              [disabled]="authorControl.invalid || feedbackControl.invalid || captchaControl.invalid || !rating"
-              (click)="save()" aria-label="Button to send the review">
-        <mat-icon>send</mat-icon>
-        {{'BTN_SUBMIT' | translate}}
-      </button>
+        translate>LABEL_WHAT_IS</span>&nbsp;
+        <code id="captcha" aria-label="CAPTCHA code which must be solved">{{captcha}}</code>&nbsp;<label
+      style="font-size:small;">?</label>
     </div>
-  </mat-card>
+    <mat-form-field appearance="outline" color="accent">
+      <mat-label translate>LABEL_RESULT</mat-label>
+      <input id="captchaControl" ngDefaultControl [formControl]="captchaControl" matInput type="text"
+        placeholder="{{ 'MANDATORY_CAPTCHA' | translate}}"
+        aria-label="Field for the result of the CAPTCHA code" pattern="-?[\d]*">
+        @if (captchaControl.invalid && captchaControl.errors.required) {
+          <mat-error translate>MANDATORY_CAPTCHA
+          </mat-error>
+        }
+        @if (captchaControl.invalid && captchaControl.errors.pattern) {
+          <mat-error translate>INVALID_CAPTCHA
+          </mat-error>
+        }
+      </mat-form-field>
+
+    </div>
+
+    <button type="submit" id="submitButton" mat-raised-button color="primary"
+      [disabled]="authorControl.invalid || feedbackControl.invalid || captchaControl.invalid || !rating"
+      (click)="save()" aria-label="Button to send the review">
+      <mat-icon>send</mat-icon>
+      {{'BTN_SUBMIT' | translate}}
+    </button>
+  </div>
+</mat-card>
 </div>

--- a/frontend/src/app/contact/contact.component.ts
+++ b/frontend/src/app/contact/contact.component.ts
@@ -15,7 +15,7 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { MatButtonModule } from '@angular/material/button'
 import { MatSliderModule } from '@angular/material/slider'
-import { NgIf } from '@angular/common'
+
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatHint, MatError } from '@angular/material/form-field'
 import { MatCardModule } from '@angular/material/card'
@@ -28,7 +28,7 @@ library.add(faStar, faPaperPlane)
   selector: 'app-contact',
   templateUrl: './contact.component.html',
   styleUrls: ['./contact.component.scss'],
-  imports: [MatCardModule, TranslateModule, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatHint, NgIf, MatError, MatSliderModule, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatHint, MatError, MatSliderModule, MatButtonModule, MatIconModule]
 })
 export class ContactComponent implements OnInit {
   public authorControl: UntypedFormControl = new UntypedFormControl({ value: '', disabled: true }, [])

--- a/frontend/src/app/data-export/data-export.component.html
+++ b/frontend/src/app/data-export/data-export.component.html
@@ -1,16 +1,18 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
     <div class="mdc-card">
       <h1 translate>TITLE_REQUEST_DATA_EXPORT</h1>
 
-      <div *ngIf="error">
-        <p class="error">{{error}}</p>
-      </div>
+      @if (error) {
+        <div>
+          <p class="error">{{error}}</p>
+        </div>
+      }
 
       <div class="form-container" id="data-export-form">
         <mat-radio-group id="formatControl" [formControl]="formatControl" aria-label="Select an option">
@@ -20,33 +22,39 @@
           <mat-radio-button value="3" aria-label="Export Option Excel" disabled>Excel</mat-radio-button>
         </mat-radio-group>
 
-        <div *ngIf="presenceOfCaptcha">
+        @if (presenceOfCaptcha) {
           <div>
-            <span style="float: left; margin-top: 40px; font-weight: 500; margin-bottom: 20px;" translate>CAPTCHA <span>:</span></span>
-            <div class="captcha-image" [innerHTML]="captcha" style="margin-left: 10px;"></div>
-          </div>
-          <mat-form-field style="margin-top: 10px; width: 100%;" appearance="outline" color="accent">
-            <mat-label translate>ENTER_CAPTCHA</mat-label>
-            <input #captchaInput [formControl]="captchaControl" type="text" matInput
-                  placeholder="{{ 'TYPE_THESE_LETTERS' | translate: {length: '5'} }}" maxlength="5"
-                  aria-label="Input for the CAPTCHA">
-            <mat-hint align="end">{{captchaInput.value?.length || 0}}/5</mat-hint>
-            <mat-error *ngIf="captchaControl.invalid && captchaControl.errors.required " translate>MANDATORY_CAPTCHA
-            </mat-error>
-            <mat-error *ngIf="captchaControl.invalid && captchaControl.errors.minlength" translate>MANDATORY_CAPTCHA
-            </mat-error>
-          </mat-form-field>
+            <div>
+              <span style="float: left; margin-top: 40px; font-weight: 500; margin-bottom: 20px;" translate>CAPTCHA <span>:</span></span>
+              <div class="captcha-image" [innerHTML]="captcha" style="margin-left: 10px;"></div>
+            </div>
+            <mat-form-field style="margin-top: 10px; width: 100%;" appearance="outline" color="accent">
+              <mat-label translate>ENTER_CAPTCHA</mat-label>
+              <input #captchaInput [formControl]="captchaControl" type="text" matInput
+                placeholder="{{ 'TYPE_THESE_LETTERS' | translate: {length: '5'} }}" maxlength="5"
+                aria-label="Input for the CAPTCHA">
+                <mat-hint align="end">{{captchaInput.value?.length || 0}}/5</mat-hint>
+                @if (captchaControl.invalid && captchaControl.errors.required ) {
+                  <mat-error translate>MANDATORY_CAPTCHA
+                  </mat-error>
+                }
+                @if (captchaControl.invalid && captchaControl.errors.minlength) {
+                  <mat-error translate>MANDATORY_CAPTCHA
+                  </mat-error>
+                }
+              </mat-form-field>
+            </div>
+          }
+        </div>
+        <button type="submit" style="margin-top: 15px;" id="submitButton" color="primary" mat-raised-button (click)="save()"
+          [disabled]="formatControl.invalid || (captchaControl.invalid && presenceOfCaptcha)"
+          aria-label="Button to send the request">
+          <mat-icon>download</mat-icon>
+          {{'BTN_REQUEST' | translate}}
+        </button>
+        <div class="hint">
+          <span translate>DATA_EXPORT_HINT</span>
         </div>
       </div>
-      <button type="submit" style="margin-top: 15px;" id="submitButton" color="primary" mat-raised-button (click)="save()"
-              [disabled]="formatControl.invalid || (captchaControl.invalid && presenceOfCaptcha)"
-              aria-label="Button to send the request">
-        <mat-icon>download</mat-icon>
-        {{'BTN_REQUEST' | translate}}
-      </button>
-      <div class="hint">
-        <span translate>DATA_EXPORT_HINT</span>
-      </div>
-    </div>
-  </mat-card>
-</div>
+    </mat-card>
+  </div>

--- a/frontend/src/app/data-export/data-export.component.html
+++ b/frontend/src/app/data-export/data-export.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/data-export/data-export.component.ts
+++ b/frontend/src/app/data-export/data-export.component.ts
@@ -12,7 +12,7 @@ import { MatButtonModule } from '@angular/material/button'
 import { MatInputModule } from '@angular/material/input'
 import { MatLabel, MatFormFieldModule, MatHint, MatError } from '@angular/material/form-field'
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio'
-import { NgIf } from '@angular/common'
+
 import { TranslateModule } from '@ngx-translate/core'
 import { MatCardModule } from '@angular/material/card'
 
@@ -22,7 +22,7 @@ import { MatIconModule } from '@angular/material/icon'
   selector: 'app-data-export',
   templateUrl: './data-export.component.html',
   styleUrls: ['./data-export.component.scss'],
-  imports: [MatCardModule, TranslateModule, NgIf, MatRadioGroup, FormsModule, ReactiveFormsModule, MatLabel, MatRadioButton, MatFormFieldModule, MatInputModule, MatHint, MatError, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatRadioGroup, FormsModule, ReactiveFormsModule, MatLabel, MatRadioButton, MatFormFieldModule, MatInputModule, MatHint, MatError, MatButtonModule, MatIconModule]
 })
 export class DataExportComponent implements OnInit {
   public captchaControl: UntypedFormControl = new UntypedFormControl('', [Validators.required, Validators.minLength(5)])

--- a/frontend/src/app/delivery-method/delivery-method.component.html
+++ b/frontend/src/app/delivery-method/delivery-method.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-elevation-z6">

--- a/frontend/src/app/delivery-method/delivery-method.component.html
+++ b/frontend/src/app/delivery-method/delivery-method.component.html
@@ -1,28 +1,32 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" class="mat-elevation-z6">
   <div class="mdc-card">
 
-    <div *ngIf="address" class="addressCont">
-      <h1 translate>LABEL_DELIVERY_ADDRESS</h1>
-      <div>{{address?.fullName}}</div>
-      <div>{{address?.streetAddress}}, {{address?.city}}, {{address?.state}}, {{address?.zipCode}}</div>
-      <div>{{address?.country}}</div>
-      <div><span translate>PHONE_NUMBER</span> {{address?.mobileNum}}</div>
-    </div>
-    <mat-divider *ngIf="address" class="detail-divider"></mat-divider>
+    @if (address) {
+      <div class="addressCont">
+        <h1 translate>LABEL_DELIVERY_ADDRESS</h1>
+        <div>{{address?.fullName}}</div>
+        <div>{{address?.streetAddress}}, {{address?.city}}, {{address?.state}}, {{address?.zipCode}}</div>
+        <div>{{address?.country}}</div>
+        <div><span translate>PHONE_NUMBER</span> {{address?.mobileNum}}</div>
+      </div>
+    }
+    @if (address) {
+      <mat-divider class="detail-divider"></mat-divider>
+    }
     <div style="height: 12px;"></div>
     <div>
       <h1 translate>LABEL_CHOOSE_A_DELIVERY_SPEED</h1>
-<mat-table [dataSource]="dataSource">
+      <mat-table [dataSource]="dataSource">
         <ng-container matColumnDef="Selection">
           <mat-header-cell *matHeaderCellDef></mat-header-cell>
           <mat-cell *matCellDef="let element; let row">
             <mat-radio-button (click)=selectMethod(element.id) [checked]="selection.isSelected(row)"
-                              (change)="$event ? selection.toggle(row) : null"></mat-radio-button>
+            (change)="$event ? selection.toggle(row) : null"></mat-radio-button>
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="Name">
@@ -39,7 +43,7 @@
         </ng-container>
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
         <mat-row *matRowDef="let row; columns: displayedColumns; let element"
-                (click)="selection.toggle(row); selectMethod(element.id)"></mat-row>
+        (click)="selection.toggle(row); selectMethod(element.id)"></mat-row>
       </mat-table>
     </div>
     <div style="margin-top: 20px;">
@@ -50,8 +54,8 @@
         {{'LABEL_BACK' | translate}}
       </button>
       <button mat-raised-button mat-button class="btn nextButton" color="primary"
-              aria-label="Proceed to delivery method selection" [disabled]="deliveryMethodId === undefined"
-              (click)="chooseDeliveryMethod()">
+        aria-label="Proceed to delivery method selection" [disabled]="deliveryMethodId === undefined"
+        (click)="chooseDeliveryMethod()">
         <mat-icon>
           navigate_next
         </mat-icon>

--- a/frontend/src/app/delivery-method/delivery-method.component.ts
+++ b/frontend/src/app/delivery-method/delivery-method.component.ts
@@ -8,7 +8,7 @@ import { DeliveryService } from '../Services/delivery.service'
 import { AddressService } from '../Services/address.service'
 import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table'
 import { Router } from '@angular/router'
-import { Location, NgIf, NgClass } from '@angular/common'
+import { Location, NgClass } from '@angular/common'
 import { type DeliveryMethod } from '../Models/deliveryMethod.model'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faRocket, faShippingFast, faTruck } from '@fortawesome/free-solid-svg-icons'
@@ -28,7 +28,7 @@ library.add(faRocket, faShippingFast, faTruck)
   selector: 'app-delivery-method',
   templateUrl: './delivery-method.component.html',
   styleUrls: ['./delivery-method.component.scss'],
-  imports: [MatCardModule, NgIf, TranslateModule, MatDivider, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatRadioButton, NgClass, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatDivider, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatRadioButton, NgClass, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatButtonModule, MatIconModule]
 })
 export class DeliveryMethodComponent implements OnInit {
   public displayedColumns = ['Selection', 'Name', 'Price', 'ETA']

--- a/frontend/src/app/deluxe-user/deluxe-user.component.html
+++ b/frontend/src/app/deluxe-user/deluxe-user.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 @if (error) {

--- a/frontend/src/app/deluxe-user/deluxe-user.component.html
+++ b/frontend/src/app/deluxe-user/deluxe-user.component.html
@@ -1,11 +1,13 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
 -->
 
-<div *ngIf="error" class="heading mat-elevation-z6">
-  <span class="error">{{error}}</span>
-</div>
+@if (error) {
+  <div class="heading mat-elevation-z6">
+    <span class="error">{{error}}</span>
+  </div>
+}
 
 <mat-card appearance="outlined" class="mat-elevation-z6 deluxe-membership">
   <svg preserveAspectRatio="xMidYMid meet" viewBox="0 0 720 720" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/app/deluxe-user/deluxe-user.component.ts
+++ b/frontend/src/app/deluxe-user/deluxe-user.component.ts
@@ -12,13 +12,12 @@ import { MatIconModule } from '@angular/material/icon'
 import { MatButtonModule } from '@angular/material/button'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatCardModule } from '@angular/material/card'
-import { NgIf } from '@angular/common'
 
 @Component({
   selector: 'app-deluxe-user',
   templateUrl: './deluxe-user.component.html',
   styleUrls: ['./deluxe-user.component.scss'],
-  imports: [NgIf, MatCardModule, TranslateModule, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatButtonModule, MatIconModule]
 })
 
 export class DeluxeUserComponent implements OnInit {

--- a/frontend/src/app/faucet/faucet.component.html
+++ b/frontend/src/app/faucet/faucet.component.html
@@ -10,76 +10,80 @@
         <span color="accent">
           {{'FAUCET_BALANCE' | translate}}: {{ BEEBalance }} | {{'BEE_BALANCE' | translate}}:
           {{ myBEEBalance }}</span
-        >
-        <div class="metamask-button">
-          <button
-            mat-raised-button
-            color="accent"
-            type="button"
-            (click)="handleAuth()"
           >
-            <mat-icon>
-              account_balance_wallet
-            </mat-icon>
-            <span *ngIf="!session" >{{"BTN_CONNECT_METAMASK" | translate}}</span>
-            <span *ngIf="session"
-              >{{ userData.address.substring(0, 6) }}...{{
-                userData.address.slice(-6)
-              }}</span
-            >
-          </button>
-        </div>
-      </div>
+          <div class="metamask-button">
+            <button
+              mat-raised-button
+              color="accent"
+              type="button"
+              (click)="handleAuth()"
+              >
+              <mat-icon>
+                account_balance_wallet
+              </mat-icon>
+              @if (!session) {
+                <span >{{"BTN_CONNECT_METAMASK" | translate}}</span>
+              }
+              @if (session) {
+                <span
+                  >{{ userData.address.substring(0, 6) }}...{{
+                  userData.address.slice(-6)
+                  }}</span
+                  >
+                }
+              </button>
+            </div>
+          </div>
 
-      <div class="withdraw-container">
-        <div>
-          <mat-form-field style="width: 100%" color="accent" appearance="outline">
-            <mat-label>{{"LABEL_NUMBER_OF_BEES" | translate}}</mat-label>
-            <input
-              matInput
-              [placeholder]="'LABEL_NUMBER_OF_BEES'|translate"
-              type="number"
-              id="withdrawAmount"
-              [(ngModel)]="withdrawAmount"
-              aria-label="Text field for the withdrawal amount"
-            />
-          </mat-form-field>
-          <h5 class="error">{{ errorMessage }}</h5>
-        </div>
-        <button
-          mat-raised-button
-          type="button"
-          color="primary"
-          (click)="extractBEETokens()"
-        >
-          <mat-icon>
-            emoji_nature
-          </mat-icon>
-          {{ "BTN_CLAIM_BEES" | translate }}
-        </button>
-      </div>
-    </div>
-  </mat-card>
-  <mat-card appearance="outlined" class="mat-elevation-z6 honeypot-container">
-    <div class="mdc-card">
-      <div class="honeypot-image mat-elevation-z6">
-        <img src="assets/public/images/HoneyPot.png" />
-      </div>
-      <h2 >{{"BEE_HONEYPOT_TITLE" | translate}}</h2>
-      <p >{{"BEE_HONEYPOT_DESCRIPTION" | translate}}</p>
+          <div class="withdraw-container">
+            <div>
+              <mat-form-field style="width: 100%" color="accent" appearance="outline">
+                <mat-label>{{"LABEL_NUMBER_OF_BEES" | translate}}</mat-label>
+                <input
+                  matInput
+                  [placeholder]="'LABEL_NUMBER_OF_BEES'|translate"
+                  type="number"
+                  id="withdrawAmount"
+                  [(ngModel)]="withdrawAmount"
+                  aria-label="Text field for the withdrawal amount"
+                  />
+                </mat-form-field>
+                <h5 class="error">{{ errorMessage }}</h5>
+              </div>
+              <button
+                mat-raised-button
+                type="button"
+                color="primary"
+                (click)="extractBEETokens()"
+                >
+                <mat-icon>
+                  emoji_nature
+                </mat-icon>
+                {{ "BTN_CLAIM_BEES" | translate }}
+              </button>
+            </div>
+          </div>
+        </mat-card>
+        <mat-card appearance="outlined" class="mat-elevation-z6 honeypot-container">
+          <div class="mdc-card">
+            <div class="honeypot-image mat-elevation-z6">
+              <img src="assets/public/images/HoneyPot.png" />
+            </div>
+            <h2 >{{"BEE_HONEYPOT_TITLE" | translate}}</h2>
+            <p >{{"BEE_HONEYPOT_DESCRIPTION" | translate}}</p>
 
-      <button
-        class="mint_button"
-        mat-raised-button
-        color="warn"
-        [disabled]="mintButtonDisabled"
-        (click)="mintNFT()"
-      >
-       <mat-icon>
-        image
-       </mat-icon>
-        {{ nftMintText }}
-      </button>
-    </div>
-  </mat-card>
-</div>
+            <button
+              class="mint_button"
+              mat-raised-button
+              color="warn"
+              [disabled]="mintButtonDisabled"
+              (click)="mintNFT()"
+              >
+              <mat-icon>
+                image
+              </mat-icon>
+              {{ nftMintText }}
+            </button>
+          </div>
+        </mat-card>
+      </div>

--- a/frontend/src/app/faucet/faucet.component.html
+++ b/frontend/src/app/faucet/faucet.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <mat-card appearance="outlined" class="mat-elevation-z6 faucet-container">
     <div class="mdc-card">
-      <h1 >{{"TITLE_BEE_HAVEN" | translate}}</h1>
+      <h1>{{"TITLE_BEE_HAVEN" | translate}}</h1>
       <div class="faucet-image">
         <img src="assets/public/images/BeeOwner.png" />
       </div>
@@ -9,81 +9,78 @@
       <div class="faucet-balance">
         <span color="accent">
           {{'FAUCET_BALANCE' | translate}}: {{ BEEBalance }} | {{'BEE_BALANCE' | translate}}:
-          {{ myBEEBalance }}</span
-          >
-          <div class="metamask-button">
-            <button
-              mat-raised-button
-              color="accent"
-              type="button"
-              (click)="handleAuth()"
-              >
-              <mat-icon>
-                account_balance_wallet
-              </mat-icon>
-              @if (!session) {
-                <span >{{"BTN_CONNECT_METAMASK" | translate}}</span>
-              }
-              @if (session) {
-                <span
-                  >{{ userData.address.substring(0, 6) }}...{{
-                  userData.address.slice(-6)
-                  }}</span
-                  >
-                }
-              </button>
-            </div>
-          </div>
-
-          <div class="withdraw-container">
-            <div>
-              <mat-form-field style="width: 100%" color="accent" appearance="outline">
-                <mat-label>{{"LABEL_NUMBER_OF_BEES" | translate}}</mat-label>
-                <input
-                  matInput
-                  [placeholder]="'LABEL_NUMBER_OF_BEES'|translate"
-                  type="number"
-                  id="withdrawAmount"
-                  [(ngModel)]="withdrawAmount"
-                  aria-label="Text field for the withdrawal amount"
-                  />
-                </mat-form-field>
-                <h5 class="error">{{ errorMessage }}</h5>
-              </div>
-              <button
-                mat-raised-button
-                type="button"
-                color="primary"
-                (click)="extractBEETokens()"
-                >
-                <mat-icon>
-                  emoji_nature
-                </mat-icon>
-                {{ "BTN_CLAIM_BEES" | translate }}
-              </button>
-            </div>
-          </div>
-        </mat-card>
-        <mat-card appearance="outlined" class="mat-elevation-z6 honeypot-container">
-          <div class="mdc-card">
-            <div class="honeypot-image mat-elevation-z6">
-              <img src="assets/public/images/HoneyPot.png" />
-            </div>
-            <h2 >{{"BEE_HONEYPOT_TITLE" | translate}}</h2>
-            <p >{{"BEE_HONEYPOT_DESCRIPTION" | translate}}</p>
-
-            <button
-              class="mint_button"
-              mat-raised-button
-              color="warn"
-              [disabled]="mintButtonDisabled"
-              (click)="mintNFT()"
-              >
-              <mat-icon>
-                image
-              </mat-icon>
-              {{ nftMintText }}
-            </button>
-          </div>
-        </mat-card>
+          {{ myBEEBalance }}
+        </span>
+        <div class="metamask-button">
+          <button
+            mat-raised-button
+            color="accent"
+            type="button"
+            (click)="handleAuth()"
+            >
+            <mat-icon>
+              account_balance_wallet
+            </mat-icon>
+            @if (session) {
+            <span>{{ userData.address.substring(0, 6) }}...{{
+              userData.address.slice(-6)
+              }}</span>
+            } @else {
+            <span>{{"BTN_CONNECT_METAMASK" | translate}}</span>
+            }
+          </button>
+        </div>
       </div>
+
+      <div class="withdraw-container">
+        <div>
+          <mat-form-field style="width: 100%" color="accent" appearance="outline">
+            <mat-label>{{"LABEL_NUMBER_OF_BEES" | translate}}</mat-label>
+            <input
+              matInput
+              [placeholder]="'LABEL_NUMBER_OF_BEES'|translate"
+              type="number"
+              id="withdrawAmount"
+              [(ngModel)]="withdrawAmount"
+              aria-label="Text field for the withdrawal amount"
+              />
+          </mat-form-field>
+          <h5 class="error">{{ errorMessage }}</h5>
+        </div>
+        <button
+          mat-raised-button
+          type="button"
+          color="primary"
+          (click)="extractBEETokens()"
+          >
+          <mat-icon>
+            emoji_nature
+          </mat-icon>
+          {{ "BTN_CLAIM_BEES" | translate }}
+        </button>
+      </div>
+    </div>
+  </mat-card>
+  <mat-card appearance="outlined" class="mat-elevation-z6 honeypot-container">
+    <div class="mdc-card">
+      <div class="honeypot-image mat-elevation-z6">
+        <img src="assets/public/images/HoneyPot.png" />
+      </div>
+      <h2>{{"BEE_HONEYPOT_TITLE" | translate}}</h2>
+      <p>{{"BEE_HONEYPOT_DESCRIPTION" | translate}}</p>
+
+      <button 
+        class="mint_button"
+        mat-raised-button
+        color="warn"
+        [disabled]="mintButtonDisabled"
+        (click)="mintNFT()"
+      >
+        <mat-icon>
+          image
+        </mat-icon>
+        {{ nftMintText }}
+      </button>
+    </div>
+  </mat-card>
+</div>

--- a/frontend/src/app/faucet/faucet.component.ts
+++ b/frontend/src/app/faucet/faucet.component.ts
@@ -18,7 +18,7 @@ import {
 import { FormsModule } from '@angular/forms'
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field'
-import { NgIf } from '@angular/common'
+
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
 import { MatIconModule } from '@angular/material/icon'
@@ -38,7 +38,7 @@ const BeeFaucetAddress = '0x860e3616aD0E0dEDc23352891f3E10C4131EA5BC'
   selector: 'app-faucet',
   templateUrl: './faucet.component.html',
   styleUrls: ['./faucet.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatButtonModule, NgIf, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatButtonModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, MatIconModule]
 })
 export class FaucetComponent {
   constructor (

--- a/frontend/src/app/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/forgot-password/forgot-password.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -10,12 +10,12 @@
       <h1 translate>TITLE_FORGOT_PASSWORD</h1>
 
       <div class="confirmation"
-          [hidden]="!(confirmation && !emailControl.dirty && !securityQuestionControl.dirty && !passwordControl.dirty && !repeatPasswordControl.dirty)">
+        [hidden]="!(confirmation && !emailControl.dirty && !securityQuestionControl.dirty && !passwordControl.dirty && !repeatPasswordControl.dirty)">
         {{ confirmation }}
       </div>
 
       <div class="error"
-          [hidden]="!(error && !emailControl.dirty && !securityQuestionControl.dirty && !passwordControl.dirty && !repeatPasswordControl.dirty)">
+        [hidden]="!(error && !emailControl.dirty && !securityQuestionControl.dirty && !passwordControl.dirty && !repeatPasswordControl.dirty)">
         {{ error }}
       </div>
 
@@ -24,81 +24,97 @@
         <mat-form-field appearance="outline" color="accent">
           <mat-label translate>LABEL_EMAIL</mat-label>
           <input id="email" [formControl]="emailControl" (ngModelChange)="findSecurityQuestion()"
-                type="email" matInput placeholder="Enter your email" aria-label="Email address field">
-          <mat-icon matSuffix matTooltip="{{ 'MANDATORY_EMAIL' | translate  }}"
-                    matTooltipPosition=right aria-label="Please enter your email address to proceed">help_outline
-          </mat-icon>
-          <mat-error *ngIf="emailControl.invalid && emailControl.errors.required" translate>MANDATORY_EMAIL</mat-error>
-          <mat-error *ngIf="emailControl.invalid && emailControl.errors.email" translate>INVALID_EMAIL</mat-error>
-        </mat-form-field>
+            type="email" matInput placeholder="Enter your email" aria-label="Email address field">
+            <mat-icon matSuffix matTooltip="{{ 'MANDATORY_EMAIL' | translate  }}"
+              matTooltipPosition=right aria-label="Please enter your email address to proceed">help_outline
+            </mat-icon>
+            @if (emailControl.invalid && emailControl.errors.required) {
+              <mat-error translate>MANDATORY_EMAIL</mat-error>
+            }
+            @if (emailControl.invalid && emailControl.errors.email) {
+              <mat-error translate>INVALID_EMAIL</mat-error>
+            }
+          </mat-form-field>
 
-      </div>
-
-      <div class="form-container" id="forgot-form">
-
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_SECURITY_QUESTION</mat-label>
-          <input id="securityAnswer" [formControl]="securityQuestionControl" type="password" matInput
-                placeholder="{{ securityQuestion }}"
-                aria-label="Field for the answer to the security question">
-          <mat-icon matSuffix matTooltip="{{ 'MANDATORY_SECURITY_ANSWER' | translate  }}"
-                    matTooltipPosition=right aria-label="Please answer your selected security question">help_outline
-          </mat-icon>
-          <mat-error *ngIf="securityQuestionControl.invalid && securityQuestionControl.errors.required" translate>
-            MANDATORY_SECURITY_ANSWER
-          </mat-error>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_NEW_PASSWORD</mat-label>
-          <input #password id="newPassword" [formControl]="passwordControl" type="password" matInput placeholder=""
-                aria-label="Field for New Password">
-          <mat-hint translate>
-            <i class="fas fa-exclamation-circle"></i>
-            <em style="margin-left:5px;" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
-          </mat-hint>
-          <mat-hint align="end">{{password.value?.length || 0}}/20</mat-hint>
-          <mat-error *ngIf="passwordControl.invalid && passwordControl.errors.required" translate>MANDATORY_NEW_PASSWORD
-          </mat-error>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_REPEAT_NEW_PASSWORD</mat-label>
-          <input #repeatPassword id="newPasswordRepeat" [formControl]="repeatPasswordControl" type="password" matInput
-                placeholder=""
-                aria-label="Field to confirm the new password">
-          <mat-hint align="end">{{repeatPassword.value?.length || 0}}/20</mat-hint>
-          <mat-error *ngIf="repeatPasswordControl.invalid && repeatPasswordControl.errors.required" translate>
-            MANDATORY_PASSWORD_REPEAT
-          </mat-error>
-          <mat-error *ngIf="repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame" translate>
-            PASSWORDS_NOT_MATCHING
-          </mat-error>
-          <mat-error *ngIf="repeatPasswordControl.invalid && (repeatPasswordControl?.errors.minlength || repeatPasswordControl?.errors.maxlength)" translate
-                    [translateParams]="{length: '5-40'}">INVALID_PASSWORD_LENGTH
-          </mat-error>
-        </mat-form-field>
-
-        <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
-        <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
-        <div class="advice-container">
-          <app-password-strength-info *ngIf="passwordInfoToggle.checked" [passwordComponent]="passwordStrength"
-                                      [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
-                                      [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
-                                      [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
-                                      [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
-                                      [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
-          </app-password-strength-info>
         </div>
-      </div>
 
-      <button type="submit" id="resetButton"
-              [disabled]="emailControl.invalid || securityQuestionControl.invalid || passwordControl.invalid || repeatPasswordControl.invalid || repeatPasswordControl.disabled"
-              (click)="resetPassword()" mat-raised-button color="primary" aria-label="Button to confirm the changes">
-        <i class="far fa-edit fa-lg" aria-hidden="true"></i>
-        {{'BTN_CHANGE' | translate}}
-      </button>
+        <div class="form-container" id="forgot-form">
 
-    </div>
-  </mat-card>
-</div>
+          <mat-form-field appearance="outline" color="accent">
+            <mat-label translate>LABEL_SECURITY_QUESTION</mat-label>
+            <input id="securityAnswer" [formControl]="securityQuestionControl" type="password" matInput
+              placeholder="{{ securityQuestion }}"
+              aria-label="Field for the answer to the security question">
+              <mat-icon matSuffix matTooltip="{{ 'MANDATORY_SECURITY_ANSWER' | translate  }}"
+                matTooltipPosition=right aria-label="Please answer your selected security question">help_outline
+              </mat-icon>
+              @if (securityQuestionControl.invalid && securityQuestionControl.errors.required) {
+                <mat-error translate>
+                  MANDATORY_SECURITY_ANSWER
+                </mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" color="accent">
+              <mat-label translate>LABEL_NEW_PASSWORD</mat-label>
+              <input #password id="newPassword" [formControl]="passwordControl" type="password" matInput placeholder=""
+                aria-label="Field for New Password">
+                <mat-hint translate>
+                  <i class="fas fa-exclamation-circle"></i>
+                  <em style="margin-left:5px;" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
+                </mat-hint>
+                <mat-hint align="end">{{password.value?.length || 0}}/20</mat-hint>
+                @if (passwordControl.invalid && passwordControl.errors.required) {
+                  <mat-error translate>MANDATORY_NEW_PASSWORD
+                  </mat-error>
+                }
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" color="accent">
+                <mat-label translate>LABEL_REPEAT_NEW_PASSWORD</mat-label>
+                <input #repeatPassword id="newPasswordRepeat" [formControl]="repeatPasswordControl" type="password" matInput
+                  placeholder=""
+                  aria-label="Field to confirm the new password">
+                  <mat-hint align="end">{{repeatPassword.value?.length || 0}}/20</mat-hint>
+                  @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.required) {
+                    <mat-error translate>
+                      MANDATORY_PASSWORD_REPEAT
+                    </mat-error>
+                  }
+                  @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame) {
+                    <mat-error translate>
+                      PASSWORDS_NOT_MATCHING
+                    </mat-error>
+                  }
+                  @if (repeatPasswordControl.invalid && (repeatPasswordControl?.errors.minlength || repeatPasswordControl?.errors.maxlength)) {
+                    <mat-error translate
+                      [translateParams]="{length: '5-40'}">INVALID_PASSWORD_LENGTH
+                    </mat-error>
+                  }
+                </mat-form-field>
+
+                <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
+                <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
+                <div class="advice-container">
+                  @if (passwordInfoToggle.checked) {
+                    <app-password-strength-info [passwordComponent]="passwordStrength"
+                      [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
+                      [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
+                      [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
+                      [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
+                      [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
+                    </app-password-strength-info>
+                  }
+                </div>
+              </div>
+
+              <button type="submit" id="resetButton"
+                [disabled]="emailControl.invalid || securityQuestionControl.invalid || passwordControl.invalid || repeatPasswordControl.invalid || repeatPasswordControl.disabled"
+                (click)="resetPassword()" mat-raised-button color="primary" aria-label="Button to confirm the changes">
+                <i class="far fa-edit fa-lg" aria-hidden="true"></i>
+                {{'BTN_CHANGE' | translate}}
+              </button>
+
+            </div>
+          </mat-card>
+        </div>

--- a/frontend/src/app/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/forgot-password/forgot-password.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/forgot-password/forgot-password.component.ts
@@ -16,7 +16,7 @@ import { MatButtonModule } from '@angular/material/button'
 import { PasswordStrengthComponent } from '../password-strength/password-strength.component'
 import { PasswordStrengthInfoComponent } from '../password-strength-info/password-strength-info.component'
 import { MatSlideToggle } from '@angular/material/slide-toggle'
-import { NgIf } from '@angular/common'
+
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
@@ -29,7 +29,7 @@ library.add(faSave, faEdit)
   selector: 'app-forgot-password',
   templateUrl: './forgot-password.component.html',
   styleUrls: ['./forgot-password.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatIconModule, MatSuffix, MatTooltip, NgIf, MatError, MatHint, MatSlideToggle, PasswordStrengthComponent, PasswordStrengthInfoComponent, MatButtonModule]
+  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatIconModule, MatSuffix, MatTooltip, MatError, MatHint, MatSlideToggle, PasswordStrengthComponent, PasswordStrengthInfoComponent, MatButtonModule]
 })
 export class ForgotPasswordComponent {
   public emailControl: UntypedFormControl = new UntypedFormControl('', [Validators.required, Validators.email])

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -9,72 +9,86 @@
 
       <h1>Login</h1>
 
-      <div class="error" *ngIf="error">{{error}}</div>
+      @if (error) {
+        <div class="error">{{error}}</div>
+      }
 
       <div class="form-container" id="login-form">
 
         <mat-form-field color="accent" appearance="outline">
           <mat-label translate>LABEL_EMAIL</mat-label>
           <input id="email" #email name="email"
-                [formControl]="emailControl"
-                (focus)="this.error=null"
-                matInput placeholder=""
-                aria-label="Text field for the login email">
-          <mat-error *ngIf="emailControl.invalid" translate>MANDATORY_EMAIL</mat-error>
-        </mat-form-field>
+            [formControl]="emailControl"
+            (focus)="this.error=null"
+            matInput placeholder=""
+            aria-label="Text field for the login email">
+            @if (emailControl.invalid) {
+              <mat-error translate>MANDATORY_EMAIL</mat-error>
+            }
+          </mat-form-field>
 
-        <mat-form-field color="accent" appearance="outline">
-          <mat-label translate>LABEL_PASSWORD</mat-label>
-          <input id="password" #password name="password"
-                [formControl]="passwordControl"
-                (focus)="this.error=null"
-                matInput placeholder="" [type]="hide ? 'password' : 'text'"
-                aria-label="Text field for the login password">
-          <button *ngIf="hide" mat-icon-button matSuffix (click)="hide = !hide"
+          <mat-form-field color="accent" appearance="outline">
+            <mat-label translate>LABEL_PASSWORD</mat-label>
+            <input id="password" #password name="password"
+              [formControl]="passwordControl"
+              (focus)="this.error=null"
+              matInput placeholder="" [type]="hide ? 'password' : 'text'"
+              aria-label="Text field for the login password">
+              @if (hide) {
+                <button mat-icon-button matSuffix (click)="hide = !hide"
                   aria-label="Button to display the password" matTooltip="{{ 'SHOW_PWD_TOOLTIP' | translate  }}"
                   matTooltipPosition=right>
-            <i class="fas fa-eye" aria-label="Eye"></i>
-          </button>
-          <button *ngIf="!hide" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password" matTooltip="{{ 'HIDE_PWD_TOOLTIP' | translate  }}"
+                  <i class="fas fa-eye" aria-label="Eye"></i>
+                </button>
+              }
+              @if (!hide) {
+                <button mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password" matTooltip="{{ 'HIDE_PWD_TOOLTIP' | translate  }}"
                   matTooltipPosition=right>
-            <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
-          </button>
-          <mat-error *ngIf="passwordControl.invalid" translate>MANDATORY_PASSWORD</mat-error>
-        </mat-form-field>
+                  <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
+                </button>
+              }
+              @if (passwordControl.invalid) {
+                <mat-error translate>MANDATORY_PASSWORD</mat-error>
+              }
+            </mat-form-field>
 
-        <a class="primary-link forgot-pw" routerLink="/forgot-password" translate>FORGOT_PASSWORD</a>
+            <a class="primary-link forgot-pw" routerLink="/forgot-password" translate>FORGOT_PASSWORD</a>
 
-        <button type="submit" id="loginButton" [disabled]="!emailControl.value||!passwordControl.value" mat-raised-button
-                color="primary" (click)="login()" aria-label="Login">
-          <mat-icon>
-            exit_to_app
-          </mat-icon>
-          {{'BTN_LOGIN' | translate}}
-        </button>
+            <button type="submit" id="loginButton" [disabled]="!emailControl.value||!passwordControl.value" mat-raised-button
+              color="primary" (click)="login()" aria-label="Login">
+              <mat-icon>
+                exit_to_app
+              </mat-icon>
+              {{'BTN_LOGIN' | translate}}
+            </button>
 
-        <mat-checkbox [formControl]="rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
-          {{'REMEMBER_ME' | translate}}
-        </mat-checkbox>
+            <mat-checkbox [formControl]="rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
+              {{'REMEMBER_ME' | translate}}
+            </mat-checkbox>
 
-        <div class="breakLine" *ngIf="!oauthUnavailable">
-          <div class="line">
-            <div></div>
-          </div>
-          <div class="textOnLine" translate>LABEL_OR</div>
-          <div class="line">
-            <div></div>
-          </div>
-        </div>
+            @if (!oauthUnavailable) {
+              <div class="breakLine">
+                <div class="line">
+                  <div></div>
+                </div>
+                <div class="textOnLine" translate>LABEL_OR</div>
+                <div class="line">
+                  <div></div>
+                </div>
+              </div>
+            }
 
-        <button id="loginButtonGoogle" *ngIf="!oauthUnavailable" mat-raised-button color="accent" (click)="googleLogin()"
+            @if (!oauthUnavailable) {
+              <button id="loginButtonGoogle" mat-raised-button color="accent" (click)="googleLogin()"
                 aria-label="Login with Google" class="google-button"><i
-          class="fab fa-google fa-lg"></i> {{'BTN_GOOGLE_LOGIN' | translate}}
-        </button>
+              class="fab fa-google fa-lg"></i> {{'BTN_GOOGLE_LOGIN' | translate}}
+            </button>
+          }
 
-        <div id="newCustomerLink">
-          <a class="primary-link" routerLink="/register" translate>NO_CUSTOMER</a>
+          <div id="newCustomerLink">
+            <a class="primary-link" routerLink="/register" translate>NO_CUSTOMER</a>
+          </div>
         </div>
       </div>
-    </div>
-  </mat-card>
-</div>
+    </mat-card>
+  </div>

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -10,7 +10,7 @@
       <h1>Login</h1>
 
       @if (error) {
-        <div class="error">{{error}}</div>
+      <div class="error">{{error}}</div>
       }
 
       <div class="form-container" id="login-form">
@@ -21,74 +21,85 @@
             [formControl]="emailControl"
             (focus)="this.error=null"
             matInput placeholder=""
-            aria-label="Text field for the login email">
-            @if (emailControl.invalid) {
-              <mat-error translate>MANDATORY_EMAIL</mat-error>
-            }
-          </mat-form-field>
-
-          <mat-form-field color="accent" appearance="outline">
-            <mat-label translate>LABEL_PASSWORD</mat-label>
-            <input id="password" #password name="password"
-              [formControl]="passwordControl"
-              (focus)="this.error=null"
-              matInput placeholder="" [type]="hide ? 'password' : 'text'"
-              aria-label="Text field for the login password">
-              @if (hide) {
-                <button mat-icon-button matSuffix (click)="hide = !hide"
-                  aria-label="Button to display the password" matTooltip="{{ 'SHOW_PWD_TOOLTIP' | translate  }}"
-                  matTooltipPosition=right>
-                  <i class="fas fa-eye" aria-label="Eye"></i>
-                </button>
-              }
-              @if (!hide) {
-                <button mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password" matTooltip="{{ 'HIDE_PWD_TOOLTIP' | translate  }}"
-                  matTooltipPosition=right>
-                  <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
-                </button>
-              }
-              @if (passwordControl.invalid) {
-                <mat-error translate>MANDATORY_PASSWORD</mat-error>
-              }
-            </mat-form-field>
-
-            <a class="primary-link forgot-pw" routerLink="/forgot-password" translate>FORGOT_PASSWORD</a>
-
-            <button type="submit" id="loginButton" [disabled]="!emailControl.value||!passwordControl.value" mat-raised-button
-              color="primary" (click)="login()" aria-label="Login">
-              <mat-icon>
-                exit_to_app
-              </mat-icon>
-              {{'BTN_LOGIN' | translate}}
-            </button>
-
-            <mat-checkbox [formControl]="rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
-              {{'REMEMBER_ME' | translate}}
-            </mat-checkbox>
-
-            @if (!oauthUnavailable) {
-              <div class="breakLine">
-                <div class="line">
-                  <div></div>
-                </div>
-                <div class="textOnLine" translate>LABEL_OR</div>
-                <div class="line">
-                  <div></div>
-                </div>
-              </div>
-            }
-
-            @if (!oauthUnavailable) {
-              <button id="loginButtonGoogle" mat-raised-button color="accent" (click)="googleLogin()"
-                aria-label="Login with Google" class="google-button"><i
-              class="fab fa-google fa-lg"></i> {{'BTN_GOOGLE_LOGIN' | translate}}
-            </button>
+            aria-label="Text field for the login email"
+          >
+          @if (emailControl.invalid) {
+          <mat-error translate>MANDATORY_EMAIL</mat-error>
           }
+        </mat-form-field>
 
-          <div id="newCustomerLink">
-            <a class="primary-link" routerLink="/register" translate>NO_CUSTOMER</a>
+        <mat-form-field color="accent" appearance="outline">
+          <mat-label translate>LABEL_PASSWORD</mat-label>
+          <input id="password" #password name="password"
+            [formControl]="passwordControl"
+            (focus)="this.error=null"
+            matInput placeholder="" [type]="hide ? 'password' : 'text'"
+            aria-label="Text field for the login password"
+          >
+          @if (hide) {
+          <button mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to display the password"
+            matTooltip="{{ 'SHOW_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
+            <i class="fas fa-eye" aria-label="Eye"></i>
+          </button>
+          } @else {
+          <button mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password"
+            matTooltip="{{ 'HIDE_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
+            <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
+          </button>
+          }
+          @if (passwordControl.invalid) {
+          <mat-error translate>MANDATORY_PASSWORD</mat-error>
+          }
+        </mat-form-field>
+
+        <a class="primary-link forgot-pw" routerLink="/forgot-password" translate>FORGOT_PASSWORD</a>
+
+        <button
+          type="submit"
+          id="loginButton"
+          [disabled]="!emailControl.value||!passwordControl.value"
+          mat-raised-button
+          color="primary"
+          (click)="login()"
+          aria-label="Login"
+        >
+          <mat-icon>
+            exit_to_app
+          </mat-icon>
+          {{'BTN_LOGIN' | translate}}
+        </button>
+
+        <mat-checkbox [formControl]="rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
+          {{'REMEMBER_ME' | translate}}
+        </mat-checkbox>
+
+        @if (!oauthUnavailable) {
+        <div class="breakLine">
+          <div class="line">
+            <div></div>
+          </div>
+          <div class="textOnLine" translate>LABEL_OR</div>
+          <div class="line">
+            <div></div>
           </div>
         </div>
+        }
+
+        @if (!oauthUnavailable) {
+        <button id="loginButtonGoogle"
+          mat-raised-button color="accent"
+          (click)="googleLogin()"
+          aria-label="Login with Google"
+          class="google-button"
+        >
+          <i class="fab fa-google fa-lg"></i> {{'BTN_GOOGLE_LOGIN' | translate}}
+        </button>
+        }
+
+        <div id="newCustomerLink">
+          <a class="primary-link" routerLink="/register" translate>NO_CUSTOMER</a>
+        </div>
       </div>
-    </mat-card>
-  </div>
+    </div>
+  </mat-card>
+</div>

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -22,7 +22,7 @@ import { MatIconButton, MatButtonModule } from '@angular/material/button'
 import { MatInputModule } from '@angular/material/input'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatFormFieldModule, MatLabel, MatError, MatSuffix } from '@angular/material/form-field'
-import { NgIf } from '@angular/common'
+
 import { MatCardModule } from '@angular/material/card'
 
 library.add(faKey, faEye, faEyeSlash, faGoogle)
@@ -33,7 +33,7 @@ const oauthProviderUrl = 'https://accounts.google.com/o/oauth2/v2/auth'
   selector: 'app-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
-  imports: [MatCardModule, NgIf, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatIconButton, MatSuffix, MatTooltip, RouterLink, MatButtonModule, MatIconModule, MatCheckbox]
+  imports: [MatCardModule, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatIconButton, MatSuffix, MatTooltip, RouterLink, MatButtonModule, MatIconModule, MatCheckbox]
 })
 
 export class LoginComponent implements OnInit {

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -36,17 +36,6 @@
     </button>
 
     <mat-menu #userMenu="matMenu">
-      @if (!isLoggedIn()) {
-        <button mat-menu-item routerLink="/login" aria-label="Go to login page"
-          id="navbarLoginButton">
-          <mat-icon>
-            exit_to_app
-          </mat-icon>
-          <span>
-            {{"TITLE_LOGIN" | translate }}
-          </span>
-        </button>
-      }
       @if (isLoggedIn()) {
         <button (click)="goToProfilePage()" mat-menu-item aria-label="Go to user profile">
           <mat-icon>
@@ -54,6 +43,16 @@
           </mat-icon>
           <span>
             {{userEmail}}
+          </span>
+        </button>
+      } @else {
+        <button mat-menu-item routerLink="/login" aria-label="Go to login page"
+          id="navbarLoginButton">
+          <mat-icon>
+            exit_to_app
+          </mat-icon>
+          <span>
+            {{"TITLE_LOGIN" | translate }}
           </span>
         </button>
       }

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -1,14 +1,14 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-toolbar class="mat-elevation-z6 navbar-toolbar" color="primary">
 
   <mat-toolbar-row class="navbar-row">
 
     <button (click)="onToggleSidenav()" mat-icon-button style="height:48px; width: 48px;" aria-label="Open Sidenav"
-            matTooltip="{{ 'SIDENAV_HINT' | translate }}" matTooltipPosition="below">
+      matTooltip="{{ 'SIDENAV_HINT' | translate }}" matTooltipPosition="below">
       <mat-icon>menu</mat-icon>
     </button>
 
@@ -25,10 +25,10 @@
       <div id="product-search-fixture"></div>
     </div>
     <app-mat-search-bar #searchControl id="searchQuery" (onEnter)="search(searchControl.value)"
-                    aria-label="Click to search"></app-mat-search-bar>
+    aria-label="Click to search"></app-mat-search-bar>
 
     <button [matMenuTriggerFor]="userMenu" mat-button style="vertical-align: middle; height:48px;" class="buttons hide-lt-md"
-            aria-label="Show/hide account menu" id="navbarAccount">
+      aria-label="Show/hide account menu" id="navbarAccount">
       <mat-icon>
         account_circle
       </mat-icon>
@@ -36,73 +36,87 @@
     </button>
 
     <mat-menu #userMenu="matMenu">
-      <button *ngIf="!isLoggedIn()" mat-menu-item routerLink="/login" aria-label="Go to login page"
-              id="navbarLoginButton">
-        <mat-icon>
-          exit_to_app
-        </mat-icon>
-        <span>
-          {{"TITLE_LOGIN" | translate }}
-        </span>
-      </button>
-      <button (click)="goToProfilePage()" *ngIf="isLoggedIn()" mat-menu-item aria-label="Go to user profile">
-        <mat-icon>
-          account_circle
-        </mat-icon>
-        <span>
-          {{userEmail}}
-        </span>
-      </button>
-      <button *ngIf="isLoggedIn() && isAccounting()" mat-menu-item routerLink="/accounting"
-              aria-label="Go to accounting page">
-        <mat-icon>
-          account_balance
-        </mat-icon>
-        <span>
-          {{"ACCOUNTING" | translate}}
-        </span>
-      </button>
-      <button mat-menu-item *ngIf="isLoggedIn()" [matMenuTriggerFor]="ordersSubMenu"
-              aria-label="Show Orders and Payment Menu">
-        <mat-icon>
-          check_circle_outline
-        </mat-icon>
-        <span>
-          {{ "ORDERS_AND_PAYMENT" | translate }}
-        </span>
-      </button>
-      <button mat-menu-item *ngIf="isLoggedIn()" [matMenuTriggerFor]="privacySubMenu"
-              aria-label="Show Privacy and Security Menu">
-        <mat-icon>
-          security
-        </mat-icon>
-        <span>
-          {{ "PRIVACY_AND_SECURITY" | translate }}
-        </span>
-      </button>
-      <button (click)="logout()" *ngIf="isLoggedIn()" mat-menu-item aria-label="Logout" id="navbarLogoutButton">
-        <mat-icon>
-          power_settings_new
-        </mat-icon>
-        <span>
-          {{"TITLE_LOGOUT" | translate }}
-        </span>
-      </button>
-</mat-menu>
+      @if (!isLoggedIn()) {
+        <button mat-menu-item routerLink="/login" aria-label="Go to login page"
+          id="navbarLoginButton">
+          <mat-icon>
+            exit_to_app
+          </mat-icon>
+          <span>
+            {{"TITLE_LOGIN" | translate }}
+          </span>
+        </button>
+      }
+      @if (isLoggedIn()) {
+        <button (click)="goToProfilePage()" mat-menu-item aria-label="Go to user profile">
+          <mat-icon>
+            account_circle
+          </mat-icon>
+          <span>
+            {{userEmail}}
+          </span>
+        </button>
+      }
+      @if (isLoggedIn() && isAccounting()) {
+        <button mat-menu-item routerLink="/accounting"
+          aria-label="Go to accounting page">
+          <mat-icon>
+            account_balance
+          </mat-icon>
+          <span>
+            {{"ACCOUNTING" | translate}}
+          </span>
+        </button>
+      }
+      @if (isLoggedIn()) {
+        <button mat-menu-item [matMenuTriggerFor]="ordersSubMenu"
+          aria-label="Show Orders and Payment Menu">
+          <mat-icon>
+            check_circle_outline
+          </mat-icon>
+          <span>
+            {{ "ORDERS_AND_PAYMENT" | translate }}
+          </span>
+        </button>
+      }
+      @if (isLoggedIn()) {
+        <button mat-menu-item [matMenuTriggerFor]="privacySubMenu"
+          aria-label="Show Privacy and Security Menu">
+          <mat-icon>
+            security
+          </mat-icon>
+          <span>
+            {{ "PRIVACY_AND_SECURITY" | translate }}
+          </span>
+        </button>
+      }
+      @if (isLoggedIn()) {
+        <button (click)="logout()" mat-menu-item aria-label="Logout" id="navbarLogoutButton">
+          <mat-icon>
+            power_settings_new
+          </mat-icon>
+          <span>
+            {{"TITLE_LOGOUT" | translate }}
+          </span>
+        </button>
+      }
+    </mat-menu>
 
-    <button *ngIf="isLoggedIn()" mat-button routerLink="/basket" style="height:48px;" class="buttons"
-            aria-label="Show the shopping cart">
-      <mat-icon>
-        shopping_cart
-      </mat-icon>
-      <span class="hide-lt-md" style="margin-right: 10px;"> {{"TITLE_BASKET" | translate}}</span>
-      <span class="fa-layers-counter fa-layers-top-right fa-3x warn-notification"
-            style="font-size: 47px;">{{itemTotal}}</span>
-    </button>
+    @if (isLoggedIn()) {
+      <button mat-button routerLink="/basket" style="height:48px;" class="buttons"
+        aria-label="Show the shopping cart">
+        <mat-icon>
+          shopping_cart
+        </mat-icon>
+        <span class="hide-lt-md" style="margin-right: 10px;"> {{"TITLE_BASKET" | translate}}</span>
+        <span class="fa-layers-counter fa-layers-top-right fa-3x warn-notification"
+        style="font-size: 47px;">{{itemTotal}}</span>
+      </button>
+    }
 
     <button id="navbarLanguageButton" [matMenuTriggerFor]="menu" mat-button style="height:48px; width: 48px;" class="buttons"
-            aria-label="Language selection menu"
-            matTooltip="{{ 'LANGUAGE_SEL_HINT' | translate }}" matTooltipPosition="below">
+      aria-label="Language selection menu"
+      matTooltip="{{ 'LANGUAGE_SEL_HINT' | translate }}" matTooltipPosition="below">
       <mat-icon>
         language
       </mat-icon>
@@ -118,16 +132,18 @@
         </mat-form-field>
       </div>
       @for (language of filteredLanguages; track language.key) {
-        <mat-radio-button 
-          (click)="changeLanguage(language.key)" 
+        <mat-radio-button
+          (click)="changeLanguage(language.key)"
           [value]="language"
           class="mat-menu-item"
           style="width: 240px;"
           [checked]="selectedLanguage === language"
           [aria-label]="language.lang"
-        >
+          >
           <div class="mat-body" style="display: inline-block; width: 200px; margin-left: 5px;">
-            <span *ngFor="let icon of language.icons" [class]="'fi fi-' + icon"></span>
+            @for (icon of language.icons; track icon) {
+              <span [class]="'fi fi-' + icon"></span>
+            }
             {{language?.lang}}
           </div>
           <i [class]="'fas fa-thermometer-' + language.gauge + (language.percentage > 70 ? ' confirmation' : ' error')"></i>
@@ -162,7 +178,7 @@
         <span translate>TITLE_CHANGE_PASSWORD</span>
       </button>
       <button mat-menu-item [routerLink]="['privacy-security/two-factor-authentication']"
-              aria-label="Go to two factor authentication page">
+        aria-label="Go to two factor authentication page">
         <mat-icon>
           exposure_plus_2
         </mat-icon>
@@ -194,31 +210,37 @@
         </span>
       </button>
       <mat-divider></mat-divider>
-      <button *ngIf="isLoggedIn()" mat-menu-item routerLink="/address/saved" aria-label="Go to saved address page">
-        <mat-icon>
-          my_location
-        </mat-icon>
-        <span>
-          {{"MY_SAVED_ADRESSES" | translate}}
-        </span>
-      </button>
-      <button *ngIf="isLoggedIn()" mat-menu-item routerLink="/saved-payment-methods"
-              aria-label="Go to saved payment methods page">
-        <mat-icon>
-          credit_card
-        </mat-icon>
-        <span>
-          {{"MY_PAYMENT_OPTIONS" | translate}}
-        </span>
-      </button>
-      <button *ngIf="isLoggedIn()" mat-menu-item routerLink="/wallet" aria-label="Go to wallet page">
-        <mat-icon>
-          account_balance_wallet
-        </mat-icon>
-        <span>
-          {{"DIGITAL_WALLET" | translate}}
-        </span>
-      </button>
+      @if (isLoggedIn()) {
+        <button mat-menu-item routerLink="/address/saved" aria-label="Go to saved address page">
+          <mat-icon>
+            my_location
+          </mat-icon>
+          <span>
+            {{"MY_SAVED_ADRESSES" | translate}}
+          </span>
+        </button>
+      }
+      @if (isLoggedIn()) {
+        <button mat-menu-item routerLink="/saved-payment-methods"
+          aria-label="Go to saved payment methods page">
+          <mat-icon>
+            credit_card
+          </mat-icon>
+          <span>
+            {{"MY_PAYMENT_OPTIONS" | translate}}
+          </span>
+        </button>
+      }
+      @if (isLoggedIn()) {
+        <button mat-menu-item routerLink="/wallet" aria-label="Go to wallet page">
+          <mat-icon>
+            account_balance_wallet
+          </mat-icon>
+          <span>
+            {{"DIGITAL_WALLET" | translate}}
+          </span>
+        </button>
+      }
 
     </mat-menu>
 

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-toolbar class="mat-elevation-z6 navbar-toolbar" color="primary">

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -47,7 +47,7 @@ import { LoginGuard } from '../app.guard'
 import { roles } from '../roles'
 import { MatDivider } from '@angular/material/divider'
 import { MatRadioButton } from '@angular/material/radio'
-import { NgIf, NgFor } from '@angular/common'
+
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu'
 import { MatSearchBarComponent } from '../mat-search-bar/mat-search-bar.component'
 
@@ -64,10 +64,22 @@ library.add(faLanguage, faSearch, faSignInAlt, faSignOutAlt, faComment, faBomb, 
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
   imports: [
-    MatToolbar, MatToolbarRow, MatButtonModule, MatTooltip,
-    MatIconModule, RouterLink, MatSearchBarComponent,
-    MatMenuTrigger, MatMenu, NgIf, MatMenuItem, NgFor, MatRadioButton,
-    TranslateModule, MatDivider, MatFormFieldModule, MatInputModule, FormsModule
+    MatToolbar,
+    MatToolbarRow,
+    MatButtonModule,
+    MatTooltip,
+    MatIconModule,
+    RouterLink,
+    MatSearchBarComponent,
+    MatMenuTrigger,
+    MatMenu,
+    MatMenuItem,
+    MatRadioButton,
+    TranslateModule,
+    MatDivider,
+    MatFormFieldModule,
+    MatInputModule,
+    FormsModule
   ]
 })
 export class NavbarComponent implements OnInit {

--- a/frontend/src/app/nft-unlock/nft-unlock.component.html
+++ b/frontend/src/app/nft-unlock/nft-unlock.component.html
@@ -13,7 +13,32 @@
         <img src="assets/public/images/products/juicy_chatbot.jpg" />
       </div>
 
-      @if (!successResponse) {
+      @if (successResponse) {
+        <div>
+          <div>
+            <mat-card-title>{{ 'TITLE_SBT' | translate }}</mat-card-title>
+          </div>
+          <div class="owner-text">
+            {{ 'OWNED_BY' | translate }}
+            <a
+              target="_blank"
+              href="https://testnets.opensea.io/0x8343d2eb2B13A2495De435a1b15e85b98115Ce05"
+              >8343D2</a
+              >
+            </div>
+            <mat-divider class="detail-divider"></mat-divider>
+            <div class="detail-box mat-elevation-z6">
+              <div class="box-title">{{ 'LABEL_ACCOUNT_ADDRESS' | translate }}</div>
+              <mat-divider class="detail-divider"></mat-divider>
+              <p class="box-text">0x8343d2eb2B13A2495De435a1b15e85b98115Ce05</p>
+            </div>
+            <div class="detail-box mat-elevation-z6">
+              <div class="box-title">{{ 'LABEL_DESCRIPTION' | translate }}</div>
+              <mat-divider class="detail-divider"></mat-divider>
+              <p class="box-text" [innerHTML]="'NFT_SBT_BOX_TEXT' | translate: i18nParams"></p>
+            </div>
+        </div>
+      } @else {
         <div>
           <div>
             <mat-card-title class="sbt-title">{{ 'TITLE_SBT' | translate }}</mat-card-title>
@@ -32,42 +57,15 @@
                   [attr.aria-label]="'LABEL_PRIVATE_KEY' | translate"
                   class="text-ellipsis"
                   />
-                </mat-form-field>
-                <h5 class="error">{{ errorMessage }}</h5>
-              </div>
-              <button type="submit" class="btn btn-primary" mat-raised-button color="accent">
-                {{ 'BTN_AUTHENTICATE' | translate }}
-              </button>
-            </form>
-          </div>
-        }
-
-        @if (successResponse) {
-          <div>
-            <div>
-              <mat-card-title>{{ 'TITLE_SBT' | translate }}</mat-card-title>
+              </mat-form-field>
+              <h5 class="error">{{ errorMessage }}</h5>
             </div>
-            <div class="owner-text">
-              {{ 'OWNED_BY' | translate }}
-              <a
-                target="_blank"
-                href="https://testnets.opensea.io/0x8343d2eb2B13A2495De435a1b15e85b98115Ce05"
-                >8343D2</a
-                >
-              </div>
-              <mat-divider class="detail-divider"></mat-divider>
-              <div class="detail-box mat-elevation-z6">
-                <div class="box-title">{{ 'LABEL_ACCOUNT_ADDRESS' | translate }}</div>
-                <mat-divider class="detail-divider"></mat-divider>
-                <p class="box-text">0x8343d2eb2B13A2495De435a1b15e85b98115Ce05</p>
-              </div>
-              <div class="detail-box mat-elevation-z6">
-                <div class="box-title">{{ 'LABEL_DESCRIPTION' | translate }}</div>
-                <mat-divider class="detail-divider"></mat-divider>
-                <p class="box-text" [innerHTML]="'NFT_SBT_BOX_TEXT' | translate: i18nParams"></p>
-              </div>
-            </div>
-          }
+            <button type="submit" class="btn btn-primary" mat-raised-button color="accent">
+              {{ 'BTN_AUTHENTICATE' | translate }}
+            </button>
+          </form>
         </div>
-      </div>
-    </mat-card>
+      }
+    </div>
+  </div>
+</mat-card>

--- a/frontend/src/app/nft-unlock/nft-unlock.component.html
+++ b/frontend/src/app/nft-unlock/nft-unlock.component.html
@@ -4,7 +4,7 @@
       class="detail-container offer-container warning-container align-self-center"
       mat-raised-button
       color="warn"
-    >
+      >
       {{ 'BTN_SBT_NOTE' | translate }}
     </button>
 
@@ -13,58 +13,61 @@
         <img src="assets/public/images/products/juicy_chatbot.jpg" />
       </div>
 
-      <div *ngIf="!successResponse">
+      @if (!successResponse) {
         <div>
-          <mat-card-title class="sbt-title">{{ 'TITLE_SBT' | translate }}</mat-card-title>
-        </div>
-        <form (ngSubmit)="submitForm()">
-          <div class="form-group">
-            <mat-form-field color="accent" appearance="outline" class="responsive-field">
-              <mat-label>{{ 'LABEL_PRIVATE_KEY' | translate }}</mat-label>
-              <input
-                matInput
-                [(ngModel)]="privateKey"
-                id="privateKey"
-                name="privateKey"
-                required
-                type="text"
-                [attr.aria-label]="'LABEL_PRIVATE_KEY' | translate"
-                class="text-ellipsis"
-              />
-            </mat-form-field>
-            <h5 class="error">{{ errorMessage }}</h5>
+          <div>
+            <mat-card-title class="sbt-title">{{ 'TITLE_SBT' | translate }}</mat-card-title>
           </div>
+          <form (ngSubmit)="submitForm()">
+            <div class="form-group">
+              <mat-form-field color="accent" appearance="outline" class="responsive-field">
+                <mat-label>{{ 'LABEL_PRIVATE_KEY' | translate }}</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="privateKey"
+                  id="privateKey"
+                  name="privateKey"
+                  required
+                  type="text"
+                  [attr.aria-label]="'LABEL_PRIVATE_KEY' | translate"
+                  class="text-ellipsis"
+                  />
+                </mat-form-field>
+                <h5 class="error">{{ errorMessage }}</h5>
+              </div>
+              <button type="submit" class="btn btn-primary" mat-raised-button color="accent">
+                {{ 'BTN_AUTHENTICATE' | translate }}
+              </button>
+            </form>
+          </div>
+        }
 
-          <button type="submit" class="btn btn-primary" mat-raised-button color="accent">
-            {{ 'BTN_AUTHENTICATE' | translate }}
-          </button>
-        </form>
-      </div>
-
-      <div *ngIf="successResponse">
-        <div>
-          <mat-card-title>{{ 'TITLE_SBT' | translate }}</mat-card-title>
-        </div>
-        <div class="owner-text">
-          {{ 'OWNED_BY' | translate }}
-          <a
-            target="_blank"
-            href="https://testnets.opensea.io/0x8343d2eb2B13A2495De435a1b15e85b98115Ce05"
-            >8343D2</a
-          >
-        </div>
-        <mat-divider class="detail-divider"></mat-divider>
-        <div class="detail-box mat-elevation-z6">
-          <div class="box-title">{{ 'LABEL_ACCOUNT_ADDRESS' | translate }}</div>
-          <mat-divider class="detail-divider"></mat-divider>
-          <p class="box-text">0x8343d2eb2B13A2495De435a1b15e85b98115Ce05</p>
-        </div>
-        <div class="detail-box mat-elevation-z6">
-          <div class="box-title">{{ 'LABEL_DESCRIPTION' | translate }}</div>
-          <mat-divider class="detail-divider"></mat-divider>
-          <p class="box-text" [innerHTML]="'NFT_SBT_BOX_TEXT' | translate: i18nParams"></p>
+        @if (successResponse) {
+          <div>
+            <div>
+              <mat-card-title>{{ 'TITLE_SBT' | translate }}</mat-card-title>
+            </div>
+            <div class="owner-text">
+              {{ 'OWNED_BY' | translate }}
+              <a
+                target="_blank"
+                href="https://testnets.opensea.io/0x8343d2eb2B13A2495De435a1b15e85b98115Ce05"
+                >8343D2</a
+                >
+              </div>
+              <mat-divider class="detail-divider"></mat-divider>
+              <div class="detail-box mat-elevation-z6">
+                <div class="box-title">{{ 'LABEL_ACCOUNT_ADDRESS' | translate }}</div>
+                <mat-divider class="detail-divider"></mat-divider>
+                <p class="box-text">0x8343d2eb2B13A2495De435a1b15e85b98115Ce05</p>
+              </div>
+              <div class="detail-box mat-elevation-z6">
+                <div class="box-title">{{ 'LABEL_DESCRIPTION' | translate }}</div>
+                <mat-divider class="detail-divider"></mat-divider>
+                <p class="box-text" [innerHTML]="'NFT_SBT_BOX_TEXT' | translate: i18nParams"></p>
+              </div>
+            </div>
+          }
         </div>
       </div>
-    </div>
-  </div>
-</mat-card>
+    </mat-card>

--- a/frontend/src/app/nft-unlock/nft-unlock.component.ts
+++ b/frontend/src/app/nft-unlock/nft-unlock.component.ts
@@ -4,7 +4,7 @@ import { MatDivider } from '@angular/material/divider'
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field'
 import { FormsModule } from '@angular/forms'
-import { NgIf } from '@angular/common'
+
 import { TranslateModule } from '@ngx-translate/core'
 import { MatButtonModule } from '@angular/material/button'
 
@@ -14,7 +14,7 @@ import { MatCardModule, MatCardTitle } from '@angular/material/card'
   selector: 'app-nft-unlock',
   templateUrl: './nft-unlock.component.html',
   styleUrls: ['./nft-unlock.component.scss'],
-  imports: [MatCardModule, MatButtonModule, TranslateModule, NgIf, MatCardTitle, FormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatDivider]
+  imports: [MatCardModule, MatButtonModule, TranslateModule, MatCardTitle, FormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatDivider]
 })
 export class NFTUnlockComponent {
   privateKey: string

--- a/frontend/src/app/order-completion/order-completion.component.html
+++ b/frontend/src/app/order-completion/order-completion.component.html
@@ -1,6 +1,6 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-elevation-z6 mat-own-card">
@@ -10,14 +10,18 @@
         <h1 class="confirmation" translate>THANKS_FOR_PURCHASE</h1>
         <div translate>PURCHASE_COMMENT_PREFIX <a routerLink="/track-result/new" [queryParams]="{ id: this.orderId }" translate>TITLE_TRACK_ORDERS</a> PURCHASE_COMMENT_SUFFIX</div>
       </div>
-      <div *ngIf="address">
-        <span *ngIf="orderDetails.eta !== '?' && orderDetails.eta !== undefined"><div class="confirmation" translate [translateParams]="{'numberdays': orderDetails.eta}">ESTIMATED_TIME_OF_DELIVERY</div></span>
-        <div><b translate>LABEL_DELIVERY_ADDRESS</b></div>
-        <div>{{address?.fullName}}</div>
-        <div>{{address?.streetAddress}}, {{address?.city}}, {{address?.state}}, {{address?.zipCode}}</div>
-        <div>{{address?.country}}</div>
-        <div><span translate>PHONE_NUMBER</span> {{address?.mobileNum}}</div>
-      </div>
+      @if (address) {
+        <div>
+          @if (orderDetails.eta !== '?' && orderDetails.eta !== undefined) {
+            <span><div class="confirmation" translate [translateParams]="{'numberdays': orderDetails.eta}">ESTIMATED_TIME_OF_DELIVERY</div></span>
+          }
+          <div><b translate>LABEL_DELIVERY_ADDRESS</b></div>
+          <div>{{address?.fullName}}</div>
+          <div>{{address?.streetAddress}}, {{address?.city}}, {{address?.state}}, {{address?.zipCode}}</div>
+          <div>{{address?.country}}</div>
+          <div><span translate>PHONE_NUMBER</span> {{address?.mobileNum}}</div>
+        </div>
+      }
     </div>
     <div class="heading-banner">
       <span class="heading-text">{{"ORDER_SUMMARY" | translate}}</span>
@@ -26,7 +30,7 @@
           <i class="fab fa-twitter fa-lg tweet-logo"></i>
         </a>
         <button mat-icon-button aria-label="Print order confirmation" [matTooltip]="'PRINT_ORDER_CONFIRMATION' | translate" matTooltipPosition="below"
-        (click)= "openConfirmationPDF()">
+          (click)= "openConfirmationPDF()">
           <mat-icon>note</mat-icon>
         </button>
       </div>

--- a/frontend/src/app/order-completion/order-completion.component.html
+++ b/frontend/src/app/order-completion/order-completion.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-elevation-z6 mat-own-card">

--- a/frontend/src/app/order-completion/order-completion.component.ts
+++ b/frontend/src/app/order-completion/order-completion.component.ts
@@ -15,7 +15,7 @@ import { faTwitter } from '@fortawesome/free-brands-svg-icons'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconButton } from '@angular/material/button'
-import { NgIf } from '@angular/common'
+
 import { TranslateModule } from '@ngx-translate/core'
 
 import { MatCardModule } from '@angular/material/card'
@@ -26,7 +26,7 @@ library.add(faTwitter)
   selector: 'app-order-completion',
   templateUrl: './order-completion.component.html',
   styleUrls: ['./order-completion.component.scss'],
-  imports: [MatCardModule, TranslateModule, RouterLink, NgIf, MatIconButton, MatTooltip, MatIconModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatFooterCellDef, MatFooterCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatFooterRowDef, MatFooterRow]
+  imports: [MatCardModule, TranslateModule, RouterLink, MatIconButton, MatTooltip, MatIconModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatFooterCellDef, MatFooterCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatFooterRowDef, MatFooterRow]
 })
 export class OrderCompletionComponent implements OnInit {
   public tableColumns = ['product', 'price', 'quantity', 'total price']

--- a/frontend/src/app/order-history/order-history.component.html
+++ b/frontend/src/app/order-history/order-history.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="card1 mat-elevation-z6 ">

--- a/frontend/src/app/order-history/order-history.component.html
+++ b/frontend/src/app/order-history/order-history.component.html
@@ -1,6 +1,6 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="card1 mat-elevation-z6 ">
@@ -9,99 +9,100 @@
       {{"LABEL_ORDER_HISTORY" | translate}}
     </mat-card-title>
 
-    <div *ngIf="!emptyState; else emptyResult" class="orders-container">
-      <div *ngFor="let order of orders">
-        <div class="table-container mat-elevation-z4 custom-slate">
-          <div class="heading">
-            <div class="heading-row">
-              <div class="col col-40 col-vertical">
-                <div>{{"LABEL_ORDER_ID" | translate}}</div>
-                <div>#{{ order.orderId }}</div>
+    @if (!emptyState) {
+      <div class="orders-container">
+        @for (order of orders; track order) {
+          <div>
+            <div class="table-container mat-elevation-z4 custom-slate">
+              <div class="heading">
+                <div class="heading-row">
+                  <div class="col col-40 col-vertical">
+                    <div>{{"LABEL_ORDER_ID" | translate}}</div>
+                    <div>#{{ order.orderId }}</div>
+                  </div>
+                  <div class="col col-15 col-vertical">
+                    <div>{{"LABEL_TOTAL_PRICE" | translate}}</div>
+                    <div>{{ order.totalPrice.toFixed(2) }}&curren;</div>
+                  </div>
+                  <div class="col col-15 col-vertical">
+                    <div>{{"LABEL_BONUS" | translate}}</div>
+                    <div>{{ order.bonus }}</div>
+                  </div>
+                  <div class="col col-20">
+                    @if (!order.delivered) {
+                      <div class="error">{{"LABEL_IN_TRANSIT" | translate}}</div>
+                    }
+                    @if (order.delivered) {
+                      <div class="confirmation">{{"LABEL_DELIVERED" | translate}}</div>
+                    }
+                  </div>
+                  <div class="col col-5 align-end">
+                    <button mat-icon-button aria-label="Track Your Order" matTooltip="{{ 'LABEL_TRACK_ORDER' | translate }}" matTooltipPosition="below" (click)="trackOrder(order.orderId)">
+                      <mat-icon>local_shipping</mat-icon>
+                    </button>
+                  </div>
+                  <div class="col col-5 align-end">
+                    <button mat-icon-button aria-label="Print order confirmation" matTooltip="{{ 'PRINT_ORDER_CONFIRMATION' | translate }}" matTooltipPosition="below" (click)="openConfirmationPDF(order.orderId)">
+                      <mat-icon>note</mat-icon>
+                    </button>
+                  </div>
+                </div>
+                <div class="border"></div>
               </div>
-              <div class="col col-15 col-vertical">
-                <div>{{"LABEL_TOTAL_PRICE" | translate}}</div>
-                <div>{{ order.totalPrice.toFixed(2) }}&curren;</div>
-              </div>
-              <div class="col col-15 col-vertical">
-                <div>{{"LABEL_BONUS" | translate}}</div>
-                <div>{{ order.bonus }}</div>
-              </div>
-              <div class="col col-20">
-                <div *ngIf="!order.delivered" class="error">{{"LABEL_IN_TRANSIT" | translate}}</div>
-                <div *ngIf="order.delivered" class="confirmation">{{"LABEL_DELIVERED" | translate}}</div>
-              </div>
-              <div class="col col-5 align-end">
-                <button mat-icon-button aria-label="Track Your Order" matTooltip="{{ 'LABEL_TRACK_ORDER' | translate }}" matTooltipPosition="below" (click)="trackOrder(order.orderId)">
-                  <mat-icon>local_shipping</mat-icon>
-                </button>
-              </div>
-              <div class="col col-5 align-end">
-                <button mat-icon-button aria-label="Print order confirmation" matTooltip="{{ 'PRINT_ORDER_CONFIRMATION' | translate }}" matTooltipPosition="below" (click)="openConfirmationPDF(order.orderId)">
-                  <mat-icon>note</mat-icon>
-                </button>
-              </div>
+              <mat-table [dataSource]="order.products">
+                <ng-container matColumnDef="product">
+                  <mat-header-cell *matHeaderCellDef>{{"LABEL_PRODUCT" | translate}}</mat-header-cell>
+                  <mat-cell *matCellDef="let element">{{element.name}}</mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="price">
+                  <mat-header-cell *matHeaderCellDef>{{"LABEL_PRICE" | translate}}</mat-header-cell>
+                  <mat-cell *matCellDef="let element">{{element.price}}&curren;</mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="quantity">
+                  <mat-header-cell *matHeaderCellDef>{{"LABEL_QUANTITY" | translate}}</mat-header-cell>
+                  <mat-cell *matCellDef="let element">
+                    <span>{{element.quantity}}</span>
+                  </mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="total price">
+                  <mat-header-cell *matHeaderCellDef>{{"LABEL_TOTAL_PRICE" | translate}}</mat-header-cell>
+                  <mat-cell *matCellDef="let element" class="price-align">{{ (element.total).toFixed(2) }}&curren;</mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="review">
+                  <mat-header-cell *matHeaderCellDef></mat-header-cell>
+                  <mat-cell *matCellDef="let element">
+                    <button mat-icon-button aria-label="Print order confirmation" matTooltip="{{ 'WRITE_REVIEW' | translate }}" matTooltipPosition="below"
+                      (click)="showDetail(element.id)">
+                      <mat-icon>rate_review</mat-icon>
+                    </button>
+                  </mat-cell>
+                </ng-container>
+                <mat-header-row *matHeaderRowDef="tableColumns"></mat-header-row>
+                <mat-row *matRowDef="let row; columns: tableColumns;"></mat-row>
+              </mat-table>
             </div>
-            <div class="border"></div>
           </div>
-
-          <mat-table [dataSource]="order.products">
-            <ng-container matColumnDef="product">
-              <mat-header-cell *matHeaderCellDef>{{"LABEL_PRODUCT" | translate}}</mat-header-cell>
-              <mat-cell *matCellDef="let element">{{element.name}}</mat-cell>
-            </ng-container>
-
-            <ng-container matColumnDef="price">
-              <mat-header-cell *matHeaderCellDef>{{"LABEL_PRICE" | translate}}</mat-header-cell>
-              <mat-cell *matCellDef="let element">{{element.price}}&curren;</mat-cell>
-            </ng-container>
-
-            <ng-container matColumnDef="quantity">
-              <mat-header-cell *matHeaderCellDef>{{"LABEL_QUANTITY" | translate}}</mat-header-cell>
-              <mat-cell *matCellDef="let element">
-                <span>{{element.quantity}}</span>
-              </mat-cell>
-            </ng-container>
-
-            <ng-container matColumnDef="total price">
-              <mat-header-cell *matHeaderCellDef>{{"LABEL_TOTAL_PRICE" | translate}}</mat-header-cell>
-              <mat-cell *matCellDef="let element" class="price-align">{{ (element.total).toFixed(2) }}&curren;</mat-cell>
-            </ng-container>
-
-            <ng-container matColumnDef="review">
-              <mat-header-cell *matHeaderCellDef></mat-header-cell>
-              <mat-cell *matCellDef="let element">
-                <button mat-icon-button aria-label="Print order confirmation" matTooltip="{{ 'WRITE_REVIEW' | translate }}" matTooltipPosition="below"
-                        (click)="showDetail(element.id)">
-                  <mat-icon>rate_review</mat-icon>
-                </button>
-              </mat-cell>
-            </ng-container>
-
-            <mat-header-row *matHeaderRowDef="tableColumns"></mat-header-row>
-            <mat-row *matRowDef="let row; columns: tableColumns;"></mat-row>
-          </mat-table>
-        </div>
+        }
       </div>
-    </div>
-
-    <ng-template #emptyResult>
+    } @else {
       <mat-card appearance="outlined" class="mat-elevation-z6 emptyState">
         <div class="mdc-card">
           <img alt="No results found"
-               class="img-responsive noResult"
-               src="assets/public/images/products/no-results.png">
-          <mat-card-title>
-            <span class="noResultText">
-              {{"NO_SEARCH_RESULT" | translate}}
-            </span>
-          </mat-card-title>
-          <mat-card-content>
-            <span class="noResultText" translate>
-              {{"NO_ORDERS_PLACED" | translate}}
-            </span>
-          </mat-card-content>
-        </div>
-      </mat-card>
-    </ng-template>
-  </div>
-</mat-card>
+            class="img-responsive noResult"
+            src="assets/public/images/products/no-results.png">
+            <mat-card-title>
+              <span class="noResultText">
+                {{"NO_SEARCH_RESULT" | translate}}
+              </span>
+            </mat-card-title>
+            <mat-card-content>
+              <span class="noResultText" translate>
+                {{"NO_ORDERS_PLACED" | translate}}
+              </span>
+            </mat-card-content>
+          </div>
+        </mat-card>
+      }
+
+    </div>
+  </mat-card>

--- a/frontend/src/app/order-history/order-history.component.ts
+++ b/frontend/src/app/order-history/order-history.component.ts
@@ -17,7 +17,6 @@ import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconButton } from '@angular/material/button'
 import { TranslateModule } from '@ngx-translate/core'
 
-import { NgIf, NgFor } from '@angular/common'
 import { MatCardModule, MatCardTitle, MatCardContent } from '@angular/material/card'
 
 export interface StrippedProduct {
@@ -40,7 +39,7 @@ export interface Order {
   selector: 'app-order-history',
   templateUrl: './order-history.component.html',
   styleUrls: ['./order-history.component.scss'],
-  imports: [MatCardModule, MatCardTitle, NgIf, NgFor, TranslateModule, MatIconButton, MatTooltip, MatIconModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatCardContent]
+  imports: [MatCardModule, MatCardTitle, TranslateModule, MatIconButton, MatTooltip, MatIconModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatCardContent]
 })
 export class OrderHistoryComponent implements OnInit {
   public tableColumns = ['product', 'price', 'quantity', 'total price', 'review']

--- a/frontend/src/app/order-summary/order-summary.component.html
+++ b/frontend/src/app/order-summary/order-summary.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 <mat-card appearance="outlined" class="container mat-elevation-z6 mat-own-card">
   <div class="mdc-card container">

--- a/frontend/src/app/order-summary/order-summary.component.html
+++ b/frontend/src/app/order-summary/order-summary.component.html
@@ -1,43 +1,45 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 <mat-card appearance="outlined" class="container mat-elevation-z6 mat-own-card">
   <div class="mdc-card container">
     <div class="column flex-50">
-      <div class="container" *ngIf="address && paymentMethod">
-        <!-- Delivery Address Card -->
-        <mat-card appearance="outlined" class="mat-elevation-z0 flex-60">
-          <div class="mdc-card">
-            <div><b>{{"LABEL_DELIVERY_ADDRESS" | translate}}</b></div>
-            <div>{{address?.fullName}}</div>
-            <div>{{address?.streetAddress}}, {{address?.city}}, {{address?.state}}, {{address?.zipCode}}</div>
-            <div>{{address?.country}}</div>
-            <div><span>{{"PHONE_NUMBER" | translate}}</span> {{address?.mobileNum}}</div>
-          </div>
-        </mat-card>
-        <!-- Payment Method Card -->
-        <mat-card appearance="outlined" class="mat-elevation-z0 flex-40" *ngIf="paymentMethod !== 'wallet'; else walletPayment">
-          <div class="mdc-card">
-            <div><b>{{"PAYMENT_METHOD" | translate}}</b></div>
-            <div><span>{{"CARD_ENDING_IN" | translate}}</span> {{paymentMethod?.cardNum}}</div>
-            <div><span>{{"CARD_HOLDER" | translate}}"</span> {{paymentMethod?.fullName}}</div>
-          </div>
-        </mat-card>
-
-        <!-- Digital Wallet (Fallback) -->
-        <ng-template #walletPayment>
-          <mat-card appearance="outlined" class="mat-elevation-z0 flex-40">
+      @if (address && paymentMethod) {
+        <div class="container">
+          <!-- Delivery Address Card -->
+          <mat-card appearance="outlined" class="mat-elevation-z0 flex-60">
             <div class="mdc-card">
-              <div><b>{{"PAYMENT_METHOD" | translate}}</b></div>
-              <div><span>{{"DIGITAL_WALLET" | translate}}</span></div>
+              <div><b>{{"LABEL_DELIVERY_ADDRESS" | translate}}</b></div>
+              <div>{{address?.fullName}}</div>
+              <div>{{address?.streetAddress}}, {{address?.city}}, {{address?.state}}, {{address?.zipCode}}</div>
+              <div>{{address?.country}}</div>
+              <div><span>{{"PHONE_NUMBER" | translate}}</span> {{address?.mobileNum}}</div>
             </div>
           </mat-card>
-        </ng-template>
-      </div>
+          <!-- Payment Method Card -->
+          @if (paymentMethod !== 'wallet') {
+            <mat-card appearance="outlined" class="mat-elevation-z0 flex-40">
+              <div class="mdc-card">
+                <div><b>{{"PAYMENT_METHOD" | translate}}</b></div>
+                <div><span>{{"CARD_ENDING_IN" | translate}}</span> {{paymentMethod?.cardNum}}</div>
+                <div><span>{{"CARD_HOLDER" | translate}}"</span> {{paymentMethod?.fullName}}</div>
+              </div>
+            </mat-card>
+          } @else {
+          <!-- Digital Wallet (Fallback) -->
+            <mat-card appearance="outlined" class="mat-elevation-z0 flex-40">
+              <div class="mdc-card">
+                <div><b>{{"PAYMENT_METHOD" | translate}}</b></div>
+                <div><span>{{"DIGITAL_WALLET" | translate}}</span></div>
+              </div>
+            </mat-card>
+          }
+        </div>
+      }
       <!-- Purchase Basket -->
       <app-purchase-basket id="app-purchase-basket" [allowEdit]="false" [totalPrice]="false"
-        (emitTotal)="getMessage($event)"></app-purchase-basket>
+      (emitTotal)="getMessage($event)"></app-purchase-basket>
     </div>
 
     <!-- Order Summary Card -->
@@ -65,7 +67,7 @@
           </table>
           <!-- Checkout Button -->
           <button mat-raised-button mat-button class="btn btn-pay" color="primary" aria-label="Complete your purchase"
-                  id="checkoutButton" (click)="placeOrder()">
+            id="checkoutButton" (click)="placeOrder()">
             <mat-icon>{{"monetization_on" | translate}}</mat-icon>
             <span>{{"PLACE_ORDER_AND_PAY" | translate}}</span>
           </button>

--- a/frontend/src/app/order-summary/order-summary.component.ts
+++ b/frontend/src/app/order-summary/order-summary.component.ts
@@ -14,7 +14,6 @@ import { MatIconModule } from '@angular/material/icon'
 import { MatButtonModule } from '@angular/material/button'
 import { PurchaseBasketComponent } from '../purchase-basket/purchase-basket.component'
 import { TranslateModule } from '@ngx-translate/core'
-import { NgIf } from '@angular/common'
 
 import { MatCardModule } from '@angular/material/card'
 
@@ -22,7 +21,7 @@ import { MatCardModule } from '@angular/material/card'
   selector: 'app-order-summary',
   templateUrl: './order-summary.component.html',
   styleUrls: ['./order-summary.component.scss'],
-  imports: [MatCardModule, NgIf, TranslateModule, PurchaseBasketComponent, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, PurchaseBasketComponent, MatButtonModule, MatIconModule]
 })
 export class OrderSummaryComponent implements OnInit {
   public bonus = 0

--- a/frontend/src/app/payment-method/payment-method.component.html
+++ b/frontend/src/app/payment-method/payment-method.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="container">

--- a/frontend/src/app/payment-method/payment-method.component.html
+++ b/frontend/src/app/payment-method/payment-method.component.html
@@ -1,40 +1,42 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="container">
   <h1>{{"MY_PAYMENT_OPTIONS" | translate}}</h1>
-  <div *ngIf="cardsExist">
-    <mat-table [dataSource]="dataSource">
-      <ng-container matColumnDef="Selection">
-        <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          <mat-radio-button (click)="emitSelectionToParent(element.id)"></mat-radio-button>
-        </mat-cell>
-      </ng-container>
-      <ng-container matColumnDef="Number">
-        <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let element">{{ element.cardNum }}</mat-cell>
-      </ng-container>
-      <ng-container matColumnDef="Name">
-        <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let element">{{ element.fullName }}</mat-cell>
-      </ng-container>
-      <ng-container matColumnDef="Expiry">
-        <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let element">{{ element.expMonth }}/{{ element.expYear }}</mat-cell>
-      </ng-container>
-      <ng-container matColumnDef="Remove">
-        <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          <button mat-icon-button (click)="delete(element.id)"><i class="far fa-trash-alt"></i></button>
-        </mat-cell>
-      </ng-container>
-      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-    </mat-table>
-  </div>
+  @if (cardsExist) {
+    <div>
+      <mat-table [dataSource]="dataSource">
+        <ng-container matColumnDef="Selection">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <mat-radio-button (click)="emitSelectionToParent(element.id)"></mat-radio-button>
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Number">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let element">{{ element.cardNum }}</mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Name">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let element">{{ element.fullName }}</mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Expiry">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let element">{{ element.expMonth }}/{{ element.expYear }}</mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="Remove">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <button mat-icon-button (click)="delete(element.id)"><i class="far fa-trash-alt"></i></button>
+          </mat-cell>
+        </ng-container>
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+      </mat-table>
+    </div>
+  }
   <div>
     <mat-expansion-panel class="mat-elevation-z0">
       <mat-expansion-panel-header style="margin-bottom: 12px;">
@@ -49,45 +51,59 @@
         <mat-form-field appearance="outline" color="accent">
           <mat-label translate>LABEL_NAME</mat-label>
           <input [formControl]="nameControl" type="text" matInput>
-          <mat-error *ngIf="nameControl.invalid && nameControl.errors.required" translate>
-            MANDATORY_NAME
-          </mat-error>
+          @if (nameControl.invalid && nameControl.errors.required) {
+            <mat-error translate>
+              MANDATORY_NAME
+            </mat-error>
+          }
         </mat-form-field>
         <mat-form-field appearance="outline" color="accent">
           <mat-label translate>LABEL_CARD_NUMBER</mat-label>
           <input #cardIn [formControl]="numberControl" type="number" matInput>
           <mat-hint align="end">{{cardIn .value?.length || 0}}/16</mat-hint>
-          <mat-error *ngIf="numberControl.invalid && numberControl.errors.required" translate>
-            MANDATORY_CARD_NUMBER
-          </mat-error>
-          <mat-error *ngIf="numberControl.invalid && (numberControl.errors.min || numberControl.errors.max)" translate>
-            VALID_CARD_NUMBER
-          </mat-error>
+          @if (numberControl.invalid && numberControl.errors.required) {
+            <mat-error translate>
+              MANDATORY_CARD_NUMBER
+            </mat-error>
+          }
+          @if (numberControl.invalid && (numberControl.errors.min || numberControl.errors.max)) {
+            <mat-error translate>
+              VALID_CARD_NUMBER
+            </mat-error>
+          }
         </mat-form-field>
         <mat-form-field class="half-field" appearance="outline" color="accent">
           <mat-label translate>LABEL_EXPIRY_MONTH</mat-label>
           <select matNativeControl [formControl]="monthControl" required>
-            <option *ngFor="let i of monthRange" value="{{ i }}">{{ i }}</option>
+            @for (i of monthRange; track i) {
+              <option value="{{ i }}">{{ i }}</option>
+            }
           </select>
-          <mat-error *ngIf="monthControl.invalid && monthControl.errors.required" translate>
-            MANDATORY_EXPIRY_MONTH
-          </mat-error>
+          @if (monthControl.invalid && monthControl.errors.required) {
+            <mat-error translate>
+              MANDATORY_EXPIRY_MONTH
+            </mat-error>
+          }
         </mat-form-field>
         <mat-form-field class="half-field" appearance="outline" color="accent">
           <mat-label translate>LABEL_EXPIRY_YEAR</mat-label>
           <select matNativeControl [formControl]="yearControl" required>
-            <option *ngFor="let i of yearRange" value="{{ i }}">{{ i }}</option>
+            @for (i of yearRange; track i) {
+              <option value="{{ i }}">{{ i }}</option>
+            }
           </select>
-          <mat-error *ngIf="yearControl.invalid && yearControl.errors.required" translate>
-            MANDATORY_EXPIRY_YEAR
-          </mat-error>
+          @if (yearControl.invalid && yearControl.errors.required) {
+            <mat-error translate>
+              MANDATORY_EXPIRY_YEAR
+            </mat-error>
+          }
         </mat-form-field>
       </div>
       <button type="submit" id="submitButton" style="margin-top:5px; float:right;" mat-raised-button color="primary"
-              [disabled]="nameControl.invalid || numberControl.invalid || monthControl.invalid || yearControl.invalid"
-              (click)="save()">
-              <mat-icon>send</mat-icon>
-              {{'BTN_SUBMIT' | translate}}
+        [disabled]="nameControl.invalid || numberControl.invalid || monthControl.invalid || yearControl.invalid"
+        (click)="save()">
+        <mat-icon>send</mat-icon>
+        {{'BTN_SUBMIT' | translate}}
       </button>
     </mat-expansion-panel>
   </div>

--- a/frontend/src/app/payment-method/payment-method.component.ts
+++ b/frontend/src/app/payment-method/payment-method.component.ts
@@ -17,7 +17,6 @@ import { MatFormFieldModule, MatLabel, MatError, MatHint } from '@angular/materi
 import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription } from '@angular/material/expansion'
 import { MatIconButton, MatButtonModule } from '@angular/material/button'
 import { MatRadioButton } from '@angular/material/radio'
-import { NgIf, NgFor } from '@angular/common'
 
 import { MatIconModule } from '@angular/material/icon'
 
@@ -27,7 +26,7 @@ library.add(faPaperPlane, faTrashAlt)
   selector: 'app-payment-method',
   templateUrl: './payment-method.component.html',
   styleUrls: ['./payment-method.component.scss'],
-  imports: [NgIf, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatRadioButton, MatIconButton, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatHint, NgFor, MatButtonModule, MatIconModule]
+  imports: [MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatRadioButton, MatIconButton, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatHint, MatButtonModule, MatIconModule]
 })
 
 export class PaymentMethodComponent implements OnInit {

--- a/frontend/src/app/payment/payment.component.html
+++ b/frontend/src/app/payment/payment.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-own-card mat-elevation-z6">

--- a/frontend/src/app/payment/payment.component.html
+++ b/frontend/src/app/payment/payment.component.html
@@ -1,150 +1,180 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" class="mat-own-card mat-elevation-z6">
   <div class="mdc-card">
     <app-payment-method (emitSelection)="getMessage($event)" [allowDelete]="false"></app-payment-method>
     <mat-divider></mat-divider>
-    <div class="mat-elevation-z0 custom-card" *ngIf="mode !== 'wallet'">
-      <div class="row">
-        <div class="col col-42">
-          <span translate class="card-title">LABEL_PAY_USING_WALLET</span>
-        </div>
-        <div class="col col-38">
-          <b>
-            <span class="card-title" translate>LABEL_WALLET_BALANCE</span>
-            <span class="confirmation card-title"> {{ walletBalanceStr }}</span>
-          </b>
-        </div>
-        <div class="col col-20">
-          <button type="submit" color="primary" mat-raised-button class="btn" style="float: right;"
-                  [disabled]="(walletBalance - totalPrice) < 0" (click)="useWallet()">
-            <i class="fas fa-hand-holding-usd fa-lg"></i> {{'LABEL_PAY' | translate}} {{ totalPrice?.toFixed(2) }}¤
-          </button>
-        </div>
-      </div>
-    </div>
-    <mat-divider></mat-divider>
-    <mat-expansion-panel class="mat-elevation-z0" [expanded]="couponPanelExpanded" id="collapseCouponElement"
-                         *ngIf="mode !== 'wallet'">
-      <mat-expansion-panel-header class="detail-divider">
-        <mat-panel-title>
-          {{"ADD_A_COUPON" | translate}}
-        </mat-panel-title>
-        <mat-panel-description>
-          {{"VOUCHERS_AND_PROMOTIONAL_CODE" | translate}}
-        </mat-panel-description>
-      </mat-expansion-panel-header>
-      <div *ngIf="couponConfirmation && !couponControl.dirty" style="margin-top:5px;" class="confirmation">{{
-        couponConfirmation }}
-      </div>
-      <div *ngIf="couponError && !couponControl.dirty" style="margin-top:5px;" class="error">{{couponError?.error}}
-      </div>
-      <mat-form-field appearance="outline" color="accent">
-        <mat-label translate>LABEL_COUPON</mat-label>
-        <mat-hint
-            [innerHtml]="'FOLLOW_FOR_MONTHLY_COUPONS' | translate:{blueSky: blueSkyUrl, reddit: redditUrl}">
-        </mat-hint>
-        <input #coupon id="coupon" [formControl]="couponControl" matInput type="text" placeholder="{{ 'ENTER_COUPON_CODE' | translate}}">
-        <mat-hint align="end">{{coupon .value?.length || 0}}/10</mat-hint>
-        <mat-error *ngIf="couponControl.invalid && (couponControl.errors.minlength || couponControl.errors.maxlength)">
-          {{'COUPON_CODE_HINT' | translate}}
-        </mat-error>
-      </mat-form-field>
-      <button type="submit" id="applyCouponButton" color="accent" style="margin-top:5px; float: right;" (click)="applyCoupon()"
-              [disabled]="couponControl.invalid" mat-raised-button>
-        <mat-icon>
-          redeem
-        </mat-icon>
-        {{'BTN_REDEEM' | translate}}
-      </button>
-    </mat-expansion-panel>
-    <mat-divider></mat-divider>
-    <mat-expansion-panel class="mat-elevation-z0" [expanded]="paymentPanelExpanded" *ngIf="mode !== 'wallet'">
-      <mat-expansion-panel-header class="detail-divider">
-        <mat-panel-title>
-          {{"OTHER_PAYMENT_OPTIONS" | translate}}
-        </mat-panel-title>
-      </mat-expansion-panel-header>
-      <div class="row responsive-row">
-        <div class="col col-34 mat-elevation-z0">
-          <div class="payment-label">
-            <label translate>LABEL_DONATIONS</label>
+    @if (mode !== 'wallet') {
+      <div class="mat-elevation-z0 custom-card">
+        <div class="row">
+          <div class="col col-42">
+            <span translate class="card-title">LABEL_PAY_USING_WALLET</span>
           </div>
-          <small>
-            (<span *ngIf="applicationName === 'OWASP Juice Shop'" translate
-                   [translateParams]="{juiceshop: 'OWASP Juice Shop'}">THANKS_FOR_SUPPORT</span>
-            <span *ngIf="applicationName !== 'OWASP Juice Shop'" translate
-                  [translateParams]="{appname: applicationName}">THANKS_FOR_SUPPORT_CUSTOMIZED</span>
+          <div class="col col-38">
+            <b>
+              <span class="card-title" translate>LABEL_WALLET_BALANCE</span>
+              <span class="confirmation card-title"> {{ walletBalanceStr }}</span>
+            </b>
+          </div>
+          <div class="col col-20">
+            <button type="submit" color="primary" mat-raised-button class="btn" style="float: right;"
+              [disabled]="(walletBalance - totalPrice) < 0" (click)="useWallet()">
+              <i class="fas fa-hand-holding-usd fa-lg"></i> {{'LABEL_PAY' | translate}} {{ totalPrice?.toFixed(2) }}¤
+            </button>
+          </div>
+        </div>
+      </div>
+    }
+    <mat-divider></mat-divider>
+    @if (mode !== 'wallet') {
+      <mat-expansion-panel class="mat-elevation-z0" [expanded]="couponPanelExpanded" id="collapseCouponElement"
+        >
+        <mat-expansion-panel-header class="detail-divider">
+          <mat-panel-title>
+            {{"ADD_A_COUPON" | translate}}
+          </mat-panel-title>
+          <mat-panel-description>
+            {{"VOUCHERS_AND_PROMOTIONAL_CODE" | translate}}
+          </mat-panel-description>
+        </mat-expansion-panel-header>
+        @if (couponConfirmation && !couponControl.dirty) {
+          <div style="margin-top:5px;" class="confirmation">{{
+            couponConfirmation }}
+          </div>
+        }
+        @if (couponError && !couponControl.dirty) {
+          <div style="margin-top:5px;" class="error">{{couponError?.error}}
+          </div>
+        }
+        <mat-form-field appearance="outline" color="accent">
+          <mat-label translate>LABEL_COUPON</mat-label>
+          <mat-hint
+            [innerHtml]="'FOLLOW_FOR_MONTHLY_COUPONS' | translate:{blueSky: blueSkyUrl, reddit: redditUrl}">
+          </mat-hint>
+          <input #coupon id="coupon" [formControl]="couponControl" matInput type="text" placeholder="{{ 'ENTER_COUPON_CODE' | translate}}">
+          <mat-hint align="end">{{coupon .value?.length || 0}}/10</mat-hint>
+          @if (couponControl.invalid && (couponControl.errors.minlength || couponControl.errors.maxlength)) {
+            <mat-error>
+              {{'COUPON_CODE_HINT' | translate}}
+            </mat-error>
+          }
+        </mat-form-field>
+        <button type="submit" id="applyCouponButton" color="accent" style="margin-top:5px; float: right;" (click)="applyCoupon()"
+          [disabled]="couponControl.invalid" mat-raised-button>
+          <mat-icon>
+            redeem
+          </mat-icon>
+          {{'BTN_REDEEM' | translate}}
+        </button>
+      </mat-expansion-panel>
+    }
+    <mat-divider></mat-divider>
+    @if (mode !== 'wallet') {
+      <mat-expansion-panel class="mat-elevation-z0" [expanded]="paymentPanelExpanded">
+        <mat-expansion-panel-header class="detail-divider">
+          <mat-panel-title>
+            {{"OTHER_PAYMENT_OPTIONS" | translate}}
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+        <div class="row responsive-row">
+          <div class="col col-34 mat-elevation-z0">
+            <div class="payment-label">
+              <label translate>LABEL_DONATIONS</label>
+            </div>
+            <small>
+              (@if (applicationName === 'OWASP Juice Shop') {
+              <span translate
+              [translateParams]="{juiceshop: 'OWASP Juice Shop'}">THANKS_FOR_SUPPORT</span>
+            }
+            @if (applicationName !== 'OWASP Juice Shop') {
+              <span translate
+              [translateParams]="{appname: applicationName}">THANKS_FOR_SUPPORT_CUSTOMIZED</span>
+            }
             <i style="margin-left: 3px;" class="fas fa-heart error"></i>)
           </small>
           <div class="button-container" style="margin-top: 6px;">
             <a href="https://pwning.owasp-juice.shop/companion-guide/latest/part3/donations.html">
               <button mat-stroked-button><i class="fab fa-stripe fa-lg"></i> {{'BTN_CREDIT_CARD' | translate}}</button>
             </a>
-            <button mat-stroked-button (click)="showBitcoinQrCode()" *ngIf="false"><i class="fab fa-btc fa-lg"></i>
+            @if (false) {
+              <button mat-stroked-button (click)="showBitcoinQrCode()"><i class="fab fa-btc fa-lg"></i>
               Bitcoin
             </button>
-            <button mat-stroked-button (click)="showDashQrCode()" *ngIf="false"><i class="fa-lg">Ð</i> Dash</button>
-            <button mat-stroked-button (click)="showEtherQrCode()" *ngIf="false"><i class="fab fa-ethereum fa-lg"></i>
-              Ether
-            </button>
-          </div>
-        </div>
-        <span class="fill-remaining-space"></span>
-        <div class="col col-65 mat-elevation-z0">
-          <div class="payment-label">
-            <label translate>LABEL_MERCHANDISE</label>
-          </div>
-          <small>
-            (<span *ngIf="applicationName === 'OWASP Juice Shop'" translate
-                   [translateParams]="{juiceshop: 'OWASP Juice Shop'}">OFFICIAL_MERCHANDISE_STORES</span>
-            <span *ngIf="applicationName !== 'OWASP Juice Shop'" translate
-                  [translateParams]="{appname: applicationName}">OFFICIAL_MERCHANDISE_STORES_CUSTOMIZED</span>
-            <i style="margin-left: 3px;" class="fas fa-thumbs-up confirmation"></i>)
-          </small>
-          <div class="button-container" style="margin-top: 6px;">
-            <a href="./redirect?to=http://shop.spreadshirt.com/juiceshop">
-              <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (US)</button>
-            </a>
-            <a href="./redirect?to=http://shop.spreadshirt.de/juiceshop">
-              <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (DE)</button>
-            </a>
-            <a href="./redirect?to=https://www.stickeryou.com/products/owasp-juice-shop/794">
-              <button mat-stroked-button><i class="fas fa-sticky-note fa-lg"></i> StickerYou</button>
-            </a>
-            <a href="./redirect?to=http://leanpub.com/juice-shop">
-              <button mat-stroked-button><i class="fab fa-leanpub fa-lg"></i> Leanpub</button>
-            </a>
-            <a href="https://opensea.io/collection/juice-shop">
-              <button mat-stroked-button><i class="fas fa-palette fa-lg"></i> OpenSea</button>
-            </a>
-          </div>
-        </div>
+          }
+          @if (false) {
+            <button mat-stroked-button (click)="showDashQrCode()"><i class="fa-lg">Ð</i> Dash</button>
+          }
+          @if (false) {
+            <button mat-stroked-button (click)="showEtherQrCode()"><i class="fab fa-ethereum fa-lg"></i>
+            Ether
+          </button>
+        }
       </div>
-    </mat-expansion-panel>
-    <mat-divider></mat-divider>
-    <div style="margin-top: 20px; margin-bottom: 20px;">
-      <button mat-stroked-button class="btn btn-return" (click)="routeToPreviousUrl()">
-        <mat-icon>
-          navigate_before
-        </mat-icon>
-        {{'LABEL_BACK' | translate}}
-      </button>
-      <button mat-raised-button mat-button class="btn nextButton" color="primary" aria-label="Proceed to review"
-              [disabled]="paymentId === undefined && paymentMode !== 'wallet'" (click)="choosePayment()">
-        <mat-icon>
-          navigate_next
-        </mat-icon>
-        <span translate>LABEL_CONTINUE</span>
-      </button>
-      <p style="text-align: center;margin-top: -27px;">
-        <span translate *ngIf="mode !== 'deluxe' && mode !== 'wallet'">REVIEW_ALERT</span>
-        <span translate *ngIf="mode === 'wallet'">REVIEW_WALLET</span>
-      </p>
+    </div>
+    <span class="fill-remaining-space"></span>
+    <div class="col col-65 mat-elevation-z0">
+      <div class="payment-label">
+        <label translate>LABEL_MERCHANDISE</label>
+      </div>
+      <small>
+        (@if (applicationName === 'OWASP Juice Shop') {
+        <span translate
+        [translateParams]="{juiceshop: 'OWASP Juice Shop'}">OFFICIAL_MERCHANDISE_STORES</span>
+      }
+      @if (applicationName !== 'OWASP Juice Shop') {
+        <span translate
+        [translateParams]="{appname: applicationName}">OFFICIAL_MERCHANDISE_STORES_CUSTOMIZED</span>
+      }
+      <i style="margin-left: 3px;" class="fas fa-thumbs-up confirmation"></i>)
+    </small>
+    <div class="button-container" style="margin-top: 6px;">
+      <a href="./redirect?to=http://shop.spreadshirt.com/juiceshop">
+        <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (US)</button>
+      </a>
+      <a href="./redirect?to=http://shop.spreadshirt.de/juiceshop">
+        <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (DE)</button>
+      </a>
+      <a href="./redirect?to=https://www.stickeryou.com/products/owasp-juice-shop/794">
+        <button mat-stroked-button><i class="fas fa-sticky-note fa-lg"></i> StickerYou</button>
+      </a>
+      <a href="./redirect?to=http://leanpub.com/juice-shop">
+        <button mat-stroked-button><i class="fab fa-leanpub fa-lg"></i> Leanpub</button>
+      </a>
+      <a href="https://opensea.io/collection/juice-shop">
+        <button mat-stroked-button><i class="fas fa-palette fa-lg"></i> OpenSea</button>
+      </a>
     </div>
   </div>
+</div>
+</mat-expansion-panel>
+}
+<mat-divider></mat-divider>
+<div style="margin-top: 20px; margin-bottom: 20px;">
+  <button mat-stroked-button class="btn btn-return" (click)="routeToPreviousUrl()">
+    <mat-icon>
+      navigate_before
+    </mat-icon>
+    {{'LABEL_BACK' | translate}}
+  </button>
+  <button mat-raised-button mat-button class="btn nextButton" color="primary" aria-label="Proceed to review"
+    [disabled]="paymentId === undefined && paymentMode !== 'wallet'" (click)="choosePayment()">
+    <mat-icon>
+      navigate_next
+    </mat-icon>
+    <span translate>LABEL_CONTINUE</span>
+  </button>
+  <p style="text-align: center;margin-top: -27px;">
+    @if (mode !== 'deluxe' && mode !== 'wallet') {
+      <span translate>REVIEW_ALERT</span>
+    }
+    @if (mode === 'wallet') {
+      <span translate>REVIEW_WALLET</span>
+    }
+  </p>
+</div>
+</div>
 
 </mat-card>

--- a/frontend/src/app/payment/payment.component.html
+++ b/frontend/src/app/payment/payment.component.html
@@ -8,88 +8,86 @@
     <app-payment-method (emitSelection)="getMessage($event)" [allowDelete]="false"></app-payment-method>
     <mat-divider></mat-divider>
     @if (mode !== 'wallet') {
-      <div class="mat-elevation-z0 custom-card">
-        <div class="row">
-          <div class="col col-42">
-            <span translate class="card-title">LABEL_PAY_USING_WALLET</span>
-          </div>
-          <div class="col col-38">
-            <b>
-              <span class="card-title" translate>LABEL_WALLET_BALANCE</span>
-              <span class="confirmation card-title"> {{ walletBalanceStr }}</span>
-            </b>
-          </div>
-          <div class="col col-20">
-            <button type="submit" color="primary" mat-raised-button class="btn" style="float: right;"
-              [disabled]="(walletBalance - totalPrice) < 0" (click)="useWallet()">
-              <i class="fas fa-hand-holding-usd fa-lg"></i> {{'LABEL_PAY' | translate}} {{ totalPrice?.toFixed(2) }}¤
-            </button>
-          </div>
+    <div class="mat-elevation-z0 custom-card">
+      <div class="row">
+        <div class="col col-42">
+          <span translate class="card-title">LABEL_PAY_USING_WALLET</span>
+        </div>
+        <div class="col col-38">
+          <b>
+            <span class="card-title" translate>LABEL_WALLET_BALANCE</span>
+            <span class="confirmation card-title"> {{ walletBalanceStr }}</span>
+          </b>
+        </div>
+        <div class="col col-20">
+          <button type="submit" color="primary" mat-raised-button class="btn" style="float: right;"
+            [disabled]="(walletBalance - totalPrice) < 0" (click)="useWallet()">
+            <i class="fas fa-hand-holding-usd fa-lg"></i> {{'LABEL_PAY' | translate}} {{ totalPrice?.toFixed(2) }}¤
+          </button>
         </div>
       </div>
+    </div>
     }
     <mat-divider></mat-divider>
     @if (mode !== 'wallet') {
-      <mat-expansion-panel class="mat-elevation-z0" [expanded]="couponPanelExpanded" id="collapseCouponElement"
-        >
-        <mat-expansion-panel-header class="detail-divider">
-          <mat-panel-title>
-            {{"ADD_A_COUPON" | translate}}
-          </mat-panel-title>
-          <mat-panel-description>
-            {{"VOUCHERS_AND_PROMOTIONAL_CODE" | translate}}
-          </mat-panel-description>
-        </mat-expansion-panel-header>
-        @if (couponConfirmation && !couponControl.dirty) {
-          <div style="margin-top:5px;" class="confirmation">{{
-            couponConfirmation }}
-          </div>
+    <mat-expansion-panel class="mat-elevation-z0" [expanded]="couponPanelExpanded" id="collapseCouponElement">
+      <mat-expansion-panel-header class="detail-divider">
+        <mat-panel-title>
+          {{"ADD_A_COUPON" | translate}}
+        </mat-panel-title>
+        <mat-panel-description>
+          {{"VOUCHERS_AND_PROMOTIONAL_CODE" | translate}}
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      @if (couponConfirmation && !couponControl.dirty) {
+      <div style="margin-top:5px;" class="confirmation">{{
+        couponConfirmation }}
+      </div>
+      }
+      @if (couponError && !couponControl.dirty) {
+      <div style="margin-top:5px;" class="error">{{couponError?.error}}
+      </div>
+      }
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label translate>LABEL_COUPON</mat-label>
+        <mat-hint
+          [innerHtml]="'FOLLOW_FOR_MONTHLY_COUPONS' | translate:{blueSky: blueSkyUrl, reddit: redditUrl}">
+        </mat-hint>
+        <input #coupon id="coupon" [formControl]="couponControl" matInput type="text" placeholder="{{ 'ENTER_COUPON_CODE' | translate}}">
+        <mat-hint align="end">{{coupon.value?.length || 0}}/10</mat-hint>
+        @if (couponControl.invalid && (couponControl.errors.minlength || couponControl.errors.maxlength)) {
+        <mat-error>
+          {{'COUPON_CODE_HINT' | translate}}
+        </mat-error>
         }
-        @if (couponError && !couponControl.dirty) {
-          <div style="margin-top:5px;" class="error">{{couponError?.error}}
-          </div>
-        }
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_COUPON</mat-label>
-          <mat-hint
-            [innerHtml]="'FOLLOW_FOR_MONTHLY_COUPONS' | translate:{blueSky: blueSkyUrl, reddit: redditUrl}">
-          </mat-hint>
-          <input #coupon id="coupon" [formControl]="couponControl" matInput type="text" placeholder="{{ 'ENTER_COUPON_CODE' | translate}}">
-          <mat-hint align="end">{{coupon .value?.length || 0}}/10</mat-hint>
-          @if (couponControl.invalid && (couponControl.errors.minlength || couponControl.errors.maxlength)) {
-            <mat-error>
-              {{'COUPON_CODE_HINT' | translate}}
-            </mat-error>
-          }
-        </mat-form-field>
-        <button type="submit" id="applyCouponButton" color="accent" style="margin-top:5px; float: right;" (click)="applyCoupon()"
-          [disabled]="couponControl.invalid" mat-raised-button>
-          <mat-icon>
-            redeem
-          </mat-icon>
-          {{'BTN_REDEEM' | translate}}
-        </button>
-      </mat-expansion-panel>
+      </mat-form-field>
+      <button type="submit" id="applyCouponButton" color="accent" style="margin-top:5px; float: right;"
+        (click)="applyCoupon()" [disabled]="couponControl.invalid" mat-raised-button>
+        <mat-icon>
+          redeem
+        </mat-icon>
+        {{'BTN_REDEEM' | translate}}
+      </button>
+    </mat-expansion-panel>
     }
     <mat-divider></mat-divider>
     @if (mode !== 'wallet') {
-      <mat-expansion-panel class="mat-elevation-z0" [expanded]="paymentPanelExpanded">
-        <mat-expansion-panel-header class="detail-divider">
-          <mat-panel-title>
-            {{"OTHER_PAYMENT_OPTIONS" | translate}}
-          </mat-panel-title>
-        </mat-expansion-panel-header>
-        <div class="row responsive-row">
-          <div class="col col-34 mat-elevation-z0">
-            <div class="payment-label">
-              <label translate>LABEL_DONATIONS</label>
-            </div>
-            <small>
-              (@if (applicationName === 'OWASP Juice Shop') {
+    <mat-expansion-panel class="mat-elevation-z0" [expanded]="paymentPanelExpanded">
+      <mat-expansion-panel-header class="detail-divider">
+        <mat-panel-title>
+          {{"OTHER_PAYMENT_OPTIONS" | translate}}
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <div class="row responsive-row">
+        <div class="col col-34 mat-elevation-z0">
+          <div class="payment-label">
+            <label translate>LABEL_DONATIONS</label>
+          </div>
+          <small>
+            (@if (applicationName === 'OWASP Juice Shop') {
               <span translate
               [translateParams]="{juiceshop: 'OWASP Juice Shop'}">THANKS_FOR_SUPPORT</span>
-            }
-            @if (applicationName !== 'OWASP Juice Shop') {
+            } @else {
               <span translate
               [translateParams]="{appname: applicationName}">THANKS_FOR_SUPPORT_CUSTOMIZED</span>
             }
@@ -100,81 +98,80 @@
               <button mat-stroked-button><i class="fab fa-stripe fa-lg"></i> {{'BTN_CREDIT_CARD' | translate}}</button>
             </a>
             @if (false) {
-              <button mat-stroked-button (click)="showBitcoinQrCode()"><i class="fab fa-btc fa-lg"></i>
+            <button mat-stroked-button (click)="showBitcoinQrCode()"><i class="fab fa-btc fa-lg"></i>
               Bitcoin
             </button>
-          }
-          @if (false) {
+            }
+            @if (false) {
             <button mat-stroked-button (click)="showDashQrCode()"><i class="fa-lg">Ð</i> Dash</button>
-          }
-          @if (false) {
+            }
+            @if (false) {
             <button mat-stroked-button (click)="showEtherQrCode()"><i class="fab fa-ethereum fa-lg"></i>
-            Ether
-          </button>
+              Ether
+            </button>
+            }
+          </div>
+        </div>
+        <span class="fill-remaining-space"></span>
+        <div class="col col-65 mat-elevation-z0">
+          <div class="payment-label">
+            <label translate>LABEL_MERCHANDISE</label>
+          </div>
+          <small>
+            (@if (applicationName === 'OWASP Juice Shop') {
+            <span translate
+              [translateParams]="{juiceshop: 'OWASP Juice Shop'}">OFFICIAL_MERCHANDISE_STORES</span>
+            } @else {
+            <span translate
+              [translateParams]="{appname: applicationName}">OFFICIAL_MERCHANDISE_STORES_CUSTOMIZED</span>
+            }
+            <i style="margin-left: 3px;" class="fas fa-thumbs-up confirmation"></i>)
+          </small>
+          <div class="button-container" style="margin-top: 6px;">
+            <a href="./redirect?to=http://shop.spreadshirt.com/juiceshop">
+              <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (US)</button>
+            </a>
+            <a href="./redirect?to=http://shop.spreadshirt.de/juiceshop">
+              <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (DE)</button>
+            </a>
+            <a href="./redirect?to=https://www.stickeryou.com/products/owasp-juice-shop/794">
+              <button mat-stroked-button><i class="fas fa-sticky-note fa-lg"></i> StickerYou</button>
+            </a>
+            <a href="./redirect?to=http://leanpub.com/juice-shop">
+              <button mat-stroked-button><i class="fab fa-leanpub fa-lg"></i> Leanpub</button>
+            </a>
+            <a href="https://opensea.io/collection/juice-shop">
+              <button mat-stroked-button><i class="fas fa-palette fa-lg"></i> OpenSea</button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </mat-expansion-panel>
+    }
+    <mat-divider></mat-divider>
+    <div style="margin-top: 20px; margin-bottom: 20px;">
+      <button mat-stroked-button class="btn btn-return" (click)="routeToPreviousUrl()">
+        <mat-icon>
+          navigate_before
+        </mat-icon>
+        {{'LABEL_BACK' | translate}}
+      </button>
+      <button mat-raised-button mat-button class="btn nextButton" color="primary" aria-label="Proceed to review"
+        [disabled]="paymentId === undefined && paymentMode !== 'wallet'" (click)="choosePayment()">
+        <mat-icon>
+          navigate_next
+        </mat-icon>
+        <span translate>LABEL_CONTINUE</span>
+      </button>
+      <p style="text-align: center;margin-top: -27px;">
+        @if (mode !== 'deluxe' && mode !== 'wallet') {
+        <span translate>REVIEW_ALERT</span>
         }
-      </div>
-    </div>
-    <span class="fill-remaining-space"></span>
-    <div class="col col-65 mat-elevation-z0">
-      <div class="payment-label">
-        <label translate>LABEL_MERCHANDISE</label>
-      </div>
-      <small>
-        (@if (applicationName === 'OWASP Juice Shop') {
-        <span translate
-        [translateParams]="{juiceshop: 'OWASP Juice Shop'}">OFFICIAL_MERCHANDISE_STORES</span>
-      }
-      @if (applicationName !== 'OWASP Juice Shop') {
-        <span translate
-        [translateParams]="{appname: applicationName}">OFFICIAL_MERCHANDISE_STORES_CUSTOMIZED</span>
-      }
-      <i style="margin-left: 3px;" class="fas fa-thumbs-up confirmation"></i>)
-    </small>
-    <div class="button-container" style="margin-top: 6px;">
-      <a href="./redirect?to=http://shop.spreadshirt.com/juiceshop">
-        <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (US)</button>
-      </a>
-      <a href="./redirect?to=http://shop.spreadshirt.de/juiceshop">
-        <button mat-stroked-button><i class="fas fa-tshirt fa-lg"></i> Spreadshirt (DE)</button>
-      </a>
-      <a href="./redirect?to=https://www.stickeryou.com/products/owasp-juice-shop/794">
-        <button mat-stroked-button><i class="fas fa-sticky-note fa-lg"></i> StickerYou</button>
-      </a>
-      <a href="./redirect?to=http://leanpub.com/juice-shop">
-        <button mat-stroked-button><i class="fab fa-leanpub fa-lg"></i> Leanpub</button>
-      </a>
-      <a href="https://opensea.io/collection/juice-shop">
-        <button mat-stroked-button><i class="fas fa-palette fa-lg"></i> OpenSea</button>
-      </a>
+        @if (mode === 'wallet') {
+        <span translate>REVIEW_WALLET</span>
+        }
+      </p>
     </div>
   </div>
-</div>
-</mat-expansion-panel>
-}
-<mat-divider></mat-divider>
-<div style="margin-top: 20px; margin-bottom: 20px;">
-  <button mat-stroked-button class="btn btn-return" (click)="routeToPreviousUrl()">
-    <mat-icon>
-      navigate_before
-    </mat-icon>
-    {{'LABEL_BACK' | translate}}
-  </button>
-  <button mat-raised-button mat-button class="btn nextButton" color="primary" aria-label="Proceed to review"
-    [disabled]="paymentId === undefined && paymentMode !== 'wallet'" (click)="choosePayment()">
-    <mat-icon>
-      navigate_next
-    </mat-icon>
-    <span translate>LABEL_CONTINUE</span>
-  </button>
-  <p style="text-align: center;margin-top: -27px;">
-    @if (mode !== 'deluxe' && mode !== 'wallet') {
-      <span translate>REVIEW_ALERT</span>
-    }
-    @if (mode === 'wallet') {
-      <span translate>REVIEW_WALLET</span>
-    }
-  </p>
-</div>
-</div>
 
 </mat-card>

--- a/frontend/src/app/payment/payment.component.ts
+++ b/frontend/src/app/payment/payment.component.ts
@@ -29,7 +29,7 @@ import { WalletService } from '../Services/wallet.service'
 import { DeliveryService } from '../Services/delivery.service'
 import { UserService } from '../Services/user.service'
 import { CookieService } from 'ngy-cookie'
-import { Location, NgIf } from '@angular/common'
+import { Location } from '@angular/common'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
@@ -47,7 +47,7 @@ library.add(faCartArrowDown, faGift, faHeart, faLeanpub, faThumbsUp, faTshirt, f
   selector: 'app-payment',
   templateUrl: './payment.component.html',
   styleUrls: ['./payment.component.scss'],
-  imports: [MatCardModule, PaymentMethodComponent, MatDivider, NgIf, TranslateModule, MatButtonModule, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription, MatFormFieldModule, MatLabel, MatHint, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatIconModule]
+  imports: [MatCardModule, PaymentMethodComponent, MatDivider, TranslateModule, MatButtonModule, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription, MatFormFieldModule, MatLabel, MatHint, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatIconModule]
 })
 export class PaymentComponent implements OnInit {
   public couponConfirmation: any

--- a/frontend/src/app/photo-wall/photo-wall.component.html
+++ b/frontend/src/app/photo-wall/photo-wall.component.html
@@ -1,73 +1,84 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" class="heading mat-elevation-z6 mat-own-card" style="margin-bottom:10px;">
   <div class="mdc-card">
     <h1>{{"LABEL_PHOTO_WALL" | translate}}</h1>
     <div>
-      <div class="grid" *ngIf="!emptyState; else emptyResult">
-                  <span *ngFor="let image of slideshowDataSource" class="container mat-elevation-z6">
-                      <img src="{{ image.url }}" alt="{{ image.caption }}" class="image">
-                      <div class="overlay">
-                          <div>{{ image.caption }}</div>
-                          <a *ngIf="twitterHandle"
-                            href="https://twitter.com/intent/tweet?text={{ image.caption }} {{ twitterHandle }}&hashtags=appsec"
-                            target="_blank">
-                              <button mat-icon-button aria-label="Tweet">
-                                  <i class="fab fa-twitter fa-lg"></i>
-                              </button>
-                          </a>
-                      </div>
-                  </span>
-      </div>
-    </div>
-
-    <ng-template #emptyResult>
-      <mat-card appearance="outlined" class="mat-elevation-z0 emptyState">
-        <div class="mdc-card">
-          <img alt=" No results found"
+      @if (!emptyState) {
+        <div class="grid">
+          @for (image of slideshowDataSource; track image) {
+            <span class="container mat-elevation-z6">
+              <img src="{{ image.url }}" alt="{{ image.caption }}" class="image">
+              <div class="overlay">
+                <div>{{ image.caption }}</div>
+                @if (twitterHandle) {
+                  <a
+                    href="https://twitter.com/intent/tweet?text={{ image.caption }} {{ twitterHandle }}&hashtags=appsec"
+                    target="_blank">
+                    <button mat-icon-button aria-label="Tweet">
+                      <i class="fab fa-twitter fa-lg"></i>
+                    </button>
+                  </a>
+                }
+              </div>
+            </span>
+          }
+        </div>
+      } @else {
+        <mat-card appearance="outlined" class="mat-elevation-z0 emptyState">
+          <div class="mdc-card">
+            <img alt=" No results found"
               class="img-responsive noResult"
               src="assets/public/images/products/no-results.png">
-          <mat-card-title>
+              <mat-card-title>
                 <span class="noResultText" translate>
-                    NO_SEARCH_RESULT
+                  NO_SEARCH_RESULT
                 </span>
-          </mat-card-title>
-          <mat-card-content>
+              </mat-card-title>
+              <mat-card-content>
                 <span class="noResultText" translate>
-                    EMPTY_MEMORY_LIST
+                  EMPTY_MEMORY_LIST
                 </span>
-          </mat-card-content>
-        </div>
-      </mat-card>
-    </ng-template>
-
-    <div *ngIf="isLoggedIn()">
-      <div style="margin-top: 10px;">
-        <h2 translate>LABEL_SHARE_A_MEMORY</h2>
-        <form [formGroup]="form" enctype="multipart/form-data">
-          <div>
-            <button mat-stroked-button type="button" (click)="filePicker.click()">{{'LABEL_PICK_IMAGE' | translate}}
-            </button>
-            <input type="file" name='file' #filePicker (change)="onImagePicked($event)">
-          </div>
-          <div class="image-preview" *ngIf="imagePreview !== '' && imagePreview && form.get('image').valid">
-            <img [src]="imagePreview" [alt]="form.value.caption">
-          </div>
-          <mat-form-field appearance="outline" color="accent">
-            <mat-label translate>LABEL_CAPTION</mat-label>
-            <input formControlName="caption" type="text" matInput>
-            <mat-error *ngIf="form.get('caption').invalid" translate>{{'MANDATORY_CAPTION' | translate}}</mat-error>
-          </mat-form-field>
-          <button id="submitButton" mat-raised-button color="primary" (click)="save()"
-                  [disabled]="form.get('image').invalid || form.get('caption').invalid">
-            <mat-icon>send</mat-icon>
-            {{'BTN_SUBMIT' | translate}}
-          </button>
-        </form>
+              </mat-card-content>
+            </div>
+          </mat-card>
+        }
       </div>
+
+
+      @if (isLoggedIn()) {
+        <div>
+          <div style="margin-top: 10px;">
+            <h2 translate>LABEL_SHARE_A_MEMORY</h2>
+            <form [formGroup]="form" enctype="multipart/form-data">
+              <div>
+                <button mat-stroked-button type="button" (click)="filePicker.click()">{{'LABEL_PICK_IMAGE' | translate}}
+                </button>
+                <input type="file" name='file' #filePicker (change)="onImagePicked($event)">
+              </div>
+              @if (imagePreview !== '' && imagePreview && form.get('image').valid) {
+                <div class="image-preview">
+                  <img [src]="imagePreview" [alt]="form.value.caption">
+                </div>
+              }
+              <mat-form-field appearance="outline" color="accent">
+                <mat-label translate>LABEL_CAPTION</mat-label>
+                <input formControlName="caption" type="text" matInput>
+                @if (form.get('caption').invalid) {
+                  <mat-error translate>{{'MANDATORY_CAPTION' | translate}}</mat-error>
+                }
+              </mat-form-field>
+              <button id="submitButton" mat-raised-button color="primary" (click)="save()"
+                [disabled]="form.get('image').invalid || form.get('caption').invalid">
+                <mat-icon>send</mat-icon>
+                {{'BTN_SUBMIT' | translate}}
+              </button>
+            </form>
+          </div>
+        </div>
+      }
     </div>
-  </div>
-</mat-card>
+  </mat-card>

--- a/frontend/src/app/photo-wall/photo-wall.component.html
+++ b/frontend/src/app/photo-wall/photo-wall.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="heading mat-elevation-z6 mat-own-card" style="margin-bottom:10px;">

--- a/frontend/src/app/photo-wall/photo-wall.component.ts
+++ b/frontend/src/app/photo-wall/photo-wall.component.ts
@@ -17,7 +17,7 @@ import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatError } from '@angular/material/form-field'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatIconButton, MatButtonModule } from '@angular/material/button'
-import { NgIf, NgFor } from '@angular/common'
+
 import { MatCardModule, MatCardTitle, MatCardContent } from '@angular/material/card'
 
 library.add(faTwitter)
@@ -26,7 +26,7 @@ library.add(faTwitter)
   selector: 'app-photo-wall',
   templateUrl: './photo-wall.component.html',
   styleUrls: ['./photo-wall.component.scss'],
-  imports: [MatCardModule, NgIf, NgFor, MatIconButton, MatCardTitle, TranslateModule, MatCardContent, FormsModule, ReactiveFormsModule, MatButtonModule, MatFormFieldModule, MatLabel, MatInputModule, MatError]
+  imports: [MatCardModule, MatIconButton, MatCardTitle, TranslateModule, MatCardContent, FormsModule, ReactiveFormsModule, MatButtonModule, MatFormFieldModule, MatLabel, MatInputModule, MatError]
 })
 export class PhotoWallComponent implements OnInit {
   public emptyState: boolean = true

--- a/frontend/src/app/product-details/product-details.component.html
+++ b/frontend/src/app/product-details/product-details.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-dialog-content>

--- a/frontend/src/app/product-details/product-details.component.html
+++ b/frontend/src/app/product-details/product-details.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-dialog-content>
 
@@ -17,13 +17,15 @@
         <br/>
         <div>
           <p class="item-price">{{data.productData.price}}&curren;</p>
-          <div *ngIf="data.productData.points > 0" matTooltip="{{'LABEL_BONUS' | translate}}"
-               aria-label="Bonus points when buying the product">
-            <span class="fa-2x fa-layers fa-fw">
-              <i class="fas fa-crown"></i>
-              <span class="fa-layers-counter fa-layers-bottom-left fa-2x warn-notification" style="font-size: 47px;">{{ data.productData.points }}</span>
-            </span>
-          </div>
+          @if (data.productData.points > 0) {
+            <div matTooltip="{{'LABEL_BONUS' | translate}}"
+              aria-label="Bonus points when buying the product">
+              <span class="fa-2x fa-layers fa-fw">
+                <i class="fas fa-crown"></i>
+                <span class="fa-layers-counter fa-layers-bottom-left fa-2x warn-notification" style="font-size: 47px;">{{ data.productData.points }}</span>
+              </span>
+            </div>
+          }
         </div>
       </div>
     </div>
@@ -41,50 +43,53 @@
       <button mat-button style="height: 0; position: absolute;">
         <!-- 'absorbs' the auto-focus behavior -->
       </button>
-      <div *ngIf="(reviews$| async)?.length >= 1; else emptyResult">
-        <div *ngFor="let review of reviews$|async" class="comment">
-          <div class="review-row">
-            <div class="review-text"
-                 (click)="review.author !== 'Anonymous' && review.author === author && editReview(review)"
-                 matTooltipDisabled="{{review.author !== author}}" matTooltip="{{'LABEL_EDIT_REVIEW' | translate}}"
-                 matTooltipPosition="right">
-              <cite>{{review.author}}</cite>
-              <p>{{ review.message }}</p>
+      @if ((reviews$| async)?.length >= 1) {
+        <div>
+          @for (review of reviews$|async; track review) {
+            <div class="comment">
+              <div class="review-row">
+                <div class="review-text"
+                  (click)="review.author !== 'Anonymous' && review.author === author && editReview(review)"
+                  matTooltipDisabled="{{review.author !== author}}" matTooltip="{{'LABEL_EDIT_REVIEW' | translate}}"
+                  matTooltipPosition="right">
+                  <cite>{{review.author}}</cite>
+                  <p>{{ review.message }}</p>
+                </div>
+                <div class="like-container">
+                  <button mat-icon-button (click)="likeReview(review)" [disabled]="review.liked || !isLoggedIn()"
+                    class="rw-button" aria-label="Rate a helpful review">
+                    <mat-icon>thumb_up</mat-icon>
+                    <span class="like-counter accent-notification">{{ review.likesCount }}</span>
+                  </button>
+                </div>
+              </div>
             </div>
-            <div class="like-container">
-              <button mat-icon-button (click)="likeReview(review)" [disabled]="review.liked || !isLoggedIn()"
-                      class="rw-button" aria-label="Rate a helpful review">
-                <mat-icon>thumb_up</mat-icon>
-                <span class="like-counter accent-notification">{{ review.likesCount }}</span>
-              </button>
-            </div>
-          </div>
+          }
         </div>
-      </div>
-
-      <ng-template #emptyResult>
+      } @else {
         <div>
           <span class="noResultText" translate>
             EMPTY_REVIEW_LIST
           </span>
         </div>
-      </ng-template>
+      }
+
     </mat-expansion-panel>
 
     <mat-divider class="detail-divider"></mat-divider>
 
     <h4 [style.display]="isLoggedIn() ? 'block' : 'none' " translate>WRITE_REVIEW</h4>
     <mat-form-field appearance="outline" color="accent"
-                    [style.display]="isLoggedIn() ? 'block' : 'none' " floatLabel="always">
+      [style.display]="isLoggedIn() ? 'block' : 'none' " floatLabel="always">
       <mat-label >{{"LABEL_REVIEW" | translate}}</mat-label>
       <mat-hint>
         <i class="fas fa-exclamation-circle"></i>
         <em style="margin-left:5px;">{{ 'MAX_TEXTAREA_LENGTH' | translate: {length: '160'} }}</em>
       </mat-hint>
       <textarea [formControl]="reviewControl" #textPut cols="50" matInput
-                placeholder="{{'WRITE_REVIEW_PLACEHOLDER' | translate}}"
-                matTextareaAutosize matAutosizeMinRows="2" maxlength="160"
-                matAutosizeMaxRows="4" aria-label="Text field to review a product"></textarea>
+        placeholder="{{'WRITE_REVIEW_PLACEHOLDER' | translate}}"
+        matTextareaAutosize matAutosizeMinRows="2" maxlength="160"
+      matAutosizeMaxRows="4" aria-label="Text field to review a product"></textarea>
       <mat-hint align="end">{{textPut.value?.length || 0}}/160</mat-hint>
     </mat-form-field>
 
@@ -95,9 +100,9 @@
       </button>
 
       <button type="submit" id="submitButton" [disabled]="!textPut.value.trim()" mat-raised-button color="primary"
-              (click)="addReview(textPut)" style="margin-left: 5px;"
-              aria-label="Send the review" class="buttons"
-              [style.display]="isLoggedIn() ? 'flex' : 'none' ">
+        (click)="addReview(textPut)" style="margin-left: 5px;"
+        aria-label="Send the review" class="buttons"
+        [style.display]="isLoggedIn() ? 'flex' : 'none' ">
         <mat-icon>send</mat-icon>
         <span>{{'BTN_SUBMIT' | translate}}</span>
       </button>

--- a/frontend/src/app/product-details/product-details.component.ts
+++ b/frontend/src/app/product-details/product-details.component.ts
@@ -23,7 +23,7 @@ import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } fr
 import { MatButtonModule, MatIconButton } from '@angular/material/button'
 import { MatDivider } from '@angular/material/divider'
 import { MatTooltip } from '@angular/material/tooltip'
-import { NgIf, NgFor, AsyncPipe } from '@angular/common'
+import { AsyncPipe } from '@angular/common'
 
 library.add(faPaperPlane, faArrowCircleLeft, faUserEdit, faThumbsUp, faCrown)
 
@@ -31,7 +31,7 @@ library.add(faPaperPlane, faArrowCircleLeft, faUserEdit, faThumbsUp, faCrown)
   selector: 'app-product-details',
   templateUrl: './product-details.component.html',
   styleUrls: ['./product-details.component.scss'],
-  imports: [MatDialogContent, NgIf, MatTooltip, MatDivider, MatButtonModule, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, TranslateModule, NgFor, MatIconButton, MatIconModule, MatFormFieldModule, MatLabel, MatHint, MatInputModule, FormsModule, ReactiveFormsModule, MatDialogActions, MatDialogClose, AsyncPipe]
+  imports: [MatDialogContent, MatTooltip, MatDivider, MatButtonModule, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, TranslateModule, MatIconButton, MatIconModule, MatFormFieldModule, MatLabel, MatHint, MatInputModule, FormsModule, ReactiveFormsModule, MatDialogActions, MatDialogClose, AsyncPipe]
 })
 export class ProductDetailsComponent implements OnInit, OnDestroy {
   public author: string = 'Anonymous'

--- a/frontend/src/app/product-review-edit/product-review-edit.component.html
+++ b/frontend/src/app/product-review-edit/product-review-edit.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-dialog-content>

--- a/frontend/src/app/product-review-edit/product-review-edit.component.html
+++ b/frontend/src/app/product-review-edit/product-review-edit.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-dialog-content>
   <div class="container column-layout">
@@ -9,12 +9,14 @@
     <div>
       <mat-form-field appearance="outline" color="accent" hintLabel="Max 160 characters" floatLabel="always">
         <mat-label translate>LABEL_REVIEW</mat-label>
-          <textarea [formControl]="editReviewControl" #textPut matInput
-                    placeholder="{{'WRITE_REVIEW_PLACEHOLDER' | translate}}"
-                    matTextareaAutosize matAutosizeMinRows="2" maxlength="160"
-                    matAutosizeMaxRows="4" aria-label="Text field to edit a product review"  (focus)="this.error=null"></textarea>
+        <textarea [formControl]="editReviewControl" #textPut matInput
+          placeholder="{{'WRITE_REVIEW_PLACEHOLDER' | translate}}"
+          matTextareaAutosize matAutosizeMinRows="2" maxlength="160"
+        matAutosizeMaxRows="4" aria-label="Text field to edit a product review"  (focus)="this.error=null"></textarea>
         <mat-hint align="end">{{textPut.value?.length || 0}}/160</mat-hint>
-        <mat-error *ngIf="editReviewControl.invalid" translate>MANDATORY_REVIEW</mat-error>
+        @if (editReviewControl.invalid) {
+          <mat-error translate>MANDATORY_REVIEW</mat-error>
+        }
       </mat-form-field>
     </div>
   </div>
@@ -26,7 +28,7 @@
     <span>{{'BTN_CLOSE' | translate}}</span>
   </button>
   <button type="submit" (click)="editReview()" mat-raised-button style="margin-left: 5px;" color="primary" aria-label="Send the review"
-          [disabled]="editReviewControl.invalid">
+    [disabled]="editReviewControl.invalid">
     <mat-icon>send</mat-icon>
     <span>{{'BTN_SUBMIT' | translate}}</span>
   </button>

--- a/frontend/src/app/product-review-edit/product-review-edit.component.ts
+++ b/frontend/src/app/product-review-edit/product-review-edit.component.ts
@@ -13,7 +13,7 @@ import { faArrowCircleLeft, faPaperPlane } from '@fortawesome/free-solid-svg-ico
 import { type Review } from '../Models/review.model'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { MatButtonModule } from '@angular/material/button'
-import { NgIf } from '@angular/common'
+
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatHint, MatError } from '@angular/material/form-field'
 import { TranslateModule } from '@ngx-translate/core'
@@ -26,7 +26,7 @@ library.add(faPaperPlane, faArrowCircleLeft)
   selector: 'app-product-review-edit',
   templateUrl: './product-review-edit.component.html',
   styleUrls: ['./product-review-edit.component.scss'],
-  imports: [MatDialogContent, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatHint, NgIf, MatError, MatDialogActions, MatButtonModule, MatDialogClose, MatIconModule]
+  imports: [MatDialogContent, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatHint, MatError, MatDialogActions, MatButtonModule, MatDialogClose, MatIconModule]
 })
 export class ProductReviewEditComponent implements OnInit {
   public editReviewControl: UntypedFormControl = new UntypedFormControl('', [Validators.required, Validators.minLength(1), Validators.maxLength(160)])

--- a/frontend/src/app/purchase-basket/purchase-basket.component.html
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 

--- a/frontend/src/app/purchase-basket/purchase-basket.component.html
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 
 <h1>
@@ -13,47 +13,57 @@
     <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
     <mat-cell *matCellDef="let element" class="content-align">
       <img [src]="'assets/public/images/products/'+element.image" alt={{element.name}}
-           class="img-responsive img-thumbnail">
-    </mat-cell>
-    <mat-footer-cell *matFooterCellDef class="content-align"></mat-footer-cell>
-  </ng-container>
+        class="img-responsive img-thumbnail">
+      </mat-cell>
+      <mat-footer-cell *matFooterCellDef class="content-align"></mat-footer-cell>
+    </ng-container>
 
-  <ng-container matColumnDef="product">
-    <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-    <mat-cell *matCellDef="let element" style="font-size: initial;"> {{element.name}}</mat-cell>
-    <mat-footer-cell *matFooterCellDef></mat-footer-cell>
-  </ng-container>
+    <ng-container matColumnDef="product">
+      <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+      <mat-cell *matCellDef="let element" style="font-size: initial;"> {{element.name}}</mat-cell>
+      <mat-footer-cell *matFooterCellDef></mat-footer-cell>
+    </ng-container>
 
-  <ng-container matColumnDef="quantity">
-    <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-    <mat-cell *matCellDef="let element" class="content-align">
-      <button mat-icon-button (click)="dec(element.BasketItem.id)" *ngIf="allowEdit"><i class="fas fa-minus-square"></i></button>
-      <span style="font-size: initial;"> {{element.BasketItem.quantity}}</span>
-      <button mat-icon-button (click)="inc(element.BasketItem.id)" *ngIf="allowEdit"><i class="fas fa-plus-square"></i></button>
-    </mat-cell>
-    <mat-footer-cell *matFooterCellDef class="header-align">TOTAL</mat-footer-cell>
-  </ng-container>
+    <ng-container matColumnDef="quantity">
+      <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+      <mat-cell *matCellDef="let element" class="content-align">
+        @if (allowEdit) {
+          <button mat-icon-button (click)="dec(element.BasketItem.id)"><i class="fas fa-minus-square"></i></button>
+        }
+        <span style="font-size: initial;"> {{element.BasketItem.quantity}}</span>
+        @if (allowEdit) {
+          <button mat-icon-button (click)="inc(element.BasketItem.id)"><i class="fas fa-plus-square"></i></button>
+        }
+      </mat-cell>
+      <mat-footer-cell *matFooterCellDef class="header-align">TOTAL</mat-footer-cell>
+    </ng-container>
 
-  <ng-container matColumnDef="price">
-    <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-    <mat-cell *matCellDef="let element" style="font-size: initial;"> {{element.price}}&curren;</mat-cell>
-    <mat-footer-cell *matFooterCellDef></mat-footer-cell>
-  </ng-container>
+    <ng-container matColumnDef="price">
+      <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+      <mat-cell *matCellDef="let element" style="font-size: initial;"> {{element.price}}&curren;</mat-cell>
+      <mat-footer-cell *matFooterCellDef></mat-footer-cell>
+    </ng-container>
 
-  <ng-container matColumnDef="remove" *ngIf="allowEdit">
-    <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
-    <mat-cell *matCellDef="let element">
-      <button mat-icon-button (click)="delete(element.BasketItem.id)"><i class="far fa-trash-alt"></i></button>
-    </mat-cell>
-    <mat-footer-cell *matFooterCellDef></mat-footer-cell>
-  </ng-container>
+    @if (allowEdit) {
+      <ng-container matColumnDef="remove">
+        <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+        <mat-cell *matCellDef="let element">
+          <button mat-icon-button (click)="delete(element.BasketItem.id)"><i class="far fa-trash-alt"></i></button>
+        </mat-cell>
+        <mat-footer-cell *matFooterCellDef></mat-footer-cell>
+      </ng-container>
+    }
 
-  <mat-header-row *matHeaderRowDef="tableColumns"></mat-header-row>
-  <mat-row *matRowDef="let row; columns: tableColumns;"></mat-row>
+    <mat-header-row *matHeaderRowDef="tableColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: tableColumns;"></mat-row>
 
-  <span *ngIf="displayTotal">
-    <mat-footer-row mat-footer-row *matFooterRowDef="tableColumns"></mat-footer-row>
-  </span>
-</mat-table>
+    @if (displayTotal) {
+      <span>
+        <mat-footer-row mat-footer-row *matFooterRowDef="tableColumns"></mat-footer-row>
+      </span>
+    }
+  </mat-table>
 
-<div *ngIf="totalPrice" id="price">{{"LABEL_TOTAL_PRICE"| translate }}: {{itemTotal}}¤</div>
+  @if (totalPrice) {
+    <div id="price">{{"LABEL_TOTAL_PRICE"| translate }}: {{itemTotal}}¤</div>
+  }

--- a/frontend/src/app/purchase-basket/purchase-basket.component.ts
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.ts
@@ -13,7 +13,6 @@ import { DeluxeGuard } from '../app.guard'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatIconButton } from '@angular/material/button'
-import { NgIf } from '@angular/common'
 
 import { MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatFooterCellDef, MatFooterCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatFooterRowDef, MatFooterRow } from '@angular/material/table'
 
@@ -23,7 +22,7 @@ library.add(faTrashAlt, faMinusSquare, faPlusSquare)
   selector: 'app-purchase-basket',
   templateUrl: './purchase-basket.component.html',
   styleUrls: ['./purchase-basket.component.scss'],
-  imports: [MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatFooterCellDef, MatFooterCell, NgIf, MatIconButton, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatFooterRowDef, MatFooterRow, TranslateModule]
+  imports: [MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatFooterCellDef, MatFooterCell, MatIconButton, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatFooterRowDef, MatFooterRow, TranslateModule]
 })
 export class PurchaseBasketComponent implements OnInit {
   @Input('allowEdit') public allowEdit: boolean = false

--- a/frontend/src/app/recycle/recycle.component.html
+++ b/frontend/src/app/recycle/recycle.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card class="mat-elevation-z6 mat-own-card recycle-container">

--- a/frontend/src/app/recycle/recycle.component.html
+++ b/frontend/src/app/recycle/recycle.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card class="mat-elevation-z6 mat-own-card recycle-container">
   <!-- left -->
@@ -17,30 +17,40 @@
       <mat-form-field appearance="outline" color="accent">
         <mat-label>{{"LABEL_QUANTITY" | translate}}</mat-label>
         <input [formControl]="recycleQuantityControl" type="number" [placeholder]="'IN_LITERS_PLACEHOLDER' | translate" matInput>
-        <mat-error *ngIf="recycleQuantityControl.invalid && recycleQuantityControl.errors.required" translate>
-          {{"MANDATORY_QUANTITY" | translate}}
-        </mat-error>
-        <mat-error *ngIf="recycleQuantityControl.invalid && (recycleQuantityControl.errors.min || recycleQuantityControl.errors.max)">
-          {{"INVALID_QUANTITY" | translate: {range: '10-1000'} }}
-        </mat-error>
+        @if (recycleQuantityControl.invalid && recycleQuantityControl.errors.required) {
+          <mat-error translate>
+            {{"MANDATORY_QUANTITY" | translate}}
+          </mat-error>
+        }
+        @if (recycleQuantityControl.invalid && (recycleQuantityControl.errors.min || recycleQuantityControl.errors.max)) {
+          <mat-error>
+            {{"INVALID_QUANTITY" | translate: {range: '10-1000'} }}
+          </mat-error>
+        }
       </mat-form-field>
 
       <app-address (emitSelection)="getMessage($event)" [addNewAddressDiv]="false" #addressComp class="mat-elevation-z0"></app-address>
 
-      <mat-form-field *ngIf="pickup.value && recycleQuantityControl.value > 100" appearance="outline">
-        <mat-label>{{"LABEL_PICKUP_DATE" | translate}}</mat-label>
-        <input [formControl]="pickUpDateControl" matInput [matDatepicker]="picker">
-        <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-datepicker #picker></mat-datepicker>
-        <mat-error *ngIf="pickUpDateControl.invalid">{{"INVALID_DATE" | translate }}</mat-error>
-      </mat-form-field>
+      @if (pickup.value && recycleQuantityControl.value > 100) {
+        <mat-form-field appearance="outline">
+          <mat-label>{{"LABEL_PICKUP_DATE" | translate}}</mat-label>
+          <input [formControl]="pickUpDateControl" matInput [matDatepicker]="picker">
+          <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+          <mat-datepicker #picker></mat-datepicker>
+          @if (pickUpDateControl.invalid) {
+            <mat-error>{{"INVALID_DATE" | translate }}</mat-error>
+          }
+        </mat-form-field>
+      }
 
-      <mat-checkbox [formControl]="pickup" *ngIf="recycleQuantityControl.value > 100">{{'REQUEST_PICKUP' | translate}}</mat-checkbox>
+      @if (recycleQuantityControl.value > 100) {
+        <mat-checkbox [formControl]="pickup">{{'REQUEST_PICKUP' | translate}}</mat-checkbox>
+      }
     </div>
 
     <button type="submit" id="recycleButton"
-            [disabled]="addressId === undefined || recycleQuantityControl.invalid || pickUpDateControl.invalid"
-            mat-raised-button color="primary" (click)="save()">
+      [disabled]="addressId === undefined || recycleQuantityControl.invalid || pickUpDateControl.invalid"
+      mat-raised-button color="primary" (click)="save()">
       <i class="fas fa-paper-plane fa-lg"></i> {{'BTN_SUBMIT' | translate}}
     </button>
   </div>

--- a/frontend/src/app/recycle/recycle.component.ts
+++ b/frontend/src/app/recycle/recycle.component.ts
@@ -17,7 +17,7 @@ import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCheckbox } from '@angular/material/checkbox'
 import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker'
-import { NgIf } from '@angular/common'
+
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatError, MatSuffix } from '@angular/material/form-field'
 
@@ -29,7 +29,7 @@ library.add(faPaperPlane)
   selector: 'app-recycle',
   templateUrl: './recycle.component.html',
   styleUrls: ['./recycle.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, NgIf, MatError, AddressComponent, MatDatepickerInput, MatDatepickerToggle, MatSuffix, MatDatepicker, MatCheckbox, MatButtonModule, MatCardImage, MatCardContent]
+  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatError, AddressComponent, MatDatepickerInput, MatDatepickerToggle, MatSuffix, MatDatepicker, MatCheckbox, MatButtonModule, MatCardImage, MatCardContent]
 })
 export class RecycleComponent implements OnInit {
   @ViewChild('addressComp', { static: true }) public addressComponent: AddressComponent

--- a/frontend/src/app/register/register.component.html
+++ b/frontend/src/app/register/register.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -16,98 +16,117 @@
         <mat-form-field appearance="outline" color="accent">
           <mat-label translate>LABEL_EMAIL</mat-label>
           <input id="emailControl" [formControl]="emailControl" (focus)="this.error=null" type="text" matInput
-                aria-label="Email address field">
-          <mat-error *ngIf="emailControl.invalid && emailControl.errors.required" translate>MANDATORY_EMAIL</mat-error>
-          <mat-error *ngIf="emailControl.invalid && emailControl.errors.email" translate>INVALID_EMAIL</mat-error>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_PASSWORD</mat-label>
-          <input #password id="passwordControl" [formControl]="passwordControl" (focus)="this.error=null" type="password"
-                matInput aria-label="Field for the password">
-          <mat-hint translate>
-            <i class="fas fa-exclamation-circle"></i>
-            <em style="margin-left:5px;" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
-          </mat-hint>
-          <mat-hint align="end">{{password.value?.length || 0}}/20</mat-hint>
-          <mat-error *ngIf="passwordControl.invalid && passwordControl.errors.required" translate>MANDATORY_PASSWORD
-          </mat-error>
-          <mat-error
-            *ngIf="passwordControl.invalid && (passwordControl.errors.minlength || passwordControl.errors.maxlength)"
-            translate [translateParams]="{length: '5-40'}">INVALID_PASSWORD_LENGTH
-          </mat-error>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_PASSWORD_REPEAT</mat-label>
-          <input #repeatPassword id="repeatPasswordControl" [formControl]="repeatPasswordControl"
-                (focus)="this.error=null" type="password" matInput aria-label="Field to confirm the password">
-          <mat-hint align="end">{{repeatPassword.value?.length || 0}}/40</mat-hint>
-          <mat-error *ngIf="repeatPasswordControl.invalid && repeatPasswordControl.errors.required" translate>
-            MANDATORY_PASSWORD_REPEAT
-          </mat-error>
-          <mat-error *ngIf="repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame" translate>
-            PASSWORDS_NOT_MATCHING
-          </mat-error>
-        </mat-form-field>
-
-        <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
-        <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
-        <app-password-strength-info *ngIf="passwordInfoToggle.checked" [passwordComponent]="passwordStrength"
-                                    [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
-                                    [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
-                                    [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
-                                    [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
-                                    [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
-        </app-password-strength-info>
-
-        <div class="security-container">
-
-          <mat-form-field color="accent" appearance="outline">
-            <mat-label>
-              {{'LABEL_SECURITY_QUESTION' | translate}}
-            </mat-label>
-            <mat-select [formControl]="securityQuestionControl" placeholder="" [(value)]="selected"
-                        (focus)="this.error=null" name="securityQuestion"
-                        aria-label="Selection list for the security question">
-              <mat-option *ngFor="let question of securityQuestions" [value]="question.id" class="mat-body">
-                {{question.question}}
-              </mat-option>
-            </mat-select>
-            <mat-hint translate>
-              <i class="fas fa-exclamation-circle"></i>
-              <em style="margin-left:5px;" translate>CANNOT_BE_CHANGED_LATER</em>
-            </mat-hint>
-            <mat-error *ngIf="securityQuestionControl.invalid && securityQuestionControl.errors.required" translate>
-              MANDATORY_SECURITY_QUESTION
-            </mat-error>
+            aria-label="Email address field">
+            @if (emailControl.invalid && emailControl.errors.required) {
+              <mat-error translate>MANDATORY_EMAIL</mat-error>
+            }
+            @if (emailControl.invalid && emailControl.errors.email) {
+              <mat-error translate>INVALID_EMAIL</mat-error>
+            }
           </mat-form-field>
 
           <mat-form-field appearance="outline" color="accent">
-            <mat-label translate>SECURITY_ANSWER</mat-label>
-            <input id="securityAnswerControl" [formControl]="securityAnswerControl" (focus)="this.error=null" type="text"
-                  matInput [placeholder]="'SECURITY_ANSWER_PLACEHOLDER' | translate"
-                  aria-label="Field for the answer to the security question">
-            <mat-error *ngIf="securityAnswerControl.invalid && securityAnswerControl.errors.required" translate>
-              MANDATORY_SECURITY_ANSWER
-            </mat-error>
-          </mat-form-field>
-        </div>
+            <mat-label translate>LABEL_PASSWORD</mat-label>
+            <input #password id="passwordControl" [formControl]="passwordControl" (focus)="this.error=null" type="password"
+              matInput aria-label="Field for the password">
+              <mat-hint translate>
+                <i class="fas fa-exclamation-circle"></i>
+                <em style="margin-left:5px;" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
+              </mat-hint>
+              <mat-hint align="end">{{password.value?.length || 0}}/20</mat-hint>
+              @if (passwordControl.invalid && passwordControl.errors.required) {
+                <mat-error translate>MANDATORY_PASSWORD
+                </mat-error>
+              }
+              @if (passwordControl.invalid && (passwordControl.errors.minlength || passwordControl.errors.maxlength)) {
+                <mat-error
+                  translate [translateParams]="{length: '5-40'}">INVALID_PASSWORD_LENGTH
+                </mat-error>
+              }
+            </mat-form-field>
 
-        <button type="submit"
-                id="registerButton"
-                mat-raised-button color="primary"
-                [disabled]="emailControl.invalid || passwordControl.invalid || repeatPasswordControl.invalid || securityQuestionControl.invalid || securityAnswerControl.invalid"
-                (click)="save()"
-                aria-label="Button to complete the registration">
-          <mat-icon>person_add</mat-icon>
-          {{'BTN_REGISTER' | translate}}
-        </button>
+            <mat-form-field appearance="outline" color="accent">
+              <mat-label translate>LABEL_PASSWORD_REPEAT</mat-label>
+              <input #repeatPassword id="repeatPasswordControl" [formControl]="repeatPasswordControl"
+                (focus)="this.error=null" type="password" matInput aria-label="Field to confirm the password">
+                <mat-hint align="end">{{repeatPassword.value?.length || 0}}/40</mat-hint>
+                @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.required) {
+                  <mat-error translate>
+                    MANDATORY_PASSWORD_REPEAT
+                  </mat-error>
+                }
+                @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame) {
+                  <mat-error translate>
+                    PASSWORDS_NOT_MATCHING
+                  </mat-error>
+                }
+              </mat-form-field>
 
-        <div id="alreadyACustomerLink">
-          <a class="primary-link" routerLink="/login" translate>ALREADY_A_CUSTOMER</a>
+              <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
+              <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
+              @if (passwordInfoToggle.checked) {
+                <app-password-strength-info [passwordComponent]="passwordStrength"
+                  [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
+                  [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
+                  [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
+                  [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
+                  [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
+                </app-password-strength-info>
+              }
+
+              <div class="security-container">
+
+                <mat-form-field color="accent" appearance="outline">
+                  <mat-label>
+                    {{'LABEL_SECURITY_QUESTION' | translate}}
+                  </mat-label>
+                  <mat-select [formControl]="securityQuestionControl" placeholder="" [(value)]="selected"
+                    (focus)="this.error=null" name="securityQuestion"
+                    aria-label="Selection list for the security question">
+                    @for (question of securityQuestions; track question) {
+                      <mat-option [value]="question.id" class="mat-body">
+                        {{question.question}}
+                      </mat-option>
+                    }
+                  </mat-select>
+                  <mat-hint translate>
+                    <i class="fas fa-exclamation-circle"></i>
+                    <em style="margin-left:5px;" translate>CANNOT_BE_CHANGED_LATER</em>
+                  </mat-hint>
+                  @if (securityQuestionControl.invalid && securityQuestionControl.errors.required) {
+                    <mat-error translate>
+                      MANDATORY_SECURITY_QUESTION
+                    </mat-error>
+                  }
+                </mat-form-field>
+
+                <mat-form-field appearance="outline" color="accent">
+                  <mat-label translate>SECURITY_ANSWER</mat-label>
+                  <input id="securityAnswerControl" [formControl]="securityAnswerControl" (focus)="this.error=null" type="text"
+                    matInput [placeholder]="'SECURITY_ANSWER_PLACEHOLDER' | translate"
+                    aria-label="Field for the answer to the security question">
+                    @if (securityAnswerControl.invalid && securityAnswerControl.errors.required) {
+                      <mat-error translate>
+                        MANDATORY_SECURITY_ANSWER
+                      </mat-error>
+                    }
+                  </mat-form-field>
+                </div>
+
+                <button type="submit"
+                  id="registerButton"
+                  mat-raised-button color="primary"
+                  [disabled]="emailControl.invalid || passwordControl.invalid || repeatPasswordControl.invalid || securityQuestionControl.invalid || securityAnswerControl.invalid"
+                  (click)="save()"
+                  aria-label="Button to complete the registration">
+                  <mat-icon>person_add</mat-icon>
+                  {{'BTN_REGISTER' | translate}}
+                </button>
+
+                <div id="alreadyACustomerLink">
+                  <a class="primary-link" routerLink="/login" translate>ALREADY_A_CUSTOMER</a>
+                </div>
+              </div>
+            </div>
+          </mat-card>
         </div>
-      </div>
-    </div>
-  </mat-card>
-</div>

--- a/frontend/src/app/register/register.component.html
+++ b/frontend/src/app/register/register.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/register/register.component.ts
+++ b/frontend/src/app/register/register.component.ts
@@ -23,7 +23,7 @@ import { MatSelect } from '@angular/material/select'
 import { PasswordStrengthComponent } from '../password-strength/password-strength.component'
 import { PasswordStrengthInfoComponent } from '../password-strength-info/password-strength-info.component'
 import { MatSlideToggle } from '@angular/material/slide-toggle'
-import { NgIf, NgFor } from '@angular/common'
+
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatError, MatHint } from '@angular/material/form-field'
 import { MatCardModule } from '@angular/material/card'
@@ -36,7 +36,7 @@ library.add(faUserPlus, faExclamationCircle)
   selector: 'app-register',
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, NgIf, MatError, MatHint, MatSlideToggle, PasswordStrengthComponent, PasswordStrengthInfoComponent, MatSelect, NgFor, MatOption, MatButtonModule, RouterLink, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatHint, MatSlideToggle, PasswordStrengthComponent, PasswordStrengthInfoComponent, MatSelect, MatOption, MatButtonModule, RouterLink, MatIconModule]
 })
 export class RegisterComponent implements OnInit {
   public emailControl: UntypedFormControl = new UntypedFormControl('', [Validators.required, Validators.email])

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
@@ -10,94 +10,106 @@
 <div class="description-row" [innerHtml]="challenge.description"></div>
 <div class="bottom-row">
   <div class="tags">
-    <span *ngFor="let tag of challenge.tagList" class="tag" [matTooltip]="('TAG_' + tag?.toUpperCase().split(' ').join('_') + '_DESCRIPTION' | translate)">{{ tag }}</span>
+    @for (tag of challenge.tagList; track tag) {
+      <span class="tag" [matTooltip]="('TAG_' + tag?.toUpperCase().split(' ').join('_') + '_DESCRIPTION' | translate)">{{ tag }}</span>
+    }
   </div>
   <div class="badge-group">
     <!-- info text if the challenge is unavailable -->
-    <button
-      class="badge"
-      *ngIf="challenge.disabledEnv !== null && challenge.disabledEnv !== 'safetyMode'"
-      [matTooltip]="'CHALLENGE_UNAVAILABLE' | translate:{ env: challenge.disabledEnv }"
-    >
-      <mat-icon [style.color]="'var(--theme-warn)'">info_outline</mat-icon>
-    </button>
-    <button
-      class="badge"
-      *ngIf="challenge.disabledEnv === 'safetyMode'"
-      [matTooltip]="'CHALLENGE_UNAVAILABLE_SAFETYMODE'| translate:{ env: challenge.disabledEnv}"
-    >
-      <mat-icon [style.color]="'var(--theme-warn)'">info_outline</mat-icon>
-    </button>
+    @if (challenge.disabledEnv !== null && challenge.disabledEnv !== 'safetyMode') {
+      <button
+        class="badge"
+        [matTooltip]="'CHALLENGE_UNAVAILABLE' | translate:{ env: challenge.disabledEnv }"
+        >
+        <mat-icon [style.color]="'var(--theme-warn)'">info_outline</mat-icon>
+      </button>
+    }
+    @if (challenge.disabledEnv === 'safetyMode') {
+      <button
+        class="badge"
+        [matTooltip]="'CHALLENGE_UNAVAILABLE_SAFETYMODE'| translate:{ env: challenge.disabledEnv}"
+        >
+        <mat-icon [style.color]="'var(--theme-warn)'">info_outline</mat-icon>
+      </button>
+    }
     <!-- coding challenge badge -->
-    <button
-      class="badge"
-      *ngIf="applicationConfiguration.challenges.codingChallengesEnabled !== 'never' && challenge.hasCodingChallenge"
-      (click)="openCodingChallengeDialog(challenge.key)"
-      [disabled]="challenge.solved === false && applicationConfiguration.challenges.codingChallengesEnabled !== 'always'"
+    @if (applicationConfiguration.challenges.codingChallengesEnabled !== 'never' && challenge.hasCodingChallenge) {
+      <button
+        class="badge"
+        (click)="openCodingChallengeDialog(challenge.key)"
+        [disabled]="challenge.solved === false && applicationConfiguration.challenges.codingChallengesEnabled !== 'always'"
       [ngClass]="{
         'partially-completed': challenge.codingChallengeStatus === 1,
         'completed': challenge.codingChallengeStatus === 2
       }"
-      [matTooltip]="(challenge.solved ? 'LAUNCH_CODING_CHALLENGE' : 'SOLVE_HACKING_CHALLENGE') | translate"
-    >
-      <span class="badge-status" *ngIf="challenge.codingChallengeStatus !== 0">{{ challenge.codingChallengeStatus }}/2</span>
-      <mat-icon>code</mat-icon>
-    </button>
+        [matTooltip]="(challenge.solved ? 'LAUNCH_CODING_CHALLENGE' : 'SOLVE_HACKING_CHALLENGE') | translate"
+        >
+        @if (challenge.codingChallengeStatus !== 0) {
+          <span class="badge-status">{{ challenge.codingChallengeStatus }}/2</span>
+        }
+        <mat-icon>code</mat-icon>
+      </button>
+    }
     <!-- cheat cheat link-->
-    <a
-      class="badge not-completable"
-      *ngIf="challenge.mitigationUrl && challenge.solved"
-      [href]="challenge.mitigationUrl"
-      target="_blank"
-      rel="noopener noreferrer"
-      [matTooltip]="'INFO_VULNERABILITY_MITIGATION_LINK' | translate"
-      aria-label="Vulnerability mitigation link"
-    >
-      <mat-icon>policy_outline</mat-icon>
-    </a>
+    @if (challenge.mitigationUrl && challenge.solved) {
+      <a
+        class="badge not-completable"
+        [href]="challenge.mitigationUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        [matTooltip]="'INFO_VULNERABILITY_MITIGATION_LINK' | translate"
+        aria-label="Vulnerability mitigation link"
+        >
+        <mat-icon>policy_outline</mat-icon>
+      </a>
+    }
     <!-- ctf mode flag repeat-->
-    <button
-      class="badge"
-      [ngClass]="{ 'completed': challenge.solved }"
-      *ngIf="challenge.solved && applicationConfiguration.ctf.showFlagsInNotifications"
-      (click)="repeatChallengeNotification(challenge.key)"
-      [matTooltip]="'NOTIFICATION_RESEND_INSTRUCTIONS' | translate"
-    >
-      <mat-icon>flag_outline</mat-icon>
-    </button>
+    @if (challenge.solved && applicationConfiguration.ctf.showFlagsInNotifications) {
+      <button
+        class="badge"
+        [ngClass]="{ 'completed': challenge.solved }"
+        (click)="repeatChallengeNotification(challenge.key)"
+        [matTooltip]="'NOTIFICATION_RESEND_INSTRUCTIONS' | translate"
+        >
+        <mat-icon>flag_outline</mat-icon>
+      </button>
+    }
     <!-- hacking instructor-->
-    <button
-      class="badge not-completable"
-      *ngIf="applicationConfiguration.hackingInstructor.isEnabled && hasInstructions(challenge.name)"
-      [matTooltip]="'INFO_HACKING_INSTRUCTOR' | translate"
-      (click)="startHackingInstructorFor(challenge.name)"
-    >
-      <mat-icon>school_outline</mat-icon>
-    </button>
+    @if (applicationConfiguration.hackingInstructor.isEnabled && hasInstructions(challenge.name)) {
+      <button
+        class="badge not-completable"
+        [matTooltip]="'INFO_HACKING_INSTRUCTOR' | translate"
+        (click)="startHackingInstructorFor(challenge.name)"
+        >
+        <mat-icon>school_outline</mat-icon>
+      </button>
+    }
     <!-- challenge hint -->
     <!-- with hintUrl -->
-    <a
-      *ngIf="challenge.hint && challenge.hintUrl"
-      class="badge not-completable"
-      [style.padding]="'0 6px 0 4px'"
-      target="_blank"
-      rel="noopener noreferrer"
-      [href]="challenge.hintUrl"
-      [matTooltip]="challenge.hint | challengeHint:{hintUrl: challenge.hintUrl} | async"
-    >
-      <mat-icon>lightbulb</mat-icon>
-      Hint
-    </a>
+    @if (challenge.hint && challenge.hintUrl) {
+      <a
+        class="badge not-completable"
+        [style.padding]="'0 6px 0 4px'"
+        target="_blank"
+        rel="noopener noreferrer"
+        [href]="challenge.hintUrl"
+        [matTooltip]="challenge.hint | challengeHint:{hintUrl: challenge.hintUrl} | async"
+        >
+        <mat-icon>lightbulb</mat-icon>
+        Hint
+      </a>
+    }
     <!-- challenge hint -->
     <!-- without hintUrl -->
-    <span
-      *ngIf="challenge.hint && !challenge.hintUrl"
-      class="badge not-completable"
-      [style.padding]="'0 6px 0 4px'"
-      [matTooltip]="challenge.hint"
-    >
-      <mat-icon>lightbulb</mat-icon>
-      Hint
-    </span>
+    @if (challenge.hint && !challenge.hintUrl) {
+      <span
+        class="badge not-completable"
+        [style.padding]="'0 6px 0 4px'"
+        [matTooltip]="challenge.hint"
+        >
+        <mat-icon>lightbulb</mat-icon>
+        Hint
+      </span>
+    }
   </div>
 </div>

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
@@ -5,14 +5,14 @@ import { ChallengeHintPipe } from '../../pipes/challenge-hint.pipe'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
-import { NgFor, NgIf, NgClass, AsyncPipe } from '@angular/common'
+import { NgClass, AsyncPipe } from '@angular/common'
 import { DifficultyStarsComponent } from '../difficulty-stars/difficulty-stars.component'
 
 @Component({
   selector: 'challenge-card',
   templateUrl: './challenge-card.component.html',
   styleUrls: ['./challenge-card.component.scss'],
-  imports: [DifficultyStarsComponent, NgFor, MatTooltip, NgIf, MatIconModule, NgClass, AsyncPipe, TranslateModule, ChallengeHintPipe]
+  imports: [DifficultyStarsComponent, MatTooltip, MatIconModule, NgClass, AsyncPipe, TranslateModule, ChallengeHintPipe]
 })
 export class ChallengeCardComponent implements OnInit {
   @Input()

--- a/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.html
+++ b/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.html
@@ -1,25 +1,22 @@
 @if (numberOfDisabledChallenges > 0) {
   <warning-card>
     <ng-container warning-icon>
-      @if (disabledBecauseOfEnv !== 'Windows') {
-        <i class="env-icon" [ngClass]="'icon-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
-      }
       @if (disabledBecauseOfEnv === 'Windows') {
         <i class="env-icon" [ngClass]="'fab fa-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
+      } @else {
+        <i class="env-icon" [ngClass]="'icon-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
       }
     </ng-container>
-    @if (disabledBecauseOfEnv !=='Safety Mode') {
-      <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges, env: disabledBecauseOfEnv}"></span>
-    }
     @if (disabledBecauseOfEnv ==='Safety Mode') {
       <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges,env:'safety mode being turned on'}"></span>
+    } @else {
+      <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges, env: disabledBecauseOfEnv}"></span>
     }
     <button warning-action mat-button color="accent" (click)="toggleShowDisabledChallenges()">
-      @if (filterSetting.showDisabledChallenges == false) {
-        {{ 'SHOW_DISABLED_CHALLENGES' | translate }}
-      }
-      @if (filterSetting.showDisabledChallenges == true) {
+      @if (filterSetting.showDisabledChallenges === true) {
         {{ 'HIDE_DISABLED_CHALLENGES' | translate }}
+      } @else {
+        {{ 'SHOW_DISABLED_CHALLENGES' | translate }}
       }
     </button>
   </warning-card>

--- a/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.html
+++ b/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.html
@@ -1,18 +1,26 @@
-<warning-card *ngIf="numberOfDisabledChallenges > 0">
-  <ng-container warning-icon>
-    <i class="env-icon" *ngIf="disabledBecauseOfEnv !== 'Windows'" [ngClass]="'icon-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
-    <i class="env-icon" *ngIf="disabledBecauseOfEnv === 'Windows'" [ngClass]="'fab fa-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
-  </ng-container>
-  
-  <span *ngIf="disabledBecauseOfEnv !=='Safety Mode'" warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges, env: disabledBecauseOfEnv}"></span>
-  <span *ngIf="disabledBecauseOfEnv ==='Safety Mode'" warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges,env:'safety mode being turned on'}"></span>
-  
-  <button warning-action mat-button color="accent" (click)="toggleShowDisabledChallenges()">
-    <ng-container *ngIf="filterSetting.showDisabledChallenges == false">
-      {{ 'SHOW_DISABLED_CHALLENGES' | translate }}
+@if (numberOfDisabledChallenges > 0) {
+  <warning-card>
+    <ng-container warning-icon>
+      @if (disabledBecauseOfEnv !== 'Windows') {
+        <i class="env-icon" [ngClass]="'icon-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
+      }
+      @if (disabledBecauseOfEnv === 'Windows') {
+        <i class="env-icon" [ngClass]="'fab fa-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
+      }
     </ng-container>
-    <ng-container *ngIf="filterSetting.showDisabledChallenges == true">
-      {{ 'HIDE_DISABLED_CHALLENGES' | translate }}
-    </ng-container>
-  </button>
-</warning-card>
+    @if (disabledBecauseOfEnv !=='Safety Mode') {
+      <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges, env: disabledBecauseOfEnv}"></span>
+    }
+    @if (disabledBecauseOfEnv ==='Safety Mode') {
+      <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges,env:'safety mode being turned on'}"></span>
+    }
+    <button warning-action mat-button color="accent" (click)="toggleShowDisabledChallenges()">
+      @if (filterSetting.showDisabledChallenges == false) {
+        {{ 'SHOW_DISABLED_CHALLENGES' | translate }}
+      }
+      @if (filterSetting.showDisabledChallenges == true) {
+        {{ 'HIDE_DISABLED_CHALLENGES' | translate }}
+      }
+    </button>
+  </warning-card>
+}

--- a/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.ts
+++ b/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.ts
@@ -5,13 +5,13 @@ import { type EnrichedChallenge } from '../../types/EnrichedChallenge'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatButtonModule } from '@angular/material/button'
 import { WarningCardComponent } from '../warning-card/warning-card.component'
-import { NgIf, NgClass } from '@angular/common'
+import { NgClass } from '@angular/common'
 
 @Component({
   selector: 'challenges-unavailable-warning',
   templateUrl: './challenges-unavailable-warning.component.html',
   styleUrls: ['./challenges-unavailable-warning.component.scss'],
-  imports: [NgIf, WarningCardComponent, NgClass, MatButtonModule, TranslateModule]
+  imports: [WarningCardComponent, NgClass, MatButtonModule, TranslateModule]
 })
 export class ChallengesUnavailableWarningComponent implements OnChanges {
   @Input()

--- a/frontend/src/app/score-board/components/difficulty-overview-score-card/difficulty-overview-score-card.component.html
+++ b/frontend/src/app/score-board/components/difficulty-overview-score-card/difficulty-overview-score-card.component.html
@@ -28,8 +28,7 @@
                   <stop stop-color="var(--theme-accent)" />
                   @if (difficulty.availableChallenges === 0) {
                     <stop offset="0%" stop-color="var(--theme-accent)" />
-                  }
-                  @if (difficulty.availableChallenges !== 0) {
+                  } @else {
                     <stop [attr.offset]="difficulty.solvedChallenges / difficulty.availableChallenges * 100 + '%'" stop-color="var(--theme-accent)" />
                   }
                   <stop stop-color="var(--theme-accent)" />

--- a/frontend/src/app/score-board/components/difficulty-overview-score-card/difficulty-overview-score-card.component.html
+++ b/frontend/src/app/score-board/components/difficulty-overview-score-card/difficulty-overview-score-card.component.html
@@ -4,40 +4,46 @@
   [score]="solvedChallenges"
   [showAsPercentage]="false"
   [showProgressBar]="false"
->
+  >
   <div right-side class="difficulties-group">
-    <div class="difficulty-container" *ngFor="let difficulty of difficultySummaries">
-      <div class="star-container">
-        <svg
-          width="28"
-          height="25"
-          viewBox="0 0 28 25"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            [attr.fill]="'url(#solved-gradient-' + difficulty.difficulty + ')'"
-            d="M12.6496 1.25874L9.57854 7.48541L2.70757 8.48713C1.4754 8.66584 0.981596 10.1849 1.87515 11.0549L6.84614 15.8989L5.67041 22.7417C5.45878 23.9786 6.76149 24.905 7.85257 24.3266L13.9993 21.0957L20.146 24.3266C21.2371 24.9003 22.5398 23.9786 22.3282 22.7417L21.1524 15.8989L26.1234 11.0549C27.017 10.1849 26.5232 8.66584 25.291 8.48713L18.42 7.48541L15.349 1.25874C14.7988 0.148847 13.2045 0.134738 12.6496 1.25874Z"
-          />
-          <defs>
-            <linearGradient
-              [attr.id]="'solved-gradient-' + difficulty.difficulty"
-              x1="0" x2="0" y1="1" y2="0"
+    @for (difficulty of difficultySummaries; track difficulty) {
+      <div class="difficulty-container">
+        <div class="star-container">
+          <svg
+            width="28"
+            height="25"
+            viewBox="0 0 28 25"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
             >
-            <stop stop-color="var(--theme-accent)" />
-            <stop *ngIf="difficulty.availableChallenges === 0" offset="0%" stop-color="var(--theme-accent)" />
-            <stop *ngIf="difficulty.availableChallenges !== 0" [attr.offset]="difficulty.solvedChallenges / difficulty.availableChallenges * 100 + '%'" stop-color="var(--theme-accent)" />
-            <stop stop-color="var(--theme-accent)" />
-            <!-- has to be duplicated here to stop the gradient directly instead of doing a "gradual" transition -->
-            <stop stop-color="var(--theme-primary)" />
-            </linearGradient>
-          </defs>
-        </svg>
-        <span class="star-difficulty-label">{{ difficulty.difficulty }}</span>
-      </div>
-      <span>
-        {{ difficulty.solvedChallenges }}/<span class="total-challenges">{{ difficulty.availableChallenges }}</span>
-      </span>
+            <path
+              [attr.fill]="'url(#solved-gradient-' + difficulty.difficulty + ')'"
+              d="M12.6496 1.25874L9.57854 7.48541L2.70757 8.48713C1.4754 8.66584 0.981596 10.1849 1.87515 11.0549L6.84614 15.8989L5.67041 22.7417C5.45878 23.9786 6.76149 24.905 7.85257 24.3266L13.9993 21.0957L20.146 24.3266C21.2371 24.9003 22.5398 23.9786 22.3282 22.7417L21.1524 15.8989L26.1234 11.0549C27.017 10.1849 26.5232 8.66584 25.291 8.48713L18.42 7.48541L15.349 1.25874C14.7988 0.148847 13.2045 0.134738 12.6496 1.25874Z"
+              />
+              <defs>
+                <linearGradient
+                  [attr.id]="'solved-gradient-' + difficulty.difficulty"
+                  x1="0" x2="0" y1="1" y2="0"
+                  >
+                  <stop stop-color="var(--theme-accent)" />
+                  @if (difficulty.availableChallenges === 0) {
+                    <stop offset="0%" stop-color="var(--theme-accent)" />
+                  }
+                  @if (difficulty.availableChallenges !== 0) {
+                    <stop [attr.offset]="difficulty.solvedChallenges / difficulty.availableChallenges * 100 + '%'" stop-color="var(--theme-accent)" />
+                  }
+                  <stop stop-color="var(--theme-accent)" />
+                  <!-- has to be duplicated here to stop the gradient directly instead of doing a "gradual" transition -->
+                  <stop stop-color="var(--theme-primary)" />
+                </linearGradient>
+              </defs>
+            </svg>
+            <span class="star-difficulty-label">{{ difficulty.difficulty }}</span>
+          </div>
+          <span>
+            {{ difficulty.solvedChallenges }}/<span class="total-challenges">{{ difficulty.availableChallenges }}</span>
+          </span>
+        </div>
+      }
     </div>
-  </div>
-</score-card>
+  </score-card>

--- a/frontend/src/app/score-board/components/difficulty-overview-score-card/difficulty-overview-score-card.component.ts
+++ b/frontend/src/app/score-board/components/difficulty-overview-score-card/difficulty-overview-score-card.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, type OnChanges, type OnInit, type SimpleChanges } fro
 
 import { type EnrichedChallenge } from '../../types/EnrichedChallenge'
 import { TranslateModule } from '@ngx-translate/core'
-import { NgFor, NgIf } from '@angular/common'
+
 import { ScoreCardComponent } from '../score-card/score-card.component'
 
 interface DifficultySummary {
@@ -28,7 +28,7 @@ const INITIAL_SUMMARIES: Readonly<DifficultySummaries> = Object.freeze({
   selector: 'difficulty-overview-score-card',
   templateUrl: './difficulty-overview-score-card.component.html',
   styleUrls: ['./difficulty-overview-score-card.component.scss'],
-  imports: [ScoreCardComponent, NgFor, NgIf, TranslateModule]
+  imports: [ScoreCardComponent, TranslateModule]
 })
 export class DifficultyOverviewScoreCardComponent implements OnInit, OnChanges {
   @Input()

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
@@ -1,14 +1,14 @@
-<ng-container *ngFor="let _ of [].constructor(difficulty)">
+@for (_ of [].constructor(difficulty); track _) {
   <svg
     width="18"
     height="18"
     viewBox="0 0 14 13"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-  >
+    >
     <path
       d="M6.56386 0.511963L8.10332 5.24992H13.0851L9.05475 8.17813L10.5942 12.9161L6.56386 9.98787L2.53352 12.9161L4.07297 8.17813L0.0426283 5.24992H5.02441L6.56386 0.511963Z"
       fill="var(--theme-text)"
-    />
-  </svg>
-</ng-container>
+      />
+    </svg>
+  }

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.ts
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.ts
@@ -1,11 +1,10 @@
 import { Component, Input } from '@angular/core'
-import { NgFor } from '@angular/common'
 
 @Component({
   selector: 'difficulty-stars',
   templateUrl: './difficulty-stars.component.html',
   styleUrls: ['./difficulty-stars.component.scss'],
-  imports: [NgFor]
+  imports: []
 })
 export class DifficultyStarsComponent {
   @Input()

--- a/frontend/src/app/score-board/components/filter-settings/components/category-filter/category-filter.component.html
+++ b/frontend/src/app/score-board/components/filter-settings/components/category-filter/category-filter.component.html
@@ -2,15 +2,16 @@
   class="pill selected"
   (click)="resetCategoryFilter()"
   [ngClass]="{ selected: isAllCategoriesSelected() }"
->
+  >
   All
 </button>
-<button
-  *ngFor="let category of availableCategories"
-  class="pill"
-  [ngClass]="{ selected: isCategorySelected(category) }"
-  (click)="toggleCategorySelected(category)"
-  [matTooltip]="'CATEGORY_' + category.toUpperCase().split(' ').join('_') + '_DESCRIPTION' | translate"
->
-  {{ category }}
-</button>
+@for (category of availableCategories; track category) {
+  <button
+    class="pill"
+    [ngClass]="{ selected: isCategorySelected(category) }"
+    (click)="toggleCategorySelected(category)"
+    [matTooltip]="'CATEGORY_' + category.toUpperCase().split(' ').join('_') + '_DESCRIPTION' | translate"
+    >
+    {{ category }}
+  </button>
+}

--- a/frontend/src/app/score-board/components/filter-settings/components/category-filter/category-filter.component.ts
+++ b/frontend/src/app/score-board/components/filter-settings/components/category-filter/category-filter.component.ts
@@ -3,13 +3,13 @@ import { type EnrichedChallenge } from '../../../../types/EnrichedChallenge'
 import { DEFAULT_FILTER_SETTING } from '../../../../filter-settings/FilterSetting'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatTooltip } from '@angular/material/tooltip'
-import { NgClass, NgFor } from '@angular/common'
+import { NgClass } from '@angular/common'
 
 @Component({
   selector: 'category-filter',
   templateUrl: './category-filter.component.html',
   styleUrls: ['./category-filter.component.scss'],
-  imports: [NgClass, NgFor, MatTooltip, TranslateModule]
+  imports: [NgClass, MatTooltip, TranslateModule]
 })
 export class CategoryFilterComponent implements OnInit, OnChanges {
   public availableCategories = new Set<string>()

--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.html
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.html
@@ -11,12 +11,14 @@
       <mat-label>{{ 'LABEL_DIFFICULTY' | translate }}</mat-label>
       <mat-select multiple [value]="filterSetting.difficulties" (selectionChange)="onDifficultyFilterChange($event.value)">
         <mat-select-trigger>
-          <ng-container *ngIf="filterSetting.difficulties.length === 0">
+          @if (filterSetting.difficulties.length === 0) {
             {{ 'LABEL_DIFFICULTY' | translate }}
-          </ng-container>
-          <span *ngIf="filterSetting.difficulties.length !== 0">
-            {{ filterSetting.difficulties | difficultySelectionSummary }}
-          </span>
+          }
+          @if (filterSetting.difficulties.length !== 0) {
+            <span>
+              {{ filterSetting.difficulties | difficultySelectionSummary }}
+            </span>
+          }
         </mat-select-trigger>
         <mat-option [value]="1">
           <difficulty-stars [difficulty]="1"></difficulty-stars>
@@ -50,7 +52,9 @@
     <mat-form-field>
       <mat-label>{{ 'LABEL_TAGS' | translate }}</mat-label>
       <mat-select multiple [value]="filterSetting.tags" (selectionChange)="onTagFilterChange($event.value)">
-        <mat-option *ngFor="let tag of tags" [value]="tag" class="mat-body">{{ tag }}</mat-option>
+        @for (tag of tags; track tag) {
+          <mat-option [value]="tag" class="mat-body">{{ tag }}</mat-option>
+        }
       </mat-select>
     </mat-form-field>
     <div class="additional-settings-wrapper">

--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.html
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.html
@@ -13,8 +13,7 @@
         <mat-select-trigger>
           @if (filterSetting.difficulties.length === 0) {
             {{ 'LABEL_DIFFICULTY' | translate }}
-          }
-          @if (filterSetting.difficulties.length !== 0) {
+          } @else {
             <span>
               {{ filterSetting.difficulties | difficultySelectionSummary }}
             </span>

--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.ts
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.ts
@@ -9,7 +9,7 @@ import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconButton } from '@angular/material/button'
 import { DifficultyStarsComponent } from '../difficulty-stars/difficulty-stars.component'
 import { MatOption } from '@angular/material/core'
-import { NgIf, NgFor } from '@angular/common'
+
 import { MatSelect, MatSelectTrigger } from '@angular/material/select'
 import { MatInputModule } from '@angular/material/input'
 import { TranslateModule } from '@ngx-translate/core'
@@ -20,7 +20,7 @@ import { MatFormFieldModule, MatPrefix, MatLabel } from '@angular/material/form-
   selector: 'filter-settings',
   templateUrl: './filter-settings.component.html',
   styleUrls: ['./filter-settings.component.scss'],
-  imports: [MatFormFieldModule, MatIconModule, MatPrefix, MatLabel, TranslateModule, MatInputModule, MatSelect, MatSelectTrigger, NgIf, MatOption, DifficultyStarsComponent, NgFor, MatIconButton, MatTooltip, CategoryFilterComponent, DifficultySelectionSummaryPipe]
+  imports: [MatFormFieldModule, MatIconModule, MatPrefix, MatLabel, TranslateModule, MatInputModule, MatSelect, MatSelectTrigger, MatOption, DifficultyStarsComponent, MatIconButton, MatTooltip, CategoryFilterComponent, DifficultySelectionSummaryPipe]
 })
 export class FilterSettingsComponent implements OnChanges {
   @Input()

--- a/frontend/src/app/score-board/components/score-card/score-card.component.html
+++ b/frontend/src/app/score-board/components/score-card/score-card.component.html
@@ -1,9 +1,8 @@
 <div class="score-group">
   <p class="score">
-    @if (showAsPercentage == true) {
+    @if (showAsPercentage === true) {
       {{ (score / total) * 100 | number : "1.0-0" }}%
-    }
-    @if (showAsPercentage == false) {
+    } @else {
       {{ score }}/<span class="fraction-total">{{ total }}</span>
     }
   </p>

--- a/frontend/src/app/score-board/components/score-card/score-card.component.html
+++ b/frontend/src/app/score-board/components/score-card/score-card.component.html
@@ -1,16 +1,18 @@
 <div class="score-group">
   <p class="score">
-    <ng-container *ngIf="showAsPercentage == true">
+    @if (showAsPercentage == true) {
       {{ (score / total) * 100 | number : "1.0-0" }}%
-    </ng-container>
-    <ng-container *ngIf="showAsPercentage == false">
+    }
+    @if (showAsPercentage == false) {
       {{ score }}/<span class="fraction-total">{{ total }}</span>
-    </ng-container>
+    }
   </p>
   <p class="category">{{ description }}</p>
-  <div *ngIf="showProgressBar === true" class="progress-bar-container">
-    <div class="progress-bar" [style.width]="(score / total) * 100 + '%'"></div>
-  </div>
+  @if (showProgressBar === true) {
+    <div class="progress-bar-container">
+      <div class="progress-bar" [style.width]="(score / total) * 100 + '%'"></div>
+    </div>
+  }
 </div>
 <div class="right-group">
   <ng-content select="[right-side]" />

--- a/frontend/src/app/score-board/components/score-card/score-card.component.ts
+++ b/frontend/src/app/score-board/components/score-card/score-card.component.ts
@@ -1,11 +1,11 @@
 import { Component, Input } from '@angular/core'
-import { NgIf, DecimalPipe } from '@angular/common'
+import { DecimalPipe } from '@angular/common'
 
 @Component({
   selector: 'score-card',
   templateUrl: './score-card.component.html',
   styleUrls: ['./score-card.component.scss'],
-  imports: [NgIf, DecimalPipe]
+  imports: [DecimalPipe]
 })
 export class ScoreCardComponent {
   @Input()

--- a/frontend/src/app/score-board/components/tutorial-mode-warning/tutorial-mode-warning.component.html
+++ b/frontend/src/app/score-board/components/tutorial-mode-warning/tutorial-mode-warning.component.html
@@ -1,6 +1,8 @@
-<warning-card *ngIf="tutorialModeActive">
-  <mat-icon warning-icon>school</mat-icon>
-  <span warning-text class="tutorial-mode-warning-text">
-    {{ 'INFO_FULL_CHALLENGE_MODE' | translate: {num: allChallenges.length} }}
-  </span>
-</warning-card>
+@if (tutorialModeActive) {
+  <warning-card>
+    <mat-icon warning-icon>school</mat-icon>
+    <span warning-text class="tutorial-mode-warning-text">
+      {{ 'INFO_FULL_CHALLENGE_MODE' | translate: {num: allChallenges.length} }}
+    </span>
+  </warning-card>
+}

--- a/frontend/src/app/score-board/components/tutorial-mode-warning/tutorial-mode-warning.component.ts
+++ b/frontend/src/app/score-board/components/tutorial-mode-warning/tutorial-mode-warning.component.ts
@@ -5,12 +5,11 @@ import { type Config } from 'src/app/Services/configuration.service'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatIconModule } from '@angular/material/icon'
 import { WarningCardComponent } from '../warning-card/warning-card.component'
-import { NgIf } from '@angular/common'
 
 @Component({
   selector: 'tutorial-mode-warning',
   templateUrl: './tutorial-mode-warning.component.html',
-  imports: [NgIf, WarningCardComponent, MatIconModule, TranslateModule]
+  imports: [WarningCardComponent, MatIconModule, TranslateModule]
 })
 export class TutorialModeWarningComponent implements OnChanges {
   @Input()

--- a/frontend/src/app/score-board/score-board.component.html
+++ b/frontend/src/app/score-board/score-board.component.html
@@ -4,49 +4,51 @@
   <difficulty-overview-score-card [allChallenges]="allChallenges" />
 </div>
 
-<filter-settings
-  *ngIf="applicationConfiguration?.challenges.restrictToTutorialsFirst === false"
-  [filterSetting]="filterSetting"
-  (filterSettingChange)="onFilterSettingUpdate($event)"
-  [allChallenges]="allChallenges"
-  [reset]="reset.bind(this)"
-></filter-settings>
+@if (applicationConfiguration?.challenges.restrictToTutorialsFirst === false) {
+  <filter-settings
+    [filterSetting]="filterSetting"
+    (filterSettingChange)="onFilterSettingUpdate($event)"
+    [allChallenges]="allChallenges"
+    [reset]="reset.bind(this)"
+  ></filter-settings>
+}
 
-<div *ngIf="isInitialized === false" class="loading-spinner-wrapper">
-  <mat-spinner></mat-spinner>
-</div>
+@if (isInitialized === false) {
+  <div class="loading-spinner-wrapper">
+    <mat-spinner></mat-spinner>
+  </div>
+}
 
-<ng-container *ngIf="isInitialized === true">
+@if (isInitialized === true) {
   <challenges-unavailable-warning
     [challenges]="allChallenges"
     [filterSetting]="filterSetting"
     (filterSettingChange)="onFilterSettingUpdate($event)"
   ></challenges-unavailable-warning>
-
   <tutorial-mode-warning
     [allChallenges]="allChallenges"
     [applicationConfig]="applicationConfiguration"
   ></tutorial-mode-warning>
-
-  <div class="challenges" *ngIf="filteredChallenges.length > 0; else emptyChallenges">
-    <challenge-card
-      *ngFor="let challenge of filteredChallenges; trackBy:getChallengeKey"
-      [challenge]="challenge"
-      [applicationConfiguration]="applicationConfiguration"
-      [openCodingChallengeDialog]="openCodingChallengeDialog.bind(this)"
-      [repeatChallengeNotification]="repeatChallengeNotification.bind(this)"
-      [ngClass]="{ solved: challenge.solved, unsolved: !challenge.solved, disabled: challenge.disabledEnv !== null }"
-    />
-  </div>
-
-  <ng-template #emptyChallenges>
-    <!-- only showing when there are more than 1 challenge in total. not completely loaded otherwise -->
-    <div class="empty-challenges" *ngIf="allChallenges.length > 0">
-      <p>{{ 'NO_CHALLENGES_FOUND' | translate }}</p>
+  @if (filteredChallenges.length > 0) {
+    <div class="challenges">
+      @for (challenge of filteredChallenges; track getChallengeKey($index, challenge)) {
+        <challenge-card
+          [challenge]="challenge"
+          [applicationConfiguration]="applicationConfiguration"
+          [openCodingChallengeDialog]="openCodingChallengeDialog.bind(this)"
+          [repeatChallengeNotification]="repeatChallengeNotification.bind(this)"
+          [ngClass]="{ solved: challenge.solved, unsolved: !challenge.solved, disabled: challenge.disabledEnv !== null }"
+          />
+      }
     </div>
-  </ng-template>
-
+  } @else {
+    <!-- only showing when there are more than 1 challenge in total. not completely loaded otherwise -->
+    @if (allChallenges.length > 0) {
+      <div class="empty-challenges">
+        <p>{{ 'NO_CHALLENGES_FOUND' | translate }}</p>
+      </div>
+    }
+  }
   <img src="assets/public/images/padding/1px.png"/>
-
-</ng-container>
+}
 

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -19,7 +19,7 @@ import { TutorialModeWarningComponent } from './components/tutorial-mode-warning
 import { ChallengesUnavailableWarningComponent } from './components/challenges-unavailable-warning/challenges-unavailable-warning.component'
 import { MatProgressSpinner } from '@angular/material/progress-spinner'
 import { FilterSettingsComponent } from './components/filter-settings/filter-settings.component'
-import { NgIf, NgFor, NgClass } from '@angular/common'
+import { NgClass } from '@angular/common'
 import { DifficultyOverviewScoreCardComponent } from './components/difficulty-overview-score-card/difficulty-overview-score-card.component'
 import { CodingChallengeProgressScoreCardComponent } from './components/coding-challenge-progress-score-card/coding-challenge-progress-score-card.component'
 import { HackingChallengeProgressScoreCardComponent } from './components/hacking-challenge-progress-score-card/hacking-challenge-progress-score-card.component'
@@ -41,7 +41,7 @@ interface CodeChallengeSolvedWebsocket {
   selector: 'app-score-board',
   templateUrl: './score-board.component.html',
   styleUrls: ['./score-board.component.scss'],
-  imports: [HackingChallengeProgressScoreCardComponent, CodingChallengeProgressScoreCardComponent, DifficultyOverviewScoreCardComponent, NgIf, FilterSettingsComponent, MatProgressSpinner, ChallengesUnavailableWarningComponent, TutorialModeWarningComponent, NgFor, ChallengeCardComponent, NgClass, TranslateModule]
+  imports: [HackingChallengeProgressScoreCardComponent, CodingChallengeProgressScoreCardComponent, DifficultyOverviewScoreCardComponent, FilterSettingsComponent, MatProgressSpinner, ChallengesUnavailableWarningComponent, TutorialModeWarningComponent, ChallengeCardComponent, NgClass, TranslateModule]
 })
 export class ScoreBoardComponent implements OnInit, OnDestroy {
   public allChallenges: EnrichedChallenge[] = []

--- a/frontend/src/app/search-result/search-result.component.html
+++ b/frontend/src/app/search-result/search-result.component.html
@@ -1,89 +1,102 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-align">
   <div class="table-container custom-slate">
 
     <div class="heading mat-elevation-z6">
-      <div *ngIf="searchValue">
-        <span>{{"TITLE_SEARCH_RESULTS" | translate}} - </span>
-        <span id="searchValue" [innerHTML]="searchValue"></span>
-      </div>
-      <div *ngIf="!searchValue">{{"TITLE_ALL_PRODUCTS" | translate}}</div>
+      @if (searchValue) {
+        <div>
+          <span>{{"TITLE_SEARCH_RESULTS" | translate}} - </span>
+          <span id="searchValue" [innerHTML]="searchValue"></span>
+        </div>
+      }
+      @if (!searchValue) {
+        <div>{{"TITLE_ALL_PRODUCTS" | translate}}</div>
+      }
       <div id="search-result-heading"></div>
     </div>
 
-    <div *ngIf=" !emptyState; else emptyResult">
-      <mat-grid-list #table (window:resize)="onResize($event)" [cols]="breakpoint" gutterSize="30px">
-        <mat-grid-tile *ngFor="let item of gridDataSource | async">
-          <mat-card appearance="outlined" [style.width]="'100%'" class="mat-elevation-z6 ribbon-card">
-            <div class="mdc-card">
-              <div class="ribbon ribbon-top-left" *ngIf="item.quantity <= 5 && item.quantity > 0">
-                <span translate [translateParams]="{quantity: item.quantity}">LABEL_ONLY_QUANTITY_LEFT</span>
-              </div>
-              <div class="ribbon ribbon-top-left ribbon-sold" *ngIf="item.quantity <= 0">
-                <span>{{"LABEL_SOLD_OUT" | translate }}</span>
-              </div>
-
-              <div class="product" (click)="showDetail(item)" aria-label="Click for more information about the product"
-                   matTooltip="Click for more information" matTooltipPosition="above">
-                <img mat-card-image [src]="'assets/public/images/products/'+item.image" alt={{item.name}}
-                     class="img-responsive img-thumbnail" role="button">
-
-  
-                <div class="info-box">
-                  <div class="item-name">{{item.name}}</div>
-                  <div class="item-price">
-                    <span *ngIf="!isDeluxe() || item.price === item.deluxePrice">{{item.price}}&curren;</span>
-                    <span *ngIf="isDeluxe() && item.price !== item.deluxePrice">
-                      <s>{{item.price}}</s> {{ item.deluxePrice }}&curren;
-                    </span>
+    @if ( !emptyState) {
+      <div>
+        <mat-grid-list #table (window:resize)="onResize($event)" [cols]="breakpoint" gutterSize="30px">
+          @for (item of gridDataSource | async; track item) {
+            <mat-grid-tile>
+              <mat-card appearance="outlined" [style.width]="'100%'" class="mat-elevation-z6 ribbon-card">
+                <div class="mdc-card">
+                  @if (item.quantity <= 5 && item.quantity > 0) {
+                    <div class="ribbon ribbon-top-left">
+                      <span translate [translateParams]="{quantity: item.quantity}">LABEL_ONLY_QUANTITY_LEFT</span>
+                    </div>
+                  }
+                  @if (item.quantity <= 0) {
+                    <div class="ribbon ribbon-top-left ribbon-sold">
+                      <span>{{"LABEL_SOLD_OUT" | translate }}</span>
+                    </div>
+                  }
+                  <div class="product" (click)="showDetail(item)" aria-label="Click for more information about the product"
+                    matTooltip="Click for more information" matTooltipPosition="above">
+                    <img mat-card-image [src]="'assets/public/images/products/'+item.image" alt={{item.name}}
+                      class="img-responsive img-thumbnail" role="button">
+                      <div class="info-box">
+                        <div class="item-name">{{item.name}}</div>
+                        <div class="item-price">
+                          @if (!isDeluxe() || item.price === item.deluxePrice) {
+                            <span>{{item.price}}&curren;</span>
+                          }
+                          @if (isDeluxe() && item.price !== item.deluxePrice) {
+                            <span>
+                              <s>{{item.price}}</s> {{ item.deluxePrice }}&curren;
+                            </span>
+                          }
+                        </div>
+                      </div>
+                    </div>
+                    <div style="display: flex; justify-content: center;" class="basket-btn-container">
+                      @if (isLoggedIn()) {
+                        <button (click)="addToBasket(item.id)" aria-label="Add to Basket" class="btn-basket"
+                          color="primary" mat-button mat-raised-button>
+                          <span>{{"ADD_BASKET" | translate}}</span>
+                        </button>
+                      }
+                    </div>
                   </div>
-                </div>
-              </div>
-
-              <div style="display: flex; justify-content: center;" class="basket-btn-container">
-                <button (click)="addToBasket(item.id)" *ngIf="isLoggedIn()" aria-label="Add to Basket" class="btn-basket"
-                        color="primary" mat-button mat-raised-button>
-                  <span>{{"ADD_BASKET" | translate}}</span>
-                </button>
-              </div>
-            </div>
-          </mat-card>
-        </mat-grid-tile>
-      </mat-grid-list>
-    </div>
-
-    <ng-template #emptyResult>
-      <mat-card appearance="outlined" class="mat-elevation-z6 emptyState">
-        <div class="mdc-card">
-          <img alt=" No results found"
+                </mat-card>
+              </mat-grid-tile>
+            }
+          </mat-grid-list>
+        </div>
+      } @else {
+        <mat-card appearance="outlined" class="mat-elevation-z6 emptyState">
+          <div class="mdc-card">
+            <img alt=" No results found"
               class="img-responsive noResult"
               src="assets/public/images/products/no-results.png">
-          <mat-card-title>
-            <span class="noResultText" >
-              {{"NO_SEARCH_RESULT" | translate}}
-            </span>
-          </mat-card-title>
-          <mat-card-content>
-            <span class="noResultText">
-              {{"EMPTY_SEARCH_RESULT" | translate}}
-            </span>
-          </mat-card-content>
-        </div>
-      </mat-card>
-    </ng-template>
+              <mat-card-title>
+                <span class="noResultText" >
+                  {{"NO_SEARCH_RESULT" | translate}}
+                </span>
+              </mat-card-title>
+              <mat-card-content>
+                <span class="noResultText">
+                  {{"EMPTY_SEARCH_RESULT" | translate}}
+                </span>
+              </mat-card-content>
+            </div>
+          </mat-card>
+        }
 
-    <mat-divider></mat-divider>
 
-    <mat-paginator #paginator
-                   [pageSize]="12"
-                   [pageSizeOptions]="pageSizeOptions"
-                   [length]="resultsLength"
-                   class="mat-elevation-z6"
-                   color="accent">
-    </mat-paginator>
-  </div>
-</div>
+        <mat-divider></mat-divider>
+
+        <mat-paginator #paginator
+          [pageSize]="12"
+          [pageSizeOptions]="pageSizeOptions"
+          [length]="resultsLength"
+          class="mat-elevation-z6"
+          color="accent">
+        </mat-paginator>
+      </div>
+    </div>

--- a/frontend/src/app/search-result/search-result.component.html
+++ b/frontend/src/app/search-result/search-result.component.html
@@ -12,14 +12,13 @@
           <span>{{"TITLE_SEARCH_RESULTS" | translate}} - </span>
           <span id="searchValue" [innerHTML]="searchValue"></span>
         </div>
-      }
-      @if (!searchValue) {
+      } @else {
         <div>{{"TITLE_ALL_PRODUCTS" | translate}}</div>
       }
       <div id="search-result-heading"></div>
     </div>
 
-    @if ( !emptyState) {
+    @if (!emptyState) {
       <div>
         <mat-grid-list #table (window:resize)="onResize($event)" [cols]="breakpoint" gutterSize="30px">
           @for (item of gridDataSource | async; track item) {
@@ -53,50 +52,50 @@
                           }
                         </div>
                       </div>
-                    </div>
-                    <div style="display: flex; justify-content: center;" class="basket-btn-container">
-                      @if (isLoggedIn()) {
-                        <button (click)="addToBasket(item.id)" aria-label="Add to Basket" class="btn-basket"
-                          color="primary" mat-button mat-raised-button>
-                          <span>{{"ADD_BASKET" | translate}}</span>
-                        </button>
-                      }
-                    </div>
                   </div>
-                </mat-card>
-              </mat-grid-tile>
-            }
-          </mat-grid-list>
-        </div>
-      } @else {
-        <mat-card appearance="outlined" class="mat-elevation-z6 emptyState">
-          <div class="mdc-card">
-            <img alt=" No results found"
-              class="img-responsive noResult"
-              src="assets/public/images/products/no-results.png">
-              <mat-card-title>
-                <span class="noResultText" >
-                  {{"NO_SEARCH_RESULT" | translate}}
-                </span>
-              </mat-card-title>
-              <mat-card-content>
-                <span class="noResultText">
-                  {{"EMPTY_SEARCH_RESULT" | translate}}
-                </span>
-              </mat-card-content>
-            </div>
-          </mat-card>
-        }
-
-
-        <mat-divider></mat-divider>
-
-        <mat-paginator #paginator
-          [pageSize]="12"
-          [pageSizeOptions]="pageSizeOptions"
-          [length]="resultsLength"
-          class="mat-elevation-z6"
-          color="accent">
-        </mat-paginator>
+                  <div style="display: flex; justify-content: center;" class="basket-btn-container">
+                    @if (isLoggedIn()) {
+                      <button (click)="addToBasket(item.id)" aria-label="Add to Basket" class="btn-basket"
+                        color="primary" mat-button mat-raised-button>
+                        <span>{{"ADD_BASKET" | translate}}</span>
+                      </button>
+                    }
+                  </div>
+                </div>
+              </mat-card>
+            </mat-grid-tile>
+          }
+        </mat-grid-list>
       </div>
-    </div>
+    } @else {
+      <mat-card appearance="outlined" class="mat-elevation-z6 emptyState">
+        <div class="mdc-card">
+          <img alt=" No results found"
+            class="img-responsive noResult"
+            src="assets/public/images/products/no-results.png">
+          <mat-card-title>
+            <span class="noResultText" >
+              {{"NO_SEARCH_RESULT" | translate}}
+            </span>
+          </mat-card-title>
+          <mat-card-content>
+            <span class="noResultText">
+              {{"EMPTY_SEARCH_RESULT" | translate}}
+            </span>
+          </mat-card-content>
+        </div>
+      </mat-card>
+    }
+
+
+    <mat-divider></mat-divider>
+
+    <mat-paginator #paginator
+      [pageSize]="12"
+      [pageSizeOptions]="pageSizeOptions"
+      [length]="resultsLength"
+      class="mat-elevation-z6"
+      color="accent">
+    </mat-paginator>
+  </div>
+</div>

--- a/frontend/src/app/search-result/search-result.component.html
+++ b/frontend/src/app/search-result/search-result.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-align">

--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -27,7 +27,7 @@ import { MatButtonModule } from '@angular/material/button'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatCardModule, MatCardImage, MatCardTitle, MatCardContent } from '@angular/material/card'
 import { MatGridList, MatGridTile } from '@angular/material/grid-list'
-import { NgIf, NgFor, AsyncPipe } from '@angular/common'
+import { AsyncPipe } from '@angular/common'
 
 library.add(faEye, faCartPlus)
 
@@ -45,7 +45,7 @@ interface TableEntry {
   selector: 'app-search-result',
   templateUrl: './search-result.component.html',
   styleUrls: ['./search-result.component.scss'],
-  imports: [NgIf, MatGridList, NgFor, MatGridTile, MatCardModule, TranslateModule, MatTooltip, MatCardImage, MatButtonModule, MatCardTitle, MatCardContent, MatDivider, MatPaginator, AsyncPipe]
+  imports: [MatGridList, MatGridTile, MatCardModule, TranslateModule, MatTooltip, MatCardImage, MatButtonModule, MatCardTitle, MatCardContent, MatDivider, MatPaginator, AsyncPipe]
 })
 export class SearchResultComponent implements OnDestroy, AfterViewInit {
   public displayedColumns = ['Image', 'Product', 'Description', 'Price', 'Select']

--- a/frontend/src/app/server-started-notification/server-started-notification.component.html
+++ b/frontend/src/app/server-started-notification/server-started-notification.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
-  
-<mat-card appearance="outlined" class="container primary-notification mat-elevation-z4" *ngIf="hackingProgress.autoRestoreMessage">
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
+
+@if (hackingProgress.autoRestoreMessage) {
+  <mat-card appearance="outlined" class="container primary-notification mat-elevation-z4">
     <mat-card-content>
-        <span translate>NOTIFICATION_SERVER_STARTED</span>: {{hackingProgress.autoRestoreMessage}}&nbsp;<button id="closeButton" mat-button (click)="closeNotification()">X</button>
-        <button mat-stroked-button [disabled]="hackingProgress.cleared" (click)="clearProgress()">
+      <span translate>NOTIFICATION_SERVER_STARTED</span>: {{hackingProgress.autoRestoreMessage}}&nbsp;<button id="closeButton" mat-button (click)="closeNotification()">X</button>
+      <button mat-stroked-button [disabled]="hackingProgress.cleared" (click)="clearProgress()">
         <mat-icon>delete_forever</mat-icon>
-        <span *ngIf="hackingProgress.cleared" translate>RESTART_REQUIRED</span>
-        <span *ngIf="!hackingProgress.cleared" translate>RESET_HACKING_PROGRESS</span>
-        </button>
+        @if (hackingProgress.cleared) {
+          <span translate>RESTART_REQUIRED</span>
+        }
+        @if (!hackingProgress.cleared) {
+          <span translate>RESET_HACKING_PROGRESS</span>
+        }
+      </button>
     </mat-card-content>
-</mat-card>
+  </mat-card>
+}

--- a/frontend/src/app/server-started-notification/server-started-notification.component.html
+++ b/frontend/src/app/server-started-notification/server-started-notification.component.html
@@ -11,8 +11,7 @@
         <mat-icon>delete_forever</mat-icon>
         @if (hackingProgress.cleared) {
           <span translate>RESTART_REQUIRED</span>
-        }
-        @if (!hackingProgress.cleared) {
+        } @else {
           <span translate>RESET_HACKING_PROGRESS</span>
         }
       </button>

--- a/frontend/src/app/server-started-notification/server-started-notification.component.html
+++ b/frontend/src/app/server-started-notification/server-started-notification.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 @if (hackingProgress.autoRestoreMessage) {

--- a/frontend/src/app/server-started-notification/server-started-notification.component.ts
+++ b/frontend/src/app/server-started-notification/server-started-notification.component.ts
@@ -11,7 +11,6 @@ import { SocketIoService } from '../Services/socket-io.service'
 import { MatIconModule } from '@angular/material/icon'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule, MatCardContent } from '@angular/material/card'
-import { NgIf } from '@angular/common'
 
 interface HackingProgress {
   autoRestoreMessage: string | null
@@ -22,7 +21,7 @@ interface HackingProgress {
   selector: 'app-server-started-notification',
   templateUrl: './server-started-notification.component.html',
   styleUrls: ['./server-started-notification.component.scss'],
-  imports: [NgIf, MatCardModule, MatCardContent, TranslateModule, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, MatCardContent, TranslateModule, MatButtonModule, MatIconModule]
 })
 export class ServerStartedNotificationComponent implements OnInit {
   public hackingProgress: HackingProgress = {} as HackingProgress

--- a/frontend/src/app/sidenav/sidenav.component.html
+++ b/frontend/src/app/sidenav/sidenav.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-toolbar class="mat-elevation-z6" color="primary">
   <mat-toolbar-row>
@@ -17,160 +17,198 @@
   <h3 mat-subheader class="side-subHeader show-lt-md-only" translate>ACCOUNT</h3>
 
   <div class="show-lt-md-only">
-    <a mat-list-item *ngIf="!isLoggedIn()" routerLink="/login" (click)="onToggleSidenav();"
-       aria-label="Go to login page">
-      <mat-icon>
-        exit_to_app
-      </mat-icon>
-      <span class="menu-text truncate">
-        {{"TITLE_LOGIN" | translate }}
-      </span>
-    </a>
-    <a mat-list-item *ngIf="isLoggedIn()" (click)="onToggleSidenav(); goToProfilePage();"
-       aria-label="Go to user profile">
-      <mat-icon>
-        account_circle
-      </mat-icon>
-      <span class="menu-text truncate">
-        {{ userEmail }}
-      </span>
-    </a>
-    <a mat-list-item *ngIf="isLoggedIn() && isAccounting()" routerLink="/accounting" (click)="onToggleSidenav();" aria-label="Go to accounting page">
-      <mat-icon>
-        account_balance
-      </mat-icon>
-      <span class="menu-text truncate">
-        {{"ACCOUNTING" | translate }}
-      </span>
-    </a>
+    @if (!isLoggedIn()) {
+      <a mat-list-item routerLink="/login" (click)="onToggleSidenav();"
+        aria-label="Go to login page">
+        <mat-icon>
+          exit_to_app
+        </mat-icon>
+        <span class="menu-text truncate">
+          {{"TITLE_LOGIN" | translate }}
+        </span>
+      </a>
+    }
+    @if (isLoggedIn()) {
+      <a mat-list-item (click)="onToggleSidenav(); goToProfilePage();"
+        aria-label="Go to user profile">
+        <mat-icon>
+          account_circle
+        </mat-icon>
+        <span class="menu-text truncate">
+          {{ userEmail }}
+        </span>
+      </a>
+    }
+    @if (isLoggedIn() && isAccounting()) {
+      <a mat-list-item routerLink="/accounting" (click)="onToggleSidenav();" aria-label="Go to accounting page">
+        <mat-icon>
+          account_balance
+        </mat-icon>
+        <span class="menu-text truncate">
+          {{"ACCOUNTING" | translate }}
+        </span>
+      </a>
+    }
 
-    <mat-list-item *ngIf="isLoggedIn()" (click)="showOrdersSubmenu = !showOrdersSubmenu" class="parent"
-                   aria-label="Show Orders and Payment Menu">
-      <mat-icon>
-        check_circle_outline
-      </mat-icon>
-      <span class="menu-text truncate">
-        {{ "ORDERS_AND_PAYMENT" | translate }}
-      </span>
-      <mat-icon class="menu-button" [ngClass]="{'rotated' : showOrdersSubmenu}">
-        expand_more
-      </mat-icon>
-    </mat-list-item>
-    <div class="submenu" [ngClass]="{'expanded' : showOrdersSubmenu}" *ngIf="showOrdersSubmenu">
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="/order-history"
-         (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to order history page">
+    @if (isLoggedIn()) {
+      <mat-list-item (click)="showOrdersSubmenu = !showOrdersSubmenu" class="parent"
+        aria-label="Show Orders and Payment Menu">
         <mat-icon>
-          archive
+          check_circle_outline
         </mat-icon>
         <span class="menu-text truncate">
-        {{"LABEL_ORDER_HISTORY" | translate}}
-      </span>
-      </a>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="/recycle"
-         (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to recycling page">
-        <mat-icon>
-          autorenew
+          {{ "ORDERS_AND_PAYMENT" | translate }}
+        </span>
+        <mat-icon class="menu-button" [ngClass]="{'rotated' : showOrdersSubmenu}">
+          expand_more
         </mat-icon>
-        <span class="menu-text truncate">
-        {{"NAV_RECYCLE" | translate}}
-      </span>
-      </a>
-      <mat-divider></mat-divider>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="/address/saved"
-         (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to saved address page">
-        <mat-icon>
-          my_location
-        </mat-icon>
-        <span class="menu-text truncate">
-        {{"MY_SAVED_ADRESSES" | translate}}
-      </span>
-      </a>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="/saved-payment-methods"
-         (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to saved payment methods page">
-        <mat-icon>
-          credit_card
-        </mat-icon>
-        <span class="menu-text truncate">
-        {{"MY_PAYMENT_OPTIONS" | translate}}
-      </span>
-      </a>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="/wallet"
-         (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to wallet page">
-        <mat-icon>
-          account_balance_wallet
-        </mat-icon>
-        <span class="menu-text truncate">
-        {{"DIGITAL_WALLET" | translate}}
-      </span>
-      </a>
-    </div>
+      </mat-list-item>
+    }
+    @if (showOrdersSubmenu) {
+      <div class="submenu" [ngClass]="{'expanded' : showOrdersSubmenu}">
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="/order-history"
+            (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to order history page">
+            <mat-icon>
+              archive
+            </mat-icon>
+            <span class="menu-text truncate">
+              {{"LABEL_ORDER_HISTORY" | translate}}
+            </span>
+          </a>
+        }
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="/recycle"
+            (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to recycling page">
+            <mat-icon>
+              autorenew
+            </mat-icon>
+            <span class="menu-text truncate">
+              {{"NAV_RECYCLE" | translate}}
+            </span>
+          </a>
+        }
+        <mat-divider></mat-divider>
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="/address/saved"
+            (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to saved address page">
+            <mat-icon>
+              my_location
+            </mat-icon>
+            <span class="menu-text truncate">
+              {{"MY_SAVED_ADRESSES" | translate}}
+            </span>
+          </a>
+        }
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="/saved-payment-methods"
+            (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to saved payment methods page">
+            <mat-icon>
+              credit_card
+            </mat-icon>
+            <span class="menu-text truncate">
+              {{"MY_PAYMENT_OPTIONS" | translate}}
+            </span>
+          </a>
+        }
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="/wallet"
+            (click)="onToggleSidenav(); showOrdersSubmenu = !showOrdersSubmenu" aria-label="Go to wallet page">
+            <mat-icon>
+              account_balance_wallet
+            </mat-icon>
+            <span class="menu-text truncate">
+              {{"DIGITAL_WALLET" | translate}}
+            </span>
+          </a>
+        }
+      </div>
+    }
 
-    <mat-list-item *ngIf="isLoggedIn()" (click)="showPrivacySubmenu = !showPrivacySubmenu" class="parent"
-                   aria-label="Show Privacy and Security Menu">
-      <mat-icon>
-        security
-      </mat-icon>
-      <span class="menu-text truncate">
-        {{ "PRIVACY_AND_SECURITY" | translate }}
-      </span>
-      <mat-icon class="menu-button" [ngClass]="{'rotated' : showPrivacySubmenu}">
-        expand_more
-      </mat-icon>
-    </mat-list-item>
-    <div class="submenu" [ngClass]="{'expanded' : showPrivacySubmenu}" *ngIf="showPrivacySubmenu">
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="privacy-security/privacy-policy"
-         (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to privacy policy page">
+    @if (isLoggedIn()) {
+      <mat-list-item (click)="showPrivacySubmenu = !showPrivacySubmenu" class="parent"
+        aria-label="Show Privacy and Security Menu">
         <mat-icon>
-          assignment
+          security
         </mat-icon>
-        <span class="menu-text truncate" translate>TITLE_PRIVACY_POLICY</span>
-      </a>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="privacy-security/data-export"
-         (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to data export page">
-        <mat-icon>
-          get_app
+        <span class="menu-text truncate">
+          {{ "PRIVACY_AND_SECURITY" | translate }}
+        </span>
+        <mat-icon class="menu-button" [ngClass]="{'rotated' : showPrivacySubmenu}">
+          expand_more
         </mat-icon>
-        <span class="menu-text truncate" translate>TITLE_REQUEST_DATA_EXPORT</span>
-      </a>
-      <a mat-list-item *ngIf="isLoggedIn()" (click) = "goToDataErasurePage()"
-         (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to data subject page">
-        <mat-icon>
-          delete_forever
-        </mat-icon>
-        <span class="menu-text truncate" translate>DATA_SUBJECT_TITLE</span>
-      </a>
-      <mat-divider></mat-divider>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="privacy-security/change-password"
-         (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to change password page">
-        <mat-icon>
-          edit
-        </mat-icon>
-        <span class="menu-text truncate" translate>TITLE_CHANGE_PASSWORD</span>
-      </a>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="privacy-security/two-factor-authentication"
-         (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to two factor authentication page">
-        <mat-icon>
-          exposure_plus_2
-        </mat-icon>
-        <span class="menu-text truncate" translate>TITLE_TWO_FACTOR_AUTH_CONFIG</span>
-      </a>
-      <a mat-list-item *ngIf="isLoggedIn()" routerLink="privacy-security/last-login-ip"
-         (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to last login ip page">
-        <mat-icon>
-          place
-        </mat-icon>
-        <span class="menu-text truncate" translate>LAST_LOGIN_IP</span>
-      </a>
-    </div>
+      </mat-list-item>
+    }
+    @if (showPrivacySubmenu) {
+      <div class="submenu" [ngClass]="{'expanded' : showPrivacySubmenu}">
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="privacy-security/privacy-policy"
+            (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to privacy policy page">
+            <mat-icon>
+              assignment
+            </mat-icon>
+            <span class="menu-text truncate" translate>TITLE_PRIVACY_POLICY</span>
+          </a>
+        }
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="privacy-security/data-export"
+            (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to data export page">
+            <mat-icon>
+              get_app
+            </mat-icon>
+            <span class="menu-text truncate" translate>TITLE_REQUEST_DATA_EXPORT</span>
+          </a>
+        }
+        @if (isLoggedIn()) {
+          <a mat-list-item (click) = "goToDataErasurePage()"
+            (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to data subject page">
+            <mat-icon>
+              delete_forever
+            </mat-icon>
+            <span class="menu-text truncate" translate>DATA_SUBJECT_TITLE</span>
+          </a>
+        }
+        <mat-divider></mat-divider>
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="privacy-security/change-password"
+            (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to change password page">
+            <mat-icon>
+              edit
+            </mat-icon>
+            <span class="menu-text truncate" translate>TITLE_CHANGE_PASSWORD</span>
+          </a>
+        }
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="privacy-security/two-factor-authentication"
+            (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to two factor authentication page">
+            <mat-icon>
+              exposure_plus_2
+            </mat-icon>
+            <span class="menu-text truncate" translate>TITLE_TWO_FACTOR_AUTH_CONFIG</span>
+          </a>
+        }
+        @if (isLoggedIn()) {
+          <a mat-list-item routerLink="privacy-security/last-login-ip"
+            (click)="onToggleSidenav(); showPrivacySubmenu = !showPrivacySubmenu" aria-label="Go to last login ip page">
+            <mat-icon>
+              place
+            </mat-icon>
+            <span class="menu-text truncate" translate>LAST_LOGIN_IP</span>
+          </a>
+        }
+      </div>
+    }
 
-    <a mat-list-item *ngIf="isLoggedIn()" (click)="onToggleSidenav(); logout()" aria-label="Logout">
-      <mat-icon>
-        power_settings_new
-      </mat-icon>
-      <span class="menu-text truncate">
-        {{"TITLE_LOGOUT" | translate }}
-      </span>
-    </a>
+    @if (isLoggedIn()) {
+      <a mat-list-item (click)="onToggleSidenav(); logout()" aria-label="Logout">
+        <mat-icon>
+          power_settings_new
+        </mat-icon>
+        <span class="menu-text truncate">
+          {{"TITLE_LOGOUT" | translate }}
+        </span>
+      </a>
+    }
   </div>
 
   <mat-divider class="show-lt-md-only"></mat-divider>
@@ -182,20 +220,24 @@
       {{"SECTION_CUSTOMER_FEEDBACK" | translate}}
     </span>
   </a>
-  <a mat-list-item *ngIf="isLoggedIn()" routerLink="/complain" (click)="onToggleSidenav();"
-     aria-label="Go to complain page">
-    <mat-icon>sentiment_dissatisfied</mat-icon>
-    <span class="menu-text truncate">
-      {{"NAV_COMPLAIN" | translate}}
-    </span>
-  </a>
-  <a mat-list-item *ngIf="isLoggedIn()" routerLink="/chatbot" (click)="onToggleSidenav();"
-     aria-label="Go to chatbot page">
-     <mat-icon>chat</mat-icon>
-    <span class="menu-text truncate">
-      {{"SECTION_SUPPORT_CHAT" | translate}}
-    </span>
-  </a>
+  @if (isLoggedIn()) {
+    <a mat-list-item routerLink="/complain" (click)="onToggleSidenav();"
+      aria-label="Go to complain page">
+      <mat-icon>sentiment_dissatisfied</mat-icon>
+      <span class="menu-text truncate">
+        {{"NAV_COMPLAIN" | translate}}
+      </span>
+    </a>
+  }
+  @if (isLoggedIn()) {
+    <a mat-list-item routerLink="/chatbot" (click)="onToggleSidenav();"
+      aria-label="Go to chatbot page">
+      <mat-icon>chat</mat-icon>
+      <span class="menu-text truncate">
+        {{"SECTION_SUPPORT_CHAT" | translate}}
+      </span>
+    </a>
+  }
 
   <mat-divider></mat-divider>
 
@@ -212,54 +254,64 @@
       {{"LABEL_PHOTO_WALL" | translate}}
     </span>
   </a>
-  <a mat-list-item *ngIf="isLoggedIn()" routerLink="/deluxe-membership" (click)="onToggleSidenav()" aria-label="Go to deluxe membership page">
-    <mat-icon>card_membership</mat-icon>
-    <span class="menu-text truncate">
-      {{"LABEL_DELUXE_MEMBERSHIP" | translate}}
-    </span>
-  </a>
+  @if (isLoggedIn()) {
+    <a mat-list-item routerLink="/deluxe-membership" (click)="onToggleSidenav()" aria-label="Go to deluxe membership page">
+      <mat-icon>card_membership</mat-icon>
+      <span class="menu-text truncate">
+        {{"LABEL_DELUXE_MEMBERSHIP" | translate}}
+      </span>
+    </a>
+  }
 
-  <mat-divider *ngIf="scoreBoardVisible || showGitHubLink" style="margin-bottom: 10px;"></mat-divider>
+  @if (scoreBoardVisible || showGitHubLink) {
+    <mat-divider style="margin-bottom: 10px;"></mat-divider>
+  }
 
-  <a *ngIf="scoreBoardVisible" mat-list-item routerLink="/score-board" (click)="onToggleSidenav()"
-     aria-label="Open score-board">
-    <mat-icon matListIcon class="fas fa-trophy fa-lg"></mat-icon>
-    <span class="menu-text truncate">
-      {{"TITLE_SCORE_BOARD" | translate}}
-    </span>
-  </a>
-  <a *ngIf="!scoreBoardVisible && offerScoreBoardTutorial" mat-list-item (click)="startHackingInstructor()"
-     aria-label="Launch beginners tutorial">
-    <mat-icon>school</mat-icon>
-    <span class="menu-text truncate">
-      {{"BTN_GETTING_STARTED" | translate}}
-    </span>
-  </a>
+  @if (scoreBoardVisible) {
+    <a mat-list-item routerLink="/score-board" (click)="onToggleSidenav()"
+      aria-label="Open score-board">
+      <mat-icon matListIcon class="fas fa-trophy fa-lg"></mat-icon>
+      <span class="menu-text truncate">
+        {{"TITLE_SCORE_BOARD" | translate}}
+      </span>
+    </a>
+  }
+  @if (!scoreBoardVisible && offerScoreBoardTutorial) {
+    <a mat-list-item (click)="startHackingInstructor()"
+      aria-label="Launch beginners tutorial">
+      <mat-icon>school</mat-icon>
+      <span class="menu-text truncate">
+        {{"BTN_GETTING_STARTED" | translate}}
+      </span>
+    </a>
+  }
 
-  <a *ngIf="showGitHubLink" mat-list-item href="./redirect?to=https://github.com/juice-shop/juice-shop"
-     aria-label="Go to OWASP Juice Shop GitHub page">
-    <mat-icon matListIcon class="fab fa-github fa-lg"></mat-icon>
-    <span class="menu-text truncate">
-      GitHub
-    </span>
-  </a>
+  @if (showGitHubLink) {
+    <a mat-list-item href="./redirect?to=https://github.com/juice-shop/juice-shop"
+      aria-label="Go to OWASP Juice Shop GitHub page">
+      <mat-icon matListIcon class="fab fa-github fa-lg"></mat-icon>
+      <span class="menu-text truncate">
+        GitHub
+      </span>
+    </a>
+  }
 </mat-nav-list>
 
 <div class="appVersion">
-    <span>
-      <span style="font-size: 13px;">{{applicationName}}</span>
-      <br>
+  <span>
+    <span style="font-size: 13px;">{{applicationName}}</span>
+    <br>
       <span style="font-size: 12px;">{{version}}</span>
       <br>
-      <div style="margin-top: 10px;">
-        <i class="icon-angular"></i>&nbsp;
-        <i class="icon-html5"></i>&nbsp;
-        <i class="icon-sass"></i>&nbsp;
-        <i class="icon-css3"></i>&nbsp;
-        <i class="icon-javascript-alt"></i>&nbsp;
-        <i class="icon-nodejs"></i>&nbsp;
-        <i class="icon-database-alt2"></i>&nbsp;
-        <i class="icon-mongodb"></i>
-      </div>
-    </span>
-</div>
+        <div style="margin-top: 10px;">
+          <i class="icon-angular"></i>&nbsp;
+          <i class="icon-html5"></i>&nbsp;
+          <i class="icon-sass"></i>&nbsp;
+          <i class="icon-css3"></i>&nbsp;
+          <i class="icon-javascript-alt"></i>&nbsp;
+          <i class="icon-nodejs"></i>&nbsp;
+          <i class="icon-database-alt2"></i>&nbsp;
+          <i class="icon-mongodb"></i>
+        </div>
+      </span>
+    </div>

--- a/frontend/src/app/sidenav/sidenav.component.html
+++ b/frontend/src/app/sidenav/sidenav.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-toolbar class="mat-elevation-z6" color="primary">

--- a/frontend/src/app/sidenav/sidenav.component.ts
+++ b/frontend/src/app/sidenav/sidenav.component.ts
@@ -16,7 +16,7 @@ import { LoginGuard } from '../app.guard'
 import { roles } from '../roles'
 import { MatDivider } from '@angular/material/divider'
 import { MatIconModule } from '@angular/material/icon'
-import { NgIf, NgClass } from '@angular/common'
+import { NgClass } from '@angular/common'
 
 import { TranslateModule } from '@ngx-translate/core'
 import { MatButtonModule } from '@angular/material/button'
@@ -27,7 +27,7 @@ import { MatToolbar, MatToolbarRow } from '@angular/material/toolbar'
   selector: 'sidenav',
   templateUrl: './sidenav.component.html',
   styleUrls: ['./sidenav.component.scss'],
-  imports: [MatToolbar, MatToolbarRow, MatNavList, MatButtonModule, MatListSubheaderCssMatStyler, TranslateModule, NgIf, MatListItem, RouterLink, MatIconModule, NgClass, MatDivider]
+  imports: [MatToolbar, MatToolbarRow, MatNavList, MatButtonModule, MatListSubheaderCssMatStyler, TranslateModule, MatListItem, RouterLink, MatIconModule, NgClass, MatDivider]
 })
 export class SidenavComponent implements OnInit {
   public applicationName = 'OWASP Juice Shop'

--- a/frontend/src/app/track-result/track-result.component.html
+++ b/frontend/src/app/track-result/track-result.component.html
@@ -1,6 +1,6 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
 -->
 
 
@@ -11,20 +11,36 @@
       <h3 translate>LABEL_EXPECTED_DELIVERY</h3>
       <div class="container-fluid well">
         <div class="row fa-4x">
-          <span *ngIf="status === Status.New"><i class="fas fa-warehouse confirmation"></i></span>
-          <span *ngIf="status !== Status.New"><i class="fas fa-warehouse"></i></span>
-          <span *ngIf="status === Status.Packing"><i class="fas fa-truck-loading confirmation"></i></span>
-          <span *ngIf="status !== Status.Packing"><i class="fas fa-truck-loading"></i></span>
-          <span *ngIf="status === Status.Transit"><i class="fas fa-truck confirmation"></i></span>
-          <span *ngIf="status !== Status.Transit"><i class="fas fa-truck"></i></span>
-          <span class="fa-layers fa-fw" *ngIf="status === Status.Delivered">
-            <span><i class="fas fa-home confirmation"></i></span>
-            <span class="fa-layers-counter accent-notification" style="width: max-content">{{results.eta}} {{'LABEL_DAYS' | translate}}</span>
-          </span>
-          <span class="fa-layers fa-fw" *ngIf="status !== Status.Delivered">
-            <span><i class="fas fa-home"></i></span>
-            <span class="fa-layers-counter accent-notification" style="width: max-content">{{results.eta}} {{'LABEL_DAYS' | translate}}</span>
-          </span>
+          @if (status === Status.New) {
+            <span><i class="fas fa-warehouse confirmation"></i></span>
+          }
+          @if (status !== Status.New) {
+            <span><i class="fas fa-warehouse"></i></span>
+          }
+          @if (status === Status.Packing) {
+            <span><i class="fas fa-truck-loading confirmation"></i></span>
+          }
+          @if (status !== Status.Packing) {
+            <span><i class="fas fa-truck-loading"></i></span>
+          }
+          @if (status === Status.Transit) {
+            <span><i class="fas fa-truck confirmation"></i></span>
+          }
+          @if (status !== Status.Transit) {
+            <span><i class="fas fa-truck"></i></span>
+          }
+          @if (status === Status.Delivered) {
+            <span class="fa-layers fa-fw">
+              <span><i class="fas fa-home confirmation"></i></span>
+              <span class="fa-layers-counter accent-notification" style="width: max-content">{{results.eta}} {{'LABEL_DAYS' | translate}}</span>
+            </span>
+          }
+          @if (status !== Status.Delivered) {
+            <span class="fa-layers fa-fw">
+              <span><i class="fas fa-home"></i></span>
+              <span class="fa-layers-counter accent-notification" style="width: max-content">{{results.eta}} {{'LABEL_DAYS' | translate}}</span>
+            </span>
+          }
         </div>
       </div>
     </div>
@@ -34,30 +50,30 @@
         <h2 translate>LABEL_PRODUCT_ORDERED</h2>
       </div>
     </div>
-    
+
     <div class="mdc-table">
       <mat-table class="mat-elevation-z0" #table [dataSource]="dataSource">
-        
+
         <ng-container matColumnDef="product">
           <mat-header-cell *matHeaderCellDef translate>LABEL_PRODUCT</mat-header-cell>
           <mat-cell class="product-name" *matCellDef="let product"> {{product.name}}</mat-cell>
         </ng-container>
-        
+
         <ng-container matColumnDef="price">
           <mat-header-cell *matHeaderCellDef translate>LABEL_PRICE</mat-header-cell>
           <mat-cell class="product-price" *matCellDef="let product"> {{product.price}}&curren;</mat-cell>
         </ng-container>
-        
+
         <ng-container matColumnDef="quantity">
           <mat-header-cell *matHeaderCellDef translate>LABEL_QUANTITY</mat-header-cell>
           <mat-cell class="product-quantity" *matCellDef="let product"> {{product.quantity}}</mat-cell>
         </ng-container>
-        
+
         <ng-container matColumnDef="total price">
           <mat-header-cell *matHeaderCellDef translate>LABEL_TOTAL_PRICE</mat-header-cell>
           <mat-cell class="product-total" *matCellDef="let product"> {{product.total}}&curren;</mat-cell>
         </ng-container>
-        
+
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
         <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
       </mat-table>
@@ -67,6 +83,6 @@
       <h2 translate [translateParams]="{'bonus': results.bonus}">BONUS_POINTS_EARNED</h2>
       <p>(<span [innerHtml]="'BONUS_FOR_FUTURE_PURCHASES' | translate"></span>)</p>
     </div>
-    
+
   </div>
 </mat-card>

--- a/frontend/src/app/track-result/track-result.component.html
+++ b/frontend/src/app/track-result/track-result.component.html
@@ -13,20 +13,17 @@
         <div class="row fa-4x">
           @if (status === Status.New) {
             <span><i class="fas fa-warehouse confirmation"></i></span>
-          }
-          @if (status !== Status.New) {
+          } @else {
             <span><i class="fas fa-warehouse"></i></span>
           }
           @if (status === Status.Packing) {
             <span><i class="fas fa-truck-loading confirmation"></i></span>
-          }
-          @if (status !== Status.Packing) {
+          } @else {
             <span><i class="fas fa-truck-loading"></i></span>
           }
           @if (status === Status.Transit) {
             <span><i class="fas fa-truck confirmation"></i></span>
-          }
-          @if (status !== Status.Transit) {
+          } @else {
             <span><i class="fas fa-truck"></i></span>
           }
           @if (status === Status.Delivered) {
@@ -34,8 +31,7 @@
               <span><i class="fas fa-home confirmation"></i></span>
               <span class="fa-layers-counter accent-notification" style="width: max-content">{{results.eta}} {{'LABEL_DAYS' | translate}}</span>
             </span>
-          }
-          @if (status !== Status.Delivered) {
+          } @else {
             <span class="fa-layers fa-fw">
               <span><i class="fas fa-home"></i></span>
               <span class="fa-layers-counter accent-notification" style="width: max-content">{{results.eta}} {{'LABEL_DAYS' | translate}}</span>

--- a/frontend/src/app/track-result/track-result.component.html
+++ b/frontend/src/app/track-result/track-result.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 

--- a/frontend/src/app/track-result/track-result.component.ts
+++ b/frontend/src/app/track-result/track-result.component.ts
@@ -11,7 +11,6 @@ import { DomSanitizer } from '@angular/platform-browser'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faHome, faSync, faTruck, faTruckLoading, faWarehouse } from '@fortawesome/free-solid-svg-icons'
 
-import { NgIf } from '@angular/common'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatCardModule } from '@angular/material/card'
 
@@ -28,7 +27,7 @@ export enum Status {
   selector: 'app-track-result',
   templateUrl: './track-result.component.html',
   styleUrls: ['./track-result.component.scss'],
-  imports: [MatCardModule, TranslateModule, NgIf, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow]
+  imports: [MatCardModule, TranslateModule, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow]
 })
 export class TrackResultComponent implements OnInit {
   public displayedColumns = ['product', 'price', 'quantity', 'total price']

--- a/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.html
+++ b/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -11,7 +11,9 @@
 
       <p translate>TITLE_TWO_FACTOR_AUTH_ENTER</p>
 
-      <div *ngIf="errored" class="error" style="margin-bottom: 10px;" translate>INVALID_TWO_FACTOR_AUTH_TOKEN</div>
+      @if (errored) {
+        <div class="error" style="margin-bottom: 10px;" translate>INVALID_TWO_FACTOR_AUTH_TOKEN</div>
+      }
 
       <form (ngSubmit)="verify()" [formGroup]="twoFactorForm">
 
@@ -19,23 +21,23 @@
           <mat-form-field id="inputToken" appearance="outline" color="accent">
             <mat-label translate>LABEL_TWO_FACTOR_AUTH_TOKEN</mat-label>
             <input #tokenInput formControlName="token" type="text" minlength="6" maxlength="6" pattern="^[\d]{6}$" matInput id="totpToken"
-                  aria-label="Field for entering the Two Factor token" placeholder="{{ '2FA_ENTER_CODE_PLACEHOLDER' | translate}}">
-            <mat-icon matSuffix matTooltip="{{ 'INITIAL_TOKEN_TOOLTIP' | translate}}"
-                      matTooltipPosition=right
-                      aria-label="The code to be entered from the authenticator must have 6 digits.">
-              help_outline
-            </mat-icon>
-            <mat-hint align="end">{{tokenInput.value?.length || 0}}/6</mat-hint>
-            <mat-error translate>INVALID_TWO_FACTOR_AUTH_TOKEN</mat-error>
-          </mat-form-field>
-        </div>
+              aria-label="Field for entering the Two Factor token" placeholder="{{ '2FA_ENTER_CODE_PLACEHOLDER' | translate}}">
+              <mat-icon matSuffix matTooltip="{{ 'INITIAL_TOKEN_TOOLTIP' | translate}}"
+                matTooltipPosition=right
+                aria-label="The code to be entered from the authenticator must have 6 digits.">
+                help_outline
+              </mat-icon>
+              <mat-hint align="end">{{tokenInput.value?.length || 0}}/6</mat-hint>
+              <mat-error translate>INVALID_TWO_FACTOR_AUTH_TOKEN</mat-error>
+            </mat-form-field>
+          </div>
 
-        <button type="submit" color="primary" mat-raised-button [disabled]="twoFactorForm.invalid" id="totpSubmitButton" aria-label="Button to confirm the input">
-          <mat-icon>lock_open</mat-icon>
-          {{'BTN_LOGIN' | translate}}
-        </button>
-      </form>
+          <button type="submit" color="primary" mat-raised-button [disabled]="twoFactorForm.invalid" id="totpSubmitButton" aria-label="Button to confirm the input">
+            <mat-icon>lock_open</mat-icon>
+            {{'BTN_LOGIN' | translate}}
+          </button>
+        </form>
 
-    </div>
-  </mat-card>
-</div>
+      </div>
+    </mat-card>
+  </div>

--- a/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.html
+++ b/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.ts
+++ b/frontend/src/app/two-factor-auth-enter/two-factor-auth-enter.component.ts
@@ -16,7 +16,7 @@ import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatSuffix, MatHint, MatError } from '@angular/material/form-field'
-import { NgIf } from '@angular/common'
+
 import { TranslateModule } from '@ngx-translate/core'
 import { MatCardModule } from '@angular/material/card'
 
@@ -30,7 +30,7 @@ interface TokenEnterFormFields {
   selector: 'app-two-factor-auth-enter',
   templateUrl: './two-factor-auth-enter.component.html',
   styleUrls: ['./two-factor-auth-enter.component.scss'],
-  imports: [MatCardModule, TranslateModule, NgIf, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatIconModule, MatSuffix, MatTooltip, MatHint, MatError, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatIconModule, MatSuffix, MatTooltip, MatHint, MatError, MatButtonModule, MatIconModule]
 })
 export class TwoFactorAuthEnterComponent {
   public twoFactorForm: UntypedFormGroup = new UntypedFormGroup({

--- a/frontend/src/app/two-factor-auth/two-factor-auth.component.html
+++ b/frontend/src/app/two-factor-auth/two-factor-auth.component.html
@@ -26,7 +26,7 @@
                 aria-label="Field to enter the current password"
                 placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}"
                 autocomplete="off">
-              </mat-form-field>
+            </mat-form-field>
               <button
                 type="submit"
                 id="disableTwoFactorAuth"
@@ -35,70 +35,68 @@
                 color="warn"
                 aria-label="Button to remove the two-factor authentication"
                 >
-                <mat-icon>remove_selection</mat-icon>
-                {{'BTN_REMOVE' | translate}}
-              </button>
-            </form>
+              <mat-icon>remove_selection</mat-icon>
+              {{'BTN_REMOVE' | translate}}
+            </button>
+          </form>
+        </div>
+      } @else {
+        <form
+          class="form-container"
+          id="two-factor-auth-setup"
+          [formGroup]="twoFactorSetupForm"
+          (ngSubmit)="setup()"
+          >
+          <span id="2fa-setup-instructions" translate>2FA_AUTH_SETUP_INSTRUCTIONS</span>
+          <div class="two-factor-qr-code center-container">
+            <qr-code
+              [value]="totpUrl"
+              [size]="300"
+              [errorCorrectionLevel]="'L'"
+            ></qr-code>
           </div>
-        }
-
-        @if (setupStatus === false) {
-          <form
-            class="form-container"
-            id="two-factor-auth-setup"
-            [formGroup]="twoFactorSetupForm"
-            (ngSubmit)="setup()"
+          <div class="error" [hidden]="!(errored && !twoFactorSetupForm.dirty)" translate>2FA_SETUP_ERROR</div>
+          <mat-form-field appearance="outline" color="accent">
+            <mat-label translate>LABEL_CURRENT_PASSWORD</mat-label>
+            <input id="currentPasswordSetup" formControlName="passwordControl" type="password" matInput
+              aria-label="Field to enter the current password"
+              placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}"
+              autocomplete="off">
+          </mat-form-field>
+          <mat-form-field appearance="outline" color="accent">
+            <mat-label translate>INITIAL_CODE</mat-label>
+            <input
+              #initToken
+              id="initialToken"
+              formControlName="initialTokenControl"
+              type="text"
+              matInput
+              [attr.data-test-totp-secret]="totpSecret"
+              aria-label="Field to enter the initial token. This must have 6 digits."
+              placeholder="{{'INITIAL_CODE_PLACEHOLDER' | translate }}"
+              minlength="6" maxlength="6" pattern="^[\d]{6}$"
             >
-            <span id="2fa-setup-instructions" translate>2FA_AUTH_SETUP_INSTRUCTIONS</span>
-            <div class="two-factor-qr-code center-container">
-              <qr-code
-                [value]="totpUrl"
-                [size]="300"
-                [errorCorrectionLevel]="'L'"
-              ></qr-code>
-            </div>
-            <div class="error" [hidden]="!(errored && !twoFactorSetupForm.dirty)" translate>2FA_SETUP_ERROR</div>
-            <mat-form-field appearance="outline" color="accent">
-              <mat-label translate>LABEL_CURRENT_PASSWORD</mat-label>
-              <input id="currentPasswordSetup" formControlName="passwordControl" type="password" matInput
-                aria-label="Field to enter the current password"
-                placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}"
-                autocomplete="off">
-              </mat-form-field>
-              <mat-form-field appearance="outline" color="accent">
-                <mat-label translate>INITIAL_CODE</mat-label>
-                <input
-                  #initToken
-                  id="initialToken"
-                  formControlName="initialTokenControl"
-                  type="text"
-                  matInput
-                  [attr.data-test-totp-secret]="totpSecret"
-                  aria-label="Field to enter the initial token. This must have 6 digits."
-                  placeholder="{{'INITIAL_CODE_PLACEHOLDER' | translate }}"
-                  minlength="6" maxlength="6" pattern="^[\d]{6}$"
-                  >
-                  <mat-error translate>INVALID_TWO_FACTOR_AUTH_TOKEN</mat-error>
-                  <mat-icon matSuffix matTooltip="{{ 'INITIAL_TOKEN_TOOLTIP' | translate}}"
-                    matTooltipPosition=right
-                    aria-label="The token to be entered from the authenticator must have 6 digits.">
-                    help_outline
-                  </mat-icon>
-                  <mat-hint align="end">{{initToken.value?.length || 0}}/6</mat-hint>
-                </mat-form-field>
-                <button
-                  type="submit"
-                  id="setupTwoFactorAuth"
-                  [disabled]="twoFactorSetupForm.invalid"
-                  mat-raised-button
-                  color="primary"
-                  aria-label="Button to complete the two-factor configuration"
-                  >
-                  <mat-icon>save</mat-icon>
-                  {{'BTN_SAVE' | translate}}
-                </button>
-              </form>
-            }
-          </div>
-        </mat-card>
-      </div>
+            <mat-error translate>INVALID_TWO_FACTOR_AUTH_TOKEN</mat-error>
+            <mat-icon matSuffix matTooltip="{{ 'INITIAL_TOKEN_TOOLTIP' | translate}}"
+              matTooltipPosition=right
+              aria-label="The token to be entered from the authenticator must have 6 digits.">
+              help_outline
+            </mat-icon>
+            <mat-hint align="end">{{initToken.value?.length || 0}}/6</mat-hint>
+          </mat-form-field>
+          <button
+            type="submit"
+            id="setupTwoFactorAuth"
+            [disabled]="twoFactorSetupForm.invalid"
+            mat-raised-button
+            color="primary"
+            aria-label="Button to complete the two-factor configuration"
+            >
+            <mat-icon>save</mat-icon>
+            {{'BTN_SAVE' | translate}}
+          </button>
+        </form>
+      }
+    </div>
+  </mat-card>
+</div>

--- a/frontend/src/app/two-factor-auth/two-factor-auth.component.html
+++ b/frontend/src/app/two-factor-auth/two-factor-auth.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <div class="center-container">

--- a/frontend/src/app/two-factor-auth/two-factor-auth.component.html
+++ b/frontend/src/app/two-factor-auth/two-factor-auth.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <div class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
@@ -9,104 +9,96 @@
 
       <h1 id="2fa-setup-title" translate>TITLE_TWO_FACTOR_AUTH_CONFIG</h1>
 
-      <div id="2fa-setup-successfully" *ngIf="setupStatus === true">
-        <p translate>2FA_SUCCESSFUL_SETUP</p>
-
-        <form
-          class="form-container"
-          id="two-factor-auth-disable"
-          [formGroup]="twoFactorDisableForm"
-          (ngSubmit)="disable()"
-        >
-
-          <h2 id="two-factor-auth-disable-title" translate>REMOVE_TWO_FACTOR_AUTH</h2>
-
-          <div class="error" [hidden]="!(errored && !twoFactorDisableForm.dirty)" translate>2FA_SETUP_ERROR</div>
-
-          <mat-form-field appearance="outline" color="accent">
-            <mat-label translate>LABEL_CURRENT_PASSWORD</mat-label>
-            <input id="currentPasswordDisable" formControlName="passwordControl" type="password" matInput
-                  aria-label="Field to enter the current password"
-                  placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}"
-                  autocomplete="off">
-          </mat-form-field>
-
-          <button
-            type="submit"
-            id="disableTwoFactorAuth"
-            [disabled]="twoFactorDisableForm.invalid"
-            mat-raised-button
-            color="warn"
-            aria-label="Button to remove the two-factor authentication"
-          >
-            <mat-icon>remove_selection</mat-icon>
-            {{'BTN_REMOVE' | translate}}
-          </button>
-        </form>
-      </div>
-
-      <form
-        *ngIf="setupStatus === false"
-        class="form-container"
-        id="two-factor-auth-setup"
-        [formGroup]="twoFactorSetupForm"
-        (ngSubmit)="setup()"
-      >
-
-        <span id="2fa-setup-instructions" translate>2FA_AUTH_SETUP_INSTRUCTIONS</span>
-
-        <div class="two-factor-qr-code center-container">
-          <qr-code
-            [value]="totpUrl"
-            [size]="300"
-            [errorCorrectionLevel]="'L'"
-          ></qr-code>
-        </div>
-
-        <div class="error" [hidden]="!(errored && !twoFactorSetupForm.dirty)" translate>2FA_SETUP_ERROR</div>
-
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>LABEL_CURRENT_PASSWORD</mat-label>
-          <input id="currentPasswordSetup" formControlName="passwordControl" type="password" matInput
+      @if (setupStatus === true) {
+        <div id="2fa-setup-successfully">
+          <p translate>2FA_SUCCESSFUL_SETUP</p>
+          <form
+            class="form-container"
+            id="two-factor-auth-disable"
+            [formGroup]="twoFactorDisableForm"
+            (ngSubmit)="disable()"
+            >
+            <h2 id="two-factor-auth-disable-title" translate>REMOVE_TWO_FACTOR_AUTH</h2>
+            <div class="error" [hidden]="!(errored && !twoFactorDisableForm.dirty)" translate>2FA_SETUP_ERROR</div>
+            <mat-form-field appearance="outline" color="accent">
+              <mat-label translate>LABEL_CURRENT_PASSWORD</mat-label>
+              <input id="currentPasswordDisable" formControlName="passwordControl" type="password" matInput
                 aria-label="Field to enter the current password"
                 placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}"
                 autocomplete="off">
-        </mat-form-field>
+              </mat-form-field>
+              <button
+                type="submit"
+                id="disableTwoFactorAuth"
+                [disabled]="twoFactorDisableForm.invalid"
+                mat-raised-button
+                color="warn"
+                aria-label="Button to remove the two-factor authentication"
+                >
+                <mat-icon>remove_selection</mat-icon>
+                {{'BTN_REMOVE' | translate}}
+              </button>
+            </form>
+          </div>
+        }
 
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label translate>INITIAL_CODE</mat-label>
-          <input
-            #initToken
-            id="initialToken"
-            formControlName="initialTokenControl"
-            type="text"
-            matInput
-            [attr.data-test-totp-secret]="totpSecret"
-            aria-label="Field to enter the initial token. This must have 6 digits."
-            placeholder="{{'INITIAL_CODE_PLACEHOLDER' | translate }}"
-            minlength="6" maxlength="6" pattern="^[\d]{6}$"
-          >
-          <mat-error translate>INVALID_TWO_FACTOR_AUTH_TOKEN</mat-error>
-          <mat-icon matSuffix matTooltip="{{ 'INITIAL_TOKEN_TOOLTIP' | translate}}"
+        @if (setupStatus === false) {
+          <form
+            class="form-container"
+            id="two-factor-auth-setup"
+            [formGroup]="twoFactorSetupForm"
+            (ngSubmit)="setup()"
+            >
+            <span id="2fa-setup-instructions" translate>2FA_AUTH_SETUP_INSTRUCTIONS</span>
+            <div class="two-factor-qr-code center-container">
+              <qr-code
+                [value]="totpUrl"
+                [size]="300"
+                [errorCorrectionLevel]="'L'"
+              ></qr-code>
+            </div>
+            <div class="error" [hidden]="!(errored && !twoFactorSetupForm.dirty)" translate>2FA_SETUP_ERROR</div>
+            <mat-form-field appearance="outline" color="accent">
+              <mat-label translate>LABEL_CURRENT_PASSWORD</mat-label>
+              <input id="currentPasswordSetup" formControlName="passwordControl" type="password" matInput
+                aria-label="Field to enter the current password"
+                placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}"
+                autocomplete="off">
+              </mat-form-field>
+              <mat-form-field appearance="outline" color="accent">
+                <mat-label translate>INITIAL_CODE</mat-label>
+                <input
+                  #initToken
+                  id="initialToken"
+                  formControlName="initialTokenControl"
+                  type="text"
+                  matInput
+                  [attr.data-test-totp-secret]="totpSecret"
+                  aria-label="Field to enter the initial token. This must have 6 digits."
+                  placeholder="{{'INITIAL_CODE_PLACEHOLDER' | translate }}"
+                  minlength="6" maxlength="6" pattern="^[\d]{6}$"
+                  >
+                  <mat-error translate>INVALID_TWO_FACTOR_AUTH_TOKEN</mat-error>
+                  <mat-icon matSuffix matTooltip="{{ 'INITIAL_TOKEN_TOOLTIP' | translate}}"
                     matTooltipPosition=right
                     aria-label="The token to be entered from the authenticator must have 6 digits.">
-            help_outline
-          </mat-icon>
-          <mat-hint align="end">{{initToken.value?.length || 0}}/6</mat-hint>
-        </mat-form-field>
-
-        <button
-          type="submit"
-          id="setupTwoFactorAuth"
-          [disabled]="twoFactorSetupForm.invalid"
-          mat-raised-button
-          color="primary"
-          aria-label="Button to complete the two-factor configuration"
-        >
-          <mat-icon>save</mat-icon>
-          {{'BTN_SAVE' | translate}}
-        </button>
-      </form>
-    </div>
-  </mat-card>
-</div>
+                    help_outline
+                  </mat-icon>
+                  <mat-hint align="end">{{initToken.value?.length || 0}}/6</mat-hint>
+                </mat-form-field>
+                <button
+                  type="submit"
+                  id="setupTwoFactorAuth"
+                  [disabled]="twoFactorSetupForm.invalid"
+                  mat-raised-button
+                  color="primary"
+                  aria-label="Button to complete the two-factor configuration"
+                  >
+                  <mat-icon>save</mat-icon>
+                  {{'BTN_SAVE' | translate}}
+                </button>
+              </form>
+            }
+          </div>
+        </mat-card>
+      </div>

--- a/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
+++ b/frontend/src/app/two-factor-auth/two-factor-auth.component.ts
@@ -22,7 +22,7 @@ import { QrCodeModule } from 'ng-qrcode'
 import { MatButtonModule } from '@angular/material/button'
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatError, MatSuffix, MatHint } from '@angular/material/form-field'
-import { NgIf } from '@angular/common'
+
 import { MatCardModule } from '@angular/material/card'
 
 library.add(faUnlockAlt, faSave)
@@ -31,7 +31,7 @@ library.add(faUnlockAlt, faSave)
   selector: 'app-two-factor-auth',
   templateUrl: './two-factor-auth.component.html',
   styleUrls: ['./two-factor-auth.component.scss'],
-  imports: [MatCardModule, TranslateModule, NgIf, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatButtonModule, QrCodeModule, MatError, MatIconModule, MatSuffix, MatTooltip, MatHint, MatIconModule]
+  imports: [MatCardModule, TranslateModule, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatLabel, MatInputModule, MatButtonModule, QrCodeModule, MatError, MatIconModule, MatSuffix, MatTooltip, MatHint, MatIconModule]
 })
 export class TwoFactorAuthComponent {
   public data?: string

--- a/frontend/src/app/wallet-web3/wallet-web3.component.html
+++ b/frontend/src/app/wallet-web3/wallet-web3.component.html
@@ -12,62 +12,62 @@
           <mat-icon>
             account_balance_wallet
           </mat-icon>
-          @if (!session) {
-            <span>{{"BTN_CONNECT_METAMASK" | translate}}</span>
-          }
+          
           @if (session) {
             <span
               >{{ userData.address.substring(0, 6) }}...{{
               userData.address.slice(-6)
-              }}</span
-              >
-            }
-          </button>
-        </div>
+              }}
+            </span>
+          } @else {
+            <span>{{"BTN_CONNECT_METAMASK" | translate}}</span>
+          }
+        </button>
       </div>
-      <p>
-        <b>
-          <span>{{"LABEL_WALLET_BALANCE" | translate}}</span>
-          <span class="confirmation"> {{ walletBalance }} ETH</span>
-        </b>
-      </p>
-      <div>
-        <mat-form-field style="width: 100%" color="accent" appearance="outline">
-          <mat-label>{{'LABEL_AMOUNT' | translate}}</mat-label>
-          <input
-            matInput
-            [placeholder]="'ENTER_ETHER_AMOUNT' | translate"
-            type="number"
-            id="inputAmount"
-            [(ngModel)]="inputAmount"
-            aria-label="Text field for the withdrawal amount"
-            />
-          </mat-form-field>
-          <h5 class="error">{{ errorMessage }}</h5>
-        </div>
-        <div class="dwbutton_container">
-          <button
-            type="submit"
-            class="deposit_withdraw_button"
-            mat-raised-button
-            color="primary"
-            aria-label="Button to deposit"
-            (click)="depositETH()"
-            >
-            <mat-icon>monetization_on</mat-icon>
-            {{'BTN_DEPOSIT' | translate}}
-          </button>
-          <button
-            type="submit"
-            class="deposit_withdraw_button"
-            mat-raised-button
-            color="warning"
-            aria-label="Button to withdraw"
-            (click)="withdrawETH()"
-            >
-            <mat-icon>local_atm</mat-icon>
-            {{'BTN_WITHDRAW' | translate}}
-          </button>
-        </div>
-      </div>
-    </mat-card>
+    </div>
+    <p>
+      <b>
+        <span>{{"LABEL_WALLET_BALANCE" | translate}}</span>
+        <span class="confirmation"> {{ walletBalance }} ETH</span>
+      </b>
+    </p>
+    <div>
+      <mat-form-field style="width: 100%" color="accent" appearance="outline">
+        <mat-label>{{'LABEL_AMOUNT' | translate}}</mat-label>
+        <input
+          matInput
+          [placeholder]="'ENTER_ETHER_AMOUNT' | translate"
+          type="number"
+          id="inputAmount"
+          [(ngModel)]="inputAmount"
+          aria-label="Text field for the withdrawal amount"
+          />
+      </mat-form-field>
+      <h5 class="error">{{ errorMessage }}</h5>
+    </div>
+    <div class="dwbutton_container">
+      <button
+        type="submit"
+        class="deposit_withdraw_button"
+        mat-raised-button
+        color="primary"
+        aria-label="Button to deposit"
+        (click)="depositETH()"
+        >
+        <mat-icon>monetization_on</mat-icon>
+        {{'BTN_DEPOSIT' | translate}}
+      </button>
+      <button
+        type="submit"
+        class="deposit_withdraw_button"
+        mat-raised-button
+        color="warning"
+        aria-label="Button to withdraw"
+        (click)="withdrawETH()"
+        >
+        <mat-icon>local_atm</mat-icon>
+        {{'BTN_WITHDRAW' | translate}}
+      </button>
+    </div>
+  </div>
+</mat-card>

--- a/frontend/src/app/wallet-web3/wallet-web3.component.html
+++ b/frontend/src/app/wallet-web3/wallet-web3.component.html
@@ -8,62 +8,66 @@
           color="accent"
           type="button"
           (click)="handleAuth()"
-        >
+          >
           <mat-icon>
             account_balance_wallet
           </mat-icon>
-          <span *ngIf="!session">{{"BTN_CONNECT_METAMASK" | translate}}</span>
-          <span *ngIf="session"
-            >{{ userData.address.substring(0, 6) }}...{{
+          @if (!session) {
+            <span>{{"BTN_CONNECT_METAMASK" | translate}}</span>
+          }
+          @if (session) {
+            <span
+              >{{ userData.address.substring(0, 6) }}...{{
               userData.address.slice(-6)
-            }}</span
-          >
-        </button>
+              }}</span
+              >
+            }
+          </button>
+        </div>
       </div>
-    </div>
-    <p>
-      <b>
-        <span>{{"LABEL_WALLET_BALANCE" | translate}}</span>
-        <span class="confirmation"> {{ walletBalance }} ETH</span>
-      </b>
-    </p>
-    <div>
-      <mat-form-field style="width: 100%" color="accent" appearance="outline">
-        <mat-label>{{'LABEL_AMOUNT' | translate}}</mat-label>
-        <input
-          matInput
-          [placeholder]="'ENTER_ETHER_AMOUNT' | translate"
-          type="number"
-          id="inputAmount"
-          [(ngModel)]="inputAmount"
-          aria-label="Text field for the withdrawal amount"
-        />
-      </mat-form-field>
-      <h5 class="error">{{ errorMessage }}</h5>
-    </div>
-    <div class="dwbutton_container">
-      <button
-        type="submit"
-        class="deposit_withdraw_button"
-        mat-raised-button
-        color="primary"
-        aria-label="Button to deposit"
-        (click)="depositETH()"
-      >
-        <mat-icon>monetization_on</mat-icon>
-        {{'BTN_DEPOSIT' | translate}}
-      </button>
-      <button
-        type="submit"
-        class="deposit_withdraw_button"
-        mat-raised-button
-        color="warning"
-        aria-label="Button to withdraw"
-        (click)="withdrawETH()"
-      >
-        <mat-icon>local_atm</mat-icon>
-        {{'BTN_WITHDRAW' | translate}}
-      </button>
-    </div>
-  </div>
-</mat-card>
+      <p>
+        <b>
+          <span>{{"LABEL_WALLET_BALANCE" | translate}}</span>
+          <span class="confirmation"> {{ walletBalance }} ETH</span>
+        </b>
+      </p>
+      <div>
+        <mat-form-field style="width: 100%" color="accent" appearance="outline">
+          <mat-label>{{'LABEL_AMOUNT' | translate}}</mat-label>
+          <input
+            matInput
+            [placeholder]="'ENTER_ETHER_AMOUNT' | translate"
+            type="number"
+            id="inputAmount"
+            [(ngModel)]="inputAmount"
+            aria-label="Text field for the withdrawal amount"
+            />
+          </mat-form-field>
+          <h5 class="error">{{ errorMessage }}</h5>
+        </div>
+        <div class="dwbutton_container">
+          <button
+            type="submit"
+            class="deposit_withdraw_button"
+            mat-raised-button
+            color="primary"
+            aria-label="Button to deposit"
+            (click)="depositETH()"
+            >
+            <mat-icon>monetization_on</mat-icon>
+            {{'BTN_DEPOSIT' | translate}}
+          </button>
+          <button
+            type="submit"
+            class="deposit_withdraw_button"
+            mat-raised-button
+            color="warning"
+            aria-label="Button to withdraw"
+            (click)="withdrawETH()"
+            >
+            <mat-icon>local_atm</mat-icon>
+            {{'BTN_WITHDRAW' | translate}}
+          </button>
+        </div>
+      </div>
+    </mat-card>

--- a/frontend/src/app/wallet-web3/wallet-web3.component.ts
+++ b/frontend/src/app/wallet-web3/wallet-web3.component.ts
@@ -15,7 +15,7 @@ import { FormsModule } from '@angular/forms'
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field'
 import { TranslateModule } from '@ngx-translate/core'
-import { NgIf } from '@angular/common'
+
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
 const { ethereum } = window
@@ -30,7 +30,7 @@ const client = createClient({
   selector: 'app-wallet-web3',
   templateUrl: './wallet-web3.component.html',
   styleUrls: ['./wallet-web3.component.scss'],
-  imports: [MatCardModule, MatButtonModule, NgIf, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, MatIconModule]
+  imports: [MatCardModule, MatButtonModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, FormsModule, MatIconModule]
 })
 export class WalletWeb3Component {
   constructor (

--- a/frontend/src/app/wallet/wallet.component.html
+++ b/frontend/src/app/wallet/wallet.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <mat-card appearance="outlined" class="mat-elevation-z6">

--- a/frontend/src/app/wallet/wallet.component.html
+++ b/frontend/src/app/wallet/wallet.component.html
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <mat-card appearance="outlined" class="mat-elevation-z6">
   <div class="mdc-card">
@@ -21,19 +21,23 @@
     <mat-form-field appearance="outline" color="accent">
       <mat-label>{{'LABEL_AMOUNT' | translate}}</mat-label>
       <input [formControl]="balanceControl" type="number" matInput aria-label="Enter an amount">
-      <mat-error *ngIf="balanceControl.invalid && balanceControl.errors.required">
-        {{"MANDATORY_AMOUNT"| translate}}
-      </mat-error>
-      <mat-error *ngIf="balanceControl.invalid && (balanceControl.errors.min || balanceControl.errors.max)">
-        {{"AMOUNT_LIMIT" | translate}}
-      </mat-error>
+      @if (balanceControl.invalid && balanceControl.errors.required) {
+        <mat-error>
+          {{"MANDATORY_AMOUNT"| translate}}
+        </mat-error>
+      }
+      @if (balanceControl.invalid && (balanceControl.errors.min || balanceControl.errors.max)) {
+        <mat-error>
+          {{"AMOUNT_LIMIT" | translate}}
+        </mat-error>
+      }
     </mat-form-field>
 
     <button type="submit" id="submitButton" (click)="continue()" [disabled]="balanceControl.invalid"
-            mat-raised-button color="primary" aria-label="Button to continue to payment">
-     <mat-icon>
-      monetization_on
-    </mat-icon>
+      mat-raised-button color="primary" aria-label="Button to continue to payment">
+      <mat-icon>
+        monetization_on
+      </mat-icon>
       {{'BTN_DEPOSIT' | translate}}
     </button>
   </div>

--- a/frontend/src/app/wallet/wallet.component.ts
+++ b/frontend/src/app/wallet/wallet.component.ts
@@ -8,7 +8,7 @@ import { WalletService } from '../Services/wallet.service'
 import { UntypedFormControl, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { Router } from '@angular/router'
 import { MatButtonModule } from '@angular/material/button'
-import { NgIf } from '@angular/common'
+
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel, MatError } from '@angular/material/form-field'
 import { TranslateModule } from '@ngx-translate/core'
@@ -19,7 +19,7 @@ import { MatIconModule } from '@angular/material/icon'
   selector: 'app-wallet',
   templateUrl: './wallet.component.html',
   styleUrls: ['./wallet.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, FormsModule, MatInputModule, ReactiveFormsModule, NgIf, MatError, MatButtonModule, MatIconModule]
+  imports: [MatCardModule, TranslateModule, MatFormFieldModule, MatLabel, FormsModule, MatInputModule, ReactiveFormsModule, MatError, MatButtonModule, MatIconModule]
 })
 export class WalletComponent implements OnInit {
   public balance: string

--- a/frontend/src/app/web3-sandbox/web3-sandbox.component.html
+++ b/frontend/src/app/web3-sandbox/web3-sandbox.component.html
@@ -15,139 +15,163 @@
             color="accent"
             type="button"
             (click)="handleAuth()"
-          >
-            <span *ngIf="!session">{{"BTN_CONNECT_METAMASK" | translate}}</span>
-            <span *ngIf="session"
-              >{{ userData.address.substring(0, 6) }}...{{
-                userData.address.slice(-6)
-              }}</span
             >
-          </button>
-        </div>
-      </div>
-      <h2 translate>TITLE_WEB3_SANDBOX</h2>
-      <ul>
-        <li translate>EXPLANATION_SMART_CONTRACT_DEPLOYMENT</li>
-        <li translate>EXPLANATION_GWEI_VALUE_POST_COMPILATION</li>
-      </ul>
-      <mat-form-field appearance="outline" color="accent">
-        <mat-label>{{ "LABEL_SELECT_COMPILER_VERSION" | translate}}</mat-label>
-        <select matNativeControl [(ngModel)]="selectedCompilerVersion">
-          <option *ngFor="let version of compilerVersions" [value]="version">
-            {{ version }}
-          </option>
-        </select>
-      </mat-form-field>
-      <button
-        type="button"
-        mat-raised-button
-        (click)="compileAndFetchContracts(code)"
-      >
-        <mat-icon>build</mat-icon>
-        {{ "BTN_COMPILE_CONTRACT" | translate}}
-      </button>
-      <div *ngIf="compilerErrors.length > 0" class="error-container mat-elevation-z6">
-        <h4>Compiler Errors:</h4>
-        <ul>
-          <li class="error" *ngFor="let error of compilerErrors">
-            {{ error.formattedMessage }}
-          </li>
-        </ul>
-      </div>
-      <div *ngIf="compiledContracts">
-        <h3 class="contracts-title">{{ "TITLE_CONTRACT_DEPLOYMENT" | translate}}</h3>
-        <div class="form-fields-container">
-          <mat-form-field
-            class="contract-selector"
-            appearance="outline"
-            color="accent"
-          >
-            <mat-label>{{ "LABEL_COMPILED_CONTRACTS" | translate}}</mat-label>
-            <select matNativeControl [(ngModel)]="selectedContractName">
-              <option
-                *ngFor="let contractName of contractNames"
-                [value]="contractName"
-              >
-                {{ contractName }}
-              </option>
-            </select>
-          </mat-form-field>
-          <mat-form-field
-            class="gwei-input"
-            appearance="outline"
-            color="accent"
-          >
-            <mat-label>{{ "GWEI_VALUE_FOR_SENDING_ETH" | translate }}</mat-label>
-            <input
-              matInput
-              type="number"
-              [(ngModel)]="commonGweiValue"
-            />
-          </mat-form-field>
-        </div>
-        <button
-          mat-raised-button
-          type="button"
-          (click)="deploySelectedContract()"
-        >
-          <mat-icon>link</mat-icon>
-          {{ "BTN_DEPLOY_SELECTED_CONTRACT" | translate}}
-        </button>
-      </div>
-      <div class="deployedaddresstext" *ngIf="deployedContractAddress">
-        {{ "LABEL_CONTRACT_ADDRESS" | translate }} {{ deployedContractAddress }}
-      </div>
-      <div class="invokecontainer mat-elevation-z6" *ngIf="deployedContractAddress">
-        <h3 translate>TITLE_INTERACT_WITH_CONTRACT</h3>
-        <div *ngFor="let func of contractFunctions">
-          <div class="function-container">
-            <ng-container *ngIf="func.inputs.length > 0; else noInputs">
-              <div class="functionwtext-container">
-                <button
-                  mat-raised-button
-                  type="button"
-                  (click)="invokeFunction(func)"
+            @if (!session) {
+              <span>{{"BTN_CONNECT_METAMASK" | translate}}</span>
+            }
+            @if (session) {
+              <span
+                >{{ userData.address.substring(0, 6) }}...{{
+                userData.address.slice(-6)
+                }}</span
                 >
-                  <mat-icon>call_to_action</mat-icon>
-                  {{ "BTN_INVOKE" | translate}} {{ func.name }}
-                </button>
-                <mat-form-field appearance="outline" color="accent">
-                  <textarea
-                    matAutosizeMinRows="4"
-                    matAutosizeMaxRows="4"
-                    matTextareaAutosize
-                    matInput
-                    placeholder="({{ func.inputHints }})"
-                    [(ngModel)]="func.inputValues"
-                  ></textarea>
-                </mat-form-field>
-              </div>
-              <div class="invoke-output" *ngIf="func.outputValue !== ''">
-                {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
-              </div>
-            </ng-container>
-            <ng-template #noInputs>
-              <div>
-                <button
-                  mat-raised-button
-                  type="button"
-                  (click)="invokeFunction(func)"
-                >
-                  <mat-icon>call_to_action</mat-icon>
-                  {{ "BTN_INVOKE" | translate}} {{ func.name }}
-                </button>
-                <div class="invoke-output" *ngIf="func.outputValue !== ''">
-                  {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
-                </div>
-              </div>
-            </ng-template>
+              }
+            </button>
           </div>
         </div>
-        <div class="output-container mat-elevation-z6">
-          <div *ngIf="invokeOutput !== ''">{{ "LABEL_OUTPUT" | translate}}: {{ invokeOutput }}</div>
+        <h2 translate>TITLE_WEB3_SANDBOX</h2>
+        <ul>
+          <li translate>EXPLANATION_SMART_CONTRACT_DEPLOYMENT</li>
+          <li translate>EXPLANATION_GWEI_VALUE_POST_COMPILATION</li>
+        </ul>
+        <mat-form-field appearance="outline" color="accent">
+          <mat-label>{{ "LABEL_SELECT_COMPILER_VERSION" | translate}}</mat-label>
+          <select matNativeControl [(ngModel)]="selectedCompilerVersion">
+            @for (version of compilerVersions; track version) {
+              <option [value]="version">
+                {{ version }}
+              </option>
+            }
+          </select>
+        </mat-form-field>
+        <button
+          type="button"
+          mat-raised-button
+          (click)="compileAndFetchContracts(code)"
+          >
+          <mat-icon>build</mat-icon>
+          {{ "BTN_COMPILE_CONTRACT" | translate}}
+        </button>
+        @if (compilerErrors.length > 0) {
+          <div class="error-container mat-elevation-z6">
+            <h4>Compiler Errors:</h4>
+            <ul>
+              @for (error of compilerErrors; track error) {
+                <li class="error">
+                  {{ error.formattedMessage }}
+                </li>
+              }
+            </ul>
+          </div>
+        }
+        @if (compiledContracts) {
+          <div>
+            <h3 class="contracts-title">{{ "TITLE_CONTRACT_DEPLOYMENT" | translate}}</h3>
+            <div class="form-fields-container">
+              <mat-form-field
+                class="contract-selector"
+                appearance="outline"
+                color="accent"
+                >
+                <mat-label>{{ "LABEL_COMPILED_CONTRACTS" | translate}}</mat-label>
+                <select matNativeControl [(ngModel)]="selectedContractName">
+                  @for (contractName of contractNames; track contractName) {
+                    <option
+                      [value]="contractName"
+                      >
+                      {{ contractName }}
+                    </option>
+                  }
+                </select>
+              </mat-form-field>
+              <mat-form-field
+                class="gwei-input"
+                appearance="outline"
+                color="accent"
+                >
+                <mat-label>{{ "GWEI_VALUE_FOR_SENDING_ETH" | translate }}</mat-label>
+                <input
+                  matInput
+                  type="number"
+                  [(ngModel)]="commonGweiValue"
+                  />
+                </mat-form-field>
+              </div>
+              <button
+                mat-raised-button
+                type="button"
+                (click)="deploySelectedContract()"
+                >
+                <mat-icon>link</mat-icon>
+                {{ "BTN_DEPLOY_SELECTED_CONTRACT" | translate}}
+              </button>
+            </div>
+          }
+          @if (deployedContractAddress) {
+            <div class="deployedaddresstext">
+              {{ "LABEL_CONTRACT_ADDRESS" | translate }} {{ deployedContractAddress }}
+            </div>
+          }
+          @if (deployedContractAddress) {
+            <div class="invokecontainer mat-elevation-z6">
+              <h3 translate>TITLE_INTERACT_WITH_CONTRACT</h3>
+              @for (func of contractFunctions; track func) {
+                <div>
+                  <div class="function-container">
+                    @if (func.inputs.length > 0) {
+                      <div class="functionwtext-container">
+                        <button
+                          mat-raised-button
+                          type="button"
+                          (click)="invokeFunction(func)"
+                          >
+                          <mat-icon>call_to_action</mat-icon>
+                          {{ "BTN_INVOKE" | translate}} {{ func.name }}
+                        </button>
+                        <mat-form-field appearance="outline" color="accent">
+                          <textarea
+                            matAutosizeMinRows="4"
+                            matAutosizeMaxRows="4"
+                            matTextareaAutosize
+                            matInput
+                            placeholder="({{ func.inputHints }})"
+                            [(ngModel)]="func.inputValues"
+                          ></textarea>
+                        </mat-form-field>
+                      </div>
+                      @if (func.outputValue !== '') {
+                        <div class="invoke-output">
+                          {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
+                        </div>
+                      }
+                    } @else {
+                      <div>
+                        <button
+                          mat-raised-button
+                          type="button"
+                          (click)="invokeFunction(func)"
+                          >
+                          <mat-icon>call_to_action</mat-icon>
+                          {{ "BTN_INVOKE" | translate}} {{ func.name }}
+                        </button>
+                        @if (func.outputValue !== '') {
+                          <div class="invoke-output">
+                            {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
+                          </div>
+                        }
+                      </div>
+                    }
+                  </div>
+                </div>
+              }
+              <div class="output-container mat-elevation-z6">
+                @if (invokeOutput !== '') {
+                  <div>{{ "LABEL_OUTPUT" | translate}}: {{ invokeOutput }}</div>
+                }
+              </div>
+            </div>
+          }
         </div>
       </div>
+      <img src="assets/public/images/padding/11px.png"/>
     </div>
-  </div>
-  <img src="assets/public/images/padding/11px.png"/>
-</div>

--- a/frontend/src/app/web3-sandbox/web3-sandbox.component.html
+++ b/frontend/src/app/web3-sandbox/web3-sandbox.component.html
@@ -16,162 +16,155 @@
             type="button"
             (click)="handleAuth()"
             >
-            @if (!session) {
-              <span>{{"BTN_CONNECT_METAMASK" | translate}}</span>
-            }
             @if (session) {
-              <span
-                >{{ userData.address.substring(0, 6) }}...{{
-                userData.address.slice(-6)
-                }}</span
-                >
-              }
-            </button>
-          </div>
-        </div>
-        <h2 translate>TITLE_WEB3_SANDBOX</h2>
-        <ul>
-          <li translate>EXPLANATION_SMART_CONTRACT_DEPLOYMENT</li>
-          <li translate>EXPLANATION_GWEI_VALUE_POST_COMPILATION</li>
-        </ul>
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label>{{ "LABEL_SELECT_COMPILER_VERSION" | translate}}</mat-label>
-          <select matNativeControl [(ngModel)]="selectedCompilerVersion">
-            @for (version of compilerVersions; track version) {
-              <option [value]="version">
-                {{ version }}
-              </option>
+              <span>{{ userData.address.substring(0, 6) }}...{{ userData.address.slice(-6) }}</span>
+            } @else {
+            <span>{{"BTN_CONNECT_METAMASK" | translate}}</span>
             }
-          </select>
-        </mat-form-field>
+          </button>
+        </div>
+      </div>
+      <h2 translate>TITLE_WEB3_SANDBOX</h2>
+      <ul>
+        <li translate>EXPLANATION_SMART_CONTRACT_DEPLOYMENT</li>
+        <li translate>EXPLANATION_GWEI_VALUE_POST_COMPILATION</li>
+      </ul>
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>{{ "LABEL_SELECT_COMPILER_VERSION" | translate}}</mat-label>
+        <select matNativeControl [(ngModel)]="selectedCompilerVersion">
+          @for (version of compilerVersions; track version) {
+          <option [value]="version">
+            {{ version }}
+          </option>
+          }
+        </select>
+      </mat-form-field>
         <button
           type="button"
           mat-raised-button
           (click)="compileAndFetchContracts(code)"
           >
-          <mat-icon>build</mat-icon>
-          {{ "BTN_COMPILE_CONTRACT" | translate}}
-        </button>
-        @if (compilerErrors.length > 0) {
-          <div class="error-container mat-elevation-z6">
-            <h4>Compiler Errors:</h4>
-            <ul>
-              @for (error of compilerErrors; track error) {
-                <li class="error">
-                  {{ error.formattedMessage }}
-                </li>
+        <mat-icon>build</mat-icon>
+        {{ "BTN_COMPILE_CONTRACT" | translate}}
+      </button>
+      @if (compilerErrors.length > 0) {
+      <div class="error-container mat-elevation-z6">
+        <h4>Compiler Errors:</h4>
+        <ul>
+          @for (error of compilerErrors; track error) {
+          <li class="error">
+            {{ error.formattedMessage }}
+          </li>
+          }
+        </ul>
+      </div>
+      }
+      @if (compiledContracts) {
+      <div>
+        <h3 class="contracts-title">{{ "TITLE_CONTRACT_DEPLOYMENT" | translate}}</h3>
+        <div class="form-fields-container">
+          <mat-form-field
+            class="contract-selector"
+            appearance="outline"
+            color="accent"
+          >
+            <mat-label>{{ "LABEL_COMPILED_CONTRACTS" | translate}}</mat-label>
+            <select matNativeControl [(ngModel)]="selectedContractName">
+              @for (contractName of contractNames; track contractName) {
+              <option [value]="contractName">
+                {{ contractName }}
+              </option>
               }
-            </ul>
-          </div>
-        }
-        @if (compiledContracts) {
-          <div>
-            <h3 class="contracts-title">{{ "TITLE_CONTRACT_DEPLOYMENT" | translate}}</h3>
-            <div class="form-fields-container">
-              <mat-form-field
-                class="contract-selector"
-                appearance="outline"
-                color="accent"
-                >
-                <mat-label>{{ "LABEL_COMPILED_CONTRACTS" | translate}}</mat-label>
-                <select matNativeControl [(ngModel)]="selectedContractName">
-                  @for (contractName of contractNames; track contractName) {
-                    <option
-                      [value]="contractName"
-                      >
-                      {{ contractName }}
-                    </option>
-                  }
-                </select>
-              </mat-form-field>
-              <mat-form-field
-                class="gwei-input"
-                appearance="outline"
-                color="accent"
-                >
-                <mat-label>{{ "GWEI_VALUE_FOR_SENDING_ETH" | translate }}</mat-label>
-                <input
-                  matInput
-                  type="number"
-                  [(ngModel)]="commonGweiValue"
-                  />
-                </mat-form-field>
-              </div>
+            </select>
+          </mat-form-field>
+          <mat-form-field
+            class="gwei-input"
+            appearance="outline"
+            color="accent"
+          >
+            <mat-label>{{ "GWEI_VALUE_FOR_SENDING_ETH" | translate }}</mat-label>
+            <input
+              matInput
+              type="number"
+              [(ngModel)]="commonGweiValue"
+            />
+          </mat-form-field>
+        </div>
+        <button
+          mat-raised-button
+          type="button"
+          (click)="deploySelectedContract()"
+        >
+          <mat-icon>link</mat-icon>
+          {{ "BTN_DEPLOY_SELECTED_CONTRACT" | translate}}
+        </button>
+      </div>
+      }
+      @if (deployedContractAddress) {
+      <div class="deployedaddresstext">
+        {{ "LABEL_CONTRACT_ADDRESS" | translate }} {{ deployedContractAddress }}
+      </div>
+      }
+      @if (deployedContractAddress) {
+      <div class="invokecontainer mat-elevation-z6">
+        <h3 translate>TITLE_INTERACT_WITH_CONTRACT</h3>
+        @for (func of contractFunctions; track func) {
+        <div>
+          <div class="function-container">
+            @if (func.inputs.length > 0) {
+            <div class="functionwtext-container">
               <button
                 mat-raised-button
                 type="button"
-                (click)="deploySelectedContract()"
-                >
-                <mat-icon>link</mat-icon>
-                {{ "BTN_DEPLOY_SELECTED_CONTRACT" | translate}}
+                (click)="invokeFunction(func)"
+              >
+                <mat-icon>call_to_action</mat-icon>
+                {{ "BTN_INVOKE" | translate}} {{ func.name }}
               </button>
+              <mat-form-field appearance="outline" color="accent">
+                <textarea
+                  matAutosizeMinRows="4"
+                  matAutosizeMaxRows="4"
+                  matTextareaAutosize
+                  matInput
+                  placeholder="({{ func.inputHints }})"
+                  [(ngModel)]="func.inputValues"
+                ></textarea>
+              </mat-form-field>
             </div>
-          }
-          @if (deployedContractAddress) {
-            <div class="deployedaddresstext">
-              {{ "LABEL_CONTRACT_ADDRESS" | translate }} {{ deployedContractAddress }}
+            @if (func.outputValue !== '') {
+            <div class="invoke-output">
+              {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
             </div>
-          }
-          @if (deployedContractAddress) {
-            <div class="invokecontainer mat-elevation-z6">
-              <h3 translate>TITLE_INTERACT_WITH_CONTRACT</h3>
-              @for (func of contractFunctions; track func) {
-                <div>
-                  <div class="function-container">
-                    @if (func.inputs.length > 0) {
-                      <div class="functionwtext-container">
-                        <button
-                          mat-raised-button
-                          type="button"
-                          (click)="invokeFunction(func)"
-                          >
-                          <mat-icon>call_to_action</mat-icon>
-                          {{ "BTN_INVOKE" | translate}} {{ func.name }}
-                        </button>
-                        <mat-form-field appearance="outline" color="accent">
-                          <textarea
-                            matAutosizeMinRows="4"
-                            matAutosizeMaxRows="4"
-                            matTextareaAutosize
-                            matInput
-                            placeholder="({{ func.inputHints }})"
-                            [(ngModel)]="func.inputValues"
-                          ></textarea>
-                        </mat-form-field>
-                      </div>
-                      @if (func.outputValue !== '') {
-                        <div class="invoke-output">
-                          {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
-                        </div>
-                      }
-                    } @else {
-                      <div>
-                        <button
-                          mat-raised-button
-                          type="button"
-                          (click)="invokeFunction(func)"
-                          >
-                          <mat-icon>call_to_action</mat-icon>
-                          {{ "BTN_INVOKE" | translate}} {{ func.name }}
-                        </button>
-                        @if (func.outputValue !== '') {
-                          <div class="invoke-output">
-                            {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
-                          </div>
-                        }
-                      </div>
-                    }
-                  </div>
-                </div>
-              }
-              <div class="output-container mat-elevation-z6">
-                @if (invokeOutput !== '') {
-                  <div>{{ "LABEL_OUTPUT" | translate}}: {{ invokeOutput }}</div>
-                }
+            }
+            } @else {
+            <div>
+              <button
+                mat-raised-button
+                type="button"
+                (click)="invokeFunction(func)"
+                >
+                <mat-icon>call_to_action</mat-icon>
+                {{ "BTN_INVOKE" | translate}} {{ func.name }}
+              </button>
+              @if (func.outputValue !== '') {
+              <div class="invoke-output">
+                {{ "LABEL_OUTPUT_FOR" | translate }} {{ func.name }}: {{ func.outputValue }}
               </div>
+              }
             </div>
+            }
+          </div>
+        </div>
+        }
+        <div class="output-container mat-elevation-z6">
+          @if (invokeOutput !== '') {
+          <div>{{ "LABEL_OUTPUT" | translate}}: {{ invokeOutput }}</div>
           }
         </div>
       </div>
-      <img src="assets/public/images/padding/11px.png"/>
+      }
     </div>
+  </div>
+  <img src="assets/public/images/padding/11px.png" />
+</div>

--- a/frontend/src/app/web3-sandbox/web3-sandbox.component.ts
+++ b/frontend/src/app/web3-sandbox/web3-sandbox.component.ts
@@ -15,7 +15,7 @@ import {
 import { MatInputModule } from '@angular/material/input'
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field'
 import { TranslateModule } from '@ngx-translate/core'
-import { NgIf, NgFor } from '@angular/common'
+
 import { MatButtonModule } from '@angular/material/button'
 import { FormsModule } from '@angular/forms'
 import { CodemirrorModule } from '@ctrl/ngx-codemirror'
@@ -42,7 +42,7 @@ const compilerReleases = {
   selector: 'app-web3-sandbox',
   templateUrl: './web3-sandbox.component.html',
   styleUrls: ['./web3-sandbox.component.scss'],
-  imports: [CodemirrorModule, FormsModule, MatButtonModule, MatIconModule, NgIf, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule, NgFor]
+  imports: [CodemirrorModule, FormsModule, MatButtonModule, MatIconModule, TranslateModule, MatFormFieldModule, MatLabel, MatInputModule]
 })
 export class Web3SandboxComponent {
   constructor (

--- a/frontend/src/app/welcome-banner/welcome-banner.component.html
+++ b/frontend/src/app/welcome-banner/welcome-banner.component.html
@@ -1,28 +1,30 @@
 <!--
-  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-  ~ SPDX-License-Identifier: MIT
-  -->
+~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+~ SPDX-License-Identifier: MIT
+-->
 
 <h1>{{title}}</h1>
 <div class="text-justify" [innerHtml]="message"></div>
 <div class="button-footer">
-  <button
-    *ngIf="showHackingInstructor"
-    mat-raised-button color="warn"
-    (click)="startHackingInstructor()"
-    [matTooltip]="('SCORE_BOARD_HACKING_INSTRUCTOR' | translate)"
-    matTooltipPosition="above">
-    <mat-icon>
-      school
-    </mat-icon>
-    <span class="hide-lt-lg">{{"BTN_GETTING_STARTED" | translate}}</span>
-  </button>
-  <button mat-raised-button class="close-dialog" (click)="closeWelcome()" color="primary"
-          *ngIf="showDismissBtn"
-          aria-label="Close Welcome Banner">
-    <mat-icon>
-      visibility_off
-    </mat-icon>
-    <span class="hide-lt-sm">{{"BTN_DISMISS" | translate }}</span>
-  </button>
+  @if (showHackingInstructor) {
+    <button
+      mat-raised-button color="warn"
+      (click)="startHackingInstructor()"
+      [matTooltip]="('SCORE_BOARD_HACKING_INSTRUCTOR' | translate)"
+      matTooltipPosition="above">
+      <mat-icon>
+        school
+      </mat-icon>
+      <span class="hide-lt-lg">{{"BTN_GETTING_STARTED" | translate}}</span>
+    </button>
+  }
+  @if (showDismissBtn) {
+    <button mat-raised-button class="close-dialog" (click)="closeWelcome()" color="primary"
+      aria-label="Close Welcome Banner">
+      <mat-icon>
+        visibility_off
+      </mat-icon>
+      <span class="hide-lt-sm">{{"BTN_DISMISS" | translate }}</span>
+    </button>
+  }
 </div>

--- a/frontend/src/app/welcome-banner/welcome-banner.component.html
+++ b/frontend/src/app/welcome-banner/welcome-banner.component.html
@@ -1,6 +1,6 @@
 <!--
-~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
-~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
 -->
 
 <h1>{{title}}</h1>

--- a/frontend/src/app/welcome-banner/welcome-banner.component.ts
+++ b/frontend/src/app/welcome-banner/welcome-banner.component.ts
@@ -12,13 +12,12 @@ import { TranslateModule } from '@ngx-translate/core'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatButtonModule } from '@angular/material/button'
-import { NgIf } from '@angular/common'
 
 @Component({
   selector: 'app-welcome-banner',
   templateUrl: 'welcome-banner.component.html',
   styleUrls: ['./welcome-banner.component.scss'],
-  imports: [NgIf, MatButtonModule, MatTooltip, MatIconModule, TranslateModule]
+  imports: [MatButtonModule, MatTooltip, MatIconModule, TranslateModule]
 })
 export class WelcomeBannerComponent implements OnInit {
   public title: string = 'Welcome to OWASP Juice Shop'


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

As part of preparing the codebase for the signal migration ([#2653](https://github.com/juice-shop/juice-shop/issues/2653)), this PR migrates templates to the new Angular control flow syntax.  

Specifically, it:  
- Replaces `*ngIf` with `@if` and `*ngFor` with `@for` directives.  
- Removes unused imports.  
- Cleans up template formatting for improved readability and maintainability.

> Note: In a follow-up PR, I plan to replace instances like:  
> 
> ```html
> @if (!session) {
>    <!-- show this if session is falsy -->
> }
> @if (session) {
>    <!-- show this if session is truthy -->
> }
> ```  
> 
> with `@if/@else` for better clarity and a bit of performance.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
