### PR TITLE
fix(server): prevent crash on unhandled exceptions in unsafe mode

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
  * SPDX-License-Identifier: MIT
  */
+
 import i18n from 'i18n'
 import cors from 'cors'
 import fs from 'node:fs'
@@ -653,6 +654,16 @@ restoreOverwrittenFilesWithOriginals().then(() => {
 
   /* Error Handling */
   app.use(verify.errorHandlingChallenge())
+
+  // This is a global error handler that will catch any unhandled errors.
+  // It only runs when the server is in 'unsafe' mode.
+  if (process.env.NODE_ENV === 'unsafe') {
+    app.use((err: Error, req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => {
+      console.error(err.stack)
+      res.status(500).send('An unexpected error occurred!')
+    })
+  }
+
   app.use(errorhandler())
 }).catch((err) => {
   console.error(err)


### PR DESCRIPTION
### Description

This change introduces a global error-handling middleware that prevents the server from crashing due to unhandled exceptions.

This new middleware is conditionally active only when the server is running with `NODE_ENV=unsafe`. When an unexpected error occurs in this mode, the handler now catches it, logs the full error stack to the console for debugging, and sends a generic 500 error response to the client. This ensures server stability while preserving the detailed error logging needed for the "unsafe" mode.

Resolved or fixed issue: #2676

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines