### PR TITLE
Fix: Removed tooltip max-height to resolve hint overflow issue

### DIFF
--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -77,7 +77,7 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
       const transformedChallenges = challenges.map((challenge) => {
         return {
           ...challenge,
-          hintText: hints.filter((hint) => hint.ChallengeId === challenge.id && hint.unlocked).map((hint) => hint.order + '. ' + hint.text).join('\n'),
+          hintText: hints.filter((hint) => hint.ChallengeId === challenge.id && hint.unlocked).map((hint) => hint.order + '. ' + hint.text).join('\n\n'),
           nextHint: hints.filter((hint) => hint.ChallengeId === challenge.id && !hint.unlocked).sort((a, b) => a.order - b.order).map((hint) => hint.id)[0],
           hintsUnlocked: hints.filter((hint) => hint.ChallengeId === challenge.id && hint.unlocked).length,
           hintsAvailable: hints.filter((hint) => hint.ChallengeId === challenge.id).length,

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -300,3 +300,9 @@ div.mdc-card {
   max-width: 480px;
   white-space: pre-line;
 }
+
+
+/* override Angular Material tooltip max-height for score-board hints */
+.mat-mdc-tooltip-surface {
+  max-height: none !important;
+}


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Fixed issue where the hint panel did not scroll correctly on smaller viewport sizes.
Fix Includes:

1. CSS Override to remove tooltip height limitation:
```

/* override Angular Material tooltip max-height for score-board hints */
.mat-mdc-tooltip-surface {
  max-height: none !important;
}

```

2. Logic Improvement to combine hints properly with double line spacing:

```
hintText: hints
  .filter((hint) => hint.ChallengeId === challenge.id && hint.unlocked)
  .map((hint) => hint.order + '. ' + hint.text)
  .join('\n\n'),

```

This ensures:
1. All unlocked hints are shown in order
2. Each hint is separated by a blank line
3. Tooltip dynamically resizes based on content

Before 
<img width="368" height="364" alt="image" src="https://github.com/user-attachments/assets/aa1b71ab-fbaa-4a9e-ad8e-6090986b5728" />
After
<img width="585" height="760" alt="image" src="https://github.com/user-attachments/assets/53b479fe-9d95-4413-9227-d41dda790e61" />



Resolved or fixed issue: #2754 #2776 <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
