### PR TITLE
fix : large hint tooltips on the scoreboard not scrollable

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -300,3 +300,8 @@ div.mdc-card {
   max-width: 480px;
   white-space: pre-line;
 }
+
+/* override Angular Material tooltip max-height for score-board hints */
+.mat-mdc-tooltip-surface {
+  max-height: none !important;
+}


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description
Fixed issue #2754 where large hint tooltips on the scoreboard were not scrollable.
Angular Material’s default max-height: 40vh on tooltips prevents larger content from being fully visible. This PR overrides that default using CSS (!important) in styles.scss, allowing hint tooltips to display their full content and scroll when necessary.

Steps to verify:

Go to the scoreboard.
Click on a challenge with more than four hints.
Hover over the hint box.
Confirm that all hints are visible and scrollable.

<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Resolved or fixed issue: #2754<!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
