### PR TITLE
Fix: update outdated repo references from bkimminich to juice-shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Feel free to have a look at the latest version of OWASP Juice Shop:
 
 ### Node.js version compatibility
 
-![GitHub package.json dynamic](https://img.shields.io/github/package-json/cpu/bkimminich/juice-shop)
-![GitHub package.json dynamic](https://img.shields.io/github/package-json/os/bkimminich/juice-shop)
+![GitHub package.json dynamic](https://img.shields.io/github/package-json/cpu/juice-shop/juice-shop)
+![GitHub package.json dynamic](https://img.shields.io/github/package-json/os/juice-shop/juice-shop)
 
 OWASP Juice Shop officially supports the following versions of
 [node.js](http://nodejs.org) in line with the official
@@ -179,11 +179,11 @@ and is available **for free** in PDF, Kindle and ePub format on LeanPub. You can
 
 ## Contributing
 
-[![GitHub contributors](https://img.shields.io/github/contributors/bkimminich/juice-shop.svg)](https://github.com/juice-shop/juice-shop/graphs/contributors)
+[![GitHub contributors](https://img.shields.io/github/contributors/juice-shop/juice-shop.svg)](https://github.com/juice-shop/juice-shop/graphs/contributors)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/owasp-juice-shop/localized.svg)](https://crowdin.com/project/owasp-juice-shop)
-![GitHub issues by-label](https://img.shields.io/github/issues/bkimminich/juice-shop/help%20wanted.svg)
-![GitHub issues by-label](https://img.shields.io/github/issues/bkimminich/juice-shop/good%20first%20issue.svg)
+![GitHub issues by-label](https://img.shields.io/github/issues/juice-shop/juice-shop/help%20wanted.svg)
+![GitHub issues by-label](https://img.shields.io/github/issues/juice-shop/juice-shop/good%20first%20issue.svg)
 
 We are always happy to get new contributors on board! Please check
 [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to
@@ -230,10 +230,10 @@ For a list of all contributors to the OWASP Juice Shop please visit our
 
 ## Licensing
 
-[![license](https://img.shields.io/github/license/bkimminich/juice-shop.svg)](LICENSE)
+[![license](https://img.shields.io/github/license/juice-shop/juice-shop.svg)](LICENSE)
 
 This program is free software: you can redistribute it and/or modify it under the terms of the [MIT license](LICENSE).
 OWASP Juice Shop and any contributions are Copyright © by Bjoern Kimminich & the OWASP Juice Shop contributors
 2014-2025.
 
-![Juice Shop Logo](https://raw.githubusercontent.com/bkimminich/juice-shop/master/frontend/src/assets/public/images/JuiceShop_Logo_400px.png)
+![Juice Shop Logo](https://raw.githubusercontent.com/juice-shop/juice-shop/master/frontend/src/assets/public/images/JuiceShop_Logo_400px.png)

--- a/ftp/package.json.bak
+++ b/ftp/package.json.bak
@@ -116,10 +116,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bkimminich/juice-shop.git"
+    "url": "https://github.com/juice-shop/juice-shop.git"
   },
   "bugs": {
-    "url": "https://github.com/bkimminich/juice-shop/issues"
+    "url": "https://github.com/juice-shop/juice-shop/issues"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
### Description

This PR fixes broken references caused by the repository transfer from
`bkimminich/juice-shop` to `juice-shop/juice-shop`.

Some badges, image links, and metadata in `README.md` and `package.json.bak`
were still pointing to the old location, resulting in 404 errors.

**Changes:**
- Updated README badges (license, contributors, issues, supported cpu, supported os)
- Fixed raw image link for Juice Shop logo
- Updated `package.json.bak`:
  - `repository.url` now points to `https://github.com/juice-shop/juice-shop.git`
  - `bugs.url` now points to `https://github.com/juice-shop/juice-shop/issues`

**Notes:**
- Links from **https://images.microbadger.com** and **https://gitter.im**
  remain valid and were left unchanged.

Resolved or fixed issue: #2721

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
