### PR TITLE
Update angular related frontend dependencies still forcing us to use legacy-peer-deps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "material-icons": "^0.3.1",
     "ng-gallery": "^12.0.0",
     "ng-qrcode": "^20.0.0",
-    "ng2-file-upload": "^7.0.1",
+    "ng2-file-upload": "^8.0.0",
     "ngx-clipboard": "^15.1.0",
     "ngx-highlightjs": "^6.1.2",
     "ngx-window-token": "^6.0.0",
@@ -95,5 +95,11 @@
     "stylelint-config-sass-guidelines": "^7.1.0",
     "stylelint-scss": "^3.18.0",
     "ts-node": "^10.9.2"
+  },
+  "overrides": {
+    "ng2-file-upload": {
+      "@angular/common": "^19.0.0 || ^20.0.0",
+      "@angular/core": "^19.0.0 || ^20.0.0"
+    }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,6 @@
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/eslint-plugin-tslint": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
-    "codelyzer": "^6.0.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "10.1.2",
     "eslint-config-standard-with-typescript": "^43.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-eslint/builder": "^18.4.3",
+    "@angular-eslint/builder": "^20.1.0",
     "@angular/language-service": "^20.1.0",
     "@types/express-serve-static-core": "^4.17.9",
     "@types/file-saver": "^2.0.1",


### PR DESCRIPTION
### Description

Tried to resolve some more angular / frontend dependencies which still force us to use `--legacy-peer-deps`

I think this is all angular related ones. But we still have issues with eslint, but definitely on a good path now, especially together with the improvements from @bogminic in #2724 :)

@bogmatic can you have a look if something in here would cause problems with the signal things you are working on, wasn't quit sure why the dependencies in #2724 were causing issue earlier but these didn't?

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
