### PR TITLE
Improve accessibility and semantic structure of Change Password component

### DIFF
--- a/frontend/src/app/change-password/change-password.component.html
+++ b/frontend/src/app/change-password/change-password.component.html
@@ -3,79 +3,155 @@
   ~ SPDX-License-Identifier: MIT
 -->
 
-<div class="center-container">
-  <mat-card appearance="outlined" class="mat-elevation-z6" style="margin-bottom: 20px;">
-    <div class="mdc-card">
+<section class="center-container">
+  <mat-card
+    appearance="outlined"
+    class="mat-elevation-z6"
+    role="region"
+    aria-labelledby="change-password-heading"
+  >
+    <header>
+      <h1 id="change-password-heading">
+        {{ 'TITLE_CHANGE_PASSWORD' | translate }}
+      </h1>
+    </header>
 
-      <h1 >{{"TITLE_CHANGE_PASSWORD" | translate }}</h1>
+    <p
+      class="confirmation"
+      [hidden]="
+        !(
+          confirmation &&
+          !passwordControl.dirty &&
+          !newPasswordControl.dirty &&
+          !repeatNewPasswordControl.dirty
+        )
+      "
+      role="status"
+      aria-live="polite"
+    >
+      {{ confirmation }}
+    </p>
 
-      <div class="confirmation"
-        [hidden]="!(confirmation && !passwordControl.dirty && !newPasswordControl.dirty && !repeatNewPasswordControl.dirty)">
-        {{ confirmation }}
-      </div>
+    <p
+      class="error"
+      [hidden]="
+        !(
+          error &&
+          !passwordControl.dirty &&
+          !newPasswordControl.dirty &&
+          !repeatNewPasswordControl.dirty
+        )
+      "
+      role="alert"
+      aria-live="assertive"
+    >
+      {{ error }}
+    </p>
 
-      <div class="error"
-        [hidden]="!(error && !passwordControl.dirty && !newPasswordControl.dirty && !repeatNewPasswordControl.dirty)">
-        {{ error }}
-      </div>
+    <form
+      class="form-container"
+      id="password-form"
+    >
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>{{ 'LABEL_CURRENT_PASSWORD' | translate }}</mat-label>
+        <input
+          id="currentPassword"
+          [formControl]="passwordControl"
+          type="password"
+          matInput
+          required
+          autocomplete="current-password"
+          aria-label="Field to enter the current password"
+          placeholder="{{ 'MANDATORY_CURRENT_PASSWORD' | translate }}"
+        />
+        @if (passwordControl.invalid) {
+          <mat-error>{{ 'MANDATORY_CURRENT_PASSWORD' | translate }}</mat-error>
+        }
+      </mat-form-field>
 
-      <div class="form-container" id="password-form">
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>{{ 'LABEL_NEW_PASSWORD' | translate }}</mat-label>
+        <input
+          #password
+          id="newPassword"
+          [formControl]="newPasswordControl"
+          type="password"
+          matInput
+          required
+          autocomplete="new-password"
+          aria-label="Field for the new password"
+        />
+        <mat-hint translate>
+          <i class="fas fa-exclamation-circle"></i>
+          <em style="margin-left: 5px" translate>{{
+            'INVALID_PASSWORD_LENGTH' | translate: { length: '5-40' }
+          }}</em>
+        </mat-hint>
+        <mat-hint align="end">{{ password.value?.length || 0 }}/40</mat-hint>
+        @if (
+          newPasswordControl?.invalid && newPasswordControl?.errors.required
+        ) {
+          <mat-error>
+            {{ 'MANDATORY_NEW_PASSWORD' | translate }}
+          </mat-error>
+        }
+        @if (
+          newPasswordControl?.invalid &&
+          (newPasswordControl?.errors.minlength ||
+            newPasswordControl?.errors.maxlength)
+        ) {
+          <mat-error translate [translateParams]="{ length: '5-40' }"
+            >{{ 'INVALID_PASSWORD_LENGTH' | translate }}
+          </mat-error>
+        }
+      </mat-form-field>
 
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label >{{"LABEL_CURRENT_PASSWORD" | translate }}</mat-label>
-          <input id="currentPassword" [formControl]="passwordControl" type="password" matInput
-            aria-label="Field to enter the current password"
-            placeholder="{{'MANDATORY_CURRENT_PASSWORD' | translate }}">
-            @if (passwordControl.invalid) {
-              <mat-error >{{"MANDATORY_CURRENT_PASSWORD" | translate }}</mat-error>
-            }
-          </mat-form-field>
-
-          <mat-form-field appearance="outline" color="accent">
-            <mat-label >{{"LABEL_NEW_PASSWORD" | translate }}</mat-label>
-            <input #password id="newPassword" [formControl]="newPasswordControl" type="password" matInput
-              aria-label="Field for the new password">
-              <mat-hint translate>
-                <i class="fas fa-exclamation-circle"></i>
-                <em style="margin-left:5px;" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
-              </mat-hint>
-              <mat-hint align="end">{{password.value?.length || 0}}/40</mat-hint>
-              @if (newPasswordControl?.invalid && newPasswordControl?.errors.required) {
-                <mat-error>
-                  {{"MANDATORY_NEW_PASSWORD" | translate }}
-                </mat-error>
-              }
-              @if (newPasswordControl?.invalid && (newPasswordControl?.errors.minlength || newPasswordControl?.errors.maxlength)) {
-                <mat-error
-                  translate [translateParams]="{length: '5-40'}">{{"INVALID_PASSWORD_LENGTH"| translate }}
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" color="accent">
-              <mat-label>{{"LABEL_REPEAT_NEW_PASSWORD"| translate }}</mat-label>
-              <input #passwordRepeat id="newPasswordRepeat" [formControl]="repeatNewPasswordControl" type="password" matInput
-                aria-label="Field to repeat the new password">
-                <mat-hint align="end">{{passwordRepeat.value?.length || 0}}/20</mat-hint>
-                @if (repeatNewPasswordControl.invalid && repeatNewPasswordControl.errors.required) {
-                  <mat-error translate>MANDATORY_PASSWORD_REPEAT</mat-error>
-                }
-                @if (repeatNewPasswordControl.invalid && repeatNewPasswordControl.errors.notSame) {
-                  <mat-error translate>
-                    {{"PASSWORDS_NOT_MATCHING" | translate }}
-                  </mat-error>
-                }
-              </mat-form-field>
-
-            </div>
-
-            <button type="submit" id="changeButton"
-              [disabled]="passwordControl.invalid || newPasswordControl.invalid || repeatNewPasswordControl.invalid"
-              mat-raised-button color="primary" (click)="changePassword()" aria-label="Button to confirm the change">
-              <i class="far fa-edit fa-lg" aria-hidden="true"></i>
-              {{'BTN_CHANGE' | translate}}
-            </button>
-
-          </div>
-        </mat-card>
-      </div>
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>{{ 'LABEL_REPEAT_NEW_PASSWORD' | translate }}</mat-label>
+        <input
+          #passwordRepeat
+          id="newPasswordRepeat"
+          [formControl]="repeatNewPasswordControl"
+          type="password"
+          matInput
+          required
+          autocomplete="new-password"
+          aria-label="Field to repeat the new password"
+        />
+        <mat-hint align="end"
+          >{{ passwordRepeat.value?.length || 0 }}/20</mat-hint
+        >
+        @if (
+          repeatNewPasswordControl.invalid &&
+          repeatNewPasswordControl.errors.required
+        ) {
+          <mat-error translate>MANDATORY_PASSWORD_REPEAT</mat-error>
+        }
+        @if (
+          repeatNewPasswordControl.invalid &&
+          repeatNewPasswordControl.errors.notSame
+        ) {
+          <mat-error translate>
+            {{ 'PASSWORDS_NOT_MATCHING' | translate }}
+          </mat-error>
+        }
+      </mat-form-field>
+    </form>
+    <button
+      type="submit"
+      id="changeButton"
+      mat-raised-button
+      [disabled]="
+        passwordControl.invalid ||
+        newPasswordControl.invalid ||
+        repeatNewPasswordControl.invalid
+      "
+      color="primary"
+      aria-label="Button to confirm the change"
+      (click)="changePassword()"
+    >
+      <i class="far fa-edit fa-lg" aria-hidden="true"></i>
+      {{ 'BTN_CHANGE' | translate }}
+    </button>
+  </mat-card>
+</section>

--- a/frontend/src/app/change-password/change-password.component.html
+++ b/frontend/src/app/change-password/change-password.component.html
@@ -83,7 +83,7 @@
         />
         <mat-hint translate>
           <i class="fas fa-exclamation-circle"></i>
-          <em style="margin-left: 5px" translate>{{
+          <em translate>{{
             'INVALID_PASSWORD_LENGTH' | translate: { length: '5-40' }
           }}</em>
         </mat-hint>

--- a/frontend/src/app/change-password/change-password.component.scss
+++ b/frontend/src/app/change-password/change-password.component.scss
@@ -7,8 +7,8 @@ mat-card {
   border: 0;
   height: auto;
   margin-bottom: 20px;
-  padding: 16px;
   min-width: 320px;
+  padding: 16px;
   width: 25%;
 }
 

--- a/frontend/src/app/change-password/change-password.component.scss
+++ b/frontend/src/app/change-password/change-password.component.scss
@@ -42,6 +42,7 @@ em {
   color: var(--theme-text-fade-30) !important;
   display: flex;
   font-size: 11px;
+  margin-left: 5px;
   white-space: nowrap;
 }
 

--- a/frontend/src/app/change-password/change-password.component.scss
+++ b/frontend/src/app/change-password/change-password.component.scss
@@ -4,19 +4,20 @@
  */
 
 mat-card {
+  border: 0;
   height: auto;
-  min-width: 320px;
-  width: 25%;
   margin-bottom: 20px;
   padding: 16px;
-  border: none;
+  min-width: 320px;
+  width: 25%;
 }
 
 mat-form-field {
   padding-top: 10px;
 }
 
-.confirmation, .error {
+.confirmation,
+.error {
   margin: 0;
 }
 

--- a/frontend/src/app/change-password/change-password.component.scss
+++ b/frontend/src/app/change-password/change-password.component.scss
@@ -7,10 +7,17 @@ mat-card {
   height: auto;
   min-width: 320px;
   width: 25%;
+  margin-bottom: 20px;
+  padding: 16px;
+  border: none;
 }
 
 mat-form-field {
   padding-top: 10px;
+}
+
+.confirmation, .error {
+  margin: 0;
 }
 
 .form-container {
@@ -28,10 +35,6 @@ button {
   margin-top: 30px;
   width: 60%;
 
-}
-
-.mdc-card {
-  border: 0;
 }
 
 em {


### PR DESCRIPTION
### Description
As part of the upcoming [Signal migration](https://github.com/juice-shop/juice-shop/issues/2653) and my wish to replace inline styles with reusable SCSS classes, this PR improves the accessibility, semantics, and maintainability of the **Change Password** page. It introduces proper ARIA roles, live regions, and semantic elements while preserving existing functionality and visual design.

### Changes made

- Replaced non-semantic `<div>` containers with meaningful elements (`<section>`, `<header>`, `<form>`).
- Added `role="region"` and `aria-labelledby` for better navigation and screen reader association.
- Implemented `role="status"` and `role="alert"` for confirmation and error messages.
- Added `required` and `autocomplete` attributes to password fields.
- Simplified and standardized CSS for consistent spacing and alignment.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
