### PR TITLE
Refactor Last Login IP and Complain pages markup and styles for better semantics

### DIFF
--- a/frontend/src/app/complaint/complaint.component.html
+++ b/frontend/src/app/complaint/complaint.component.html
@@ -5,28 +5,28 @@
 
 <main class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
-    <h1>{{ 'NAV_COMPLAIN' | translate }}</h1>
+    <h1>{{ "NAV_COMPLAIN" | translate }}</h1>
 
     <section aria-live="polite">
       <p class="confirmation" [hidden]="!(confirmation && !messageControl.dirty)">
         {{ confirmation }}
       </p>
 
-      @if (fileUploadError && fileUploadError.name == 'mimeType') {
+      @if (fileUploadError && fileUploadError.name == "mimeType") {
         <p class="error fileUploadError" role="alert">
-          {{ 'INVALID_FILE_TYPE' | translate: { type: 'PDF, ZIP' } }}
+          {{ "INVALID_FILE_TYPE" | translate: { type: "PDF, ZIP" } }}
         </p>
       }
-      @if (fileUploadError && fileUploadError.name == 'fileSize') {
+      @if (fileUploadError && fileUploadError.name == "fileSize") {
         <p class="error fileUploadError" role="alert">
-          {{ 'INVALID_FILE_SIZE' | translate: { size: '100 KB' } }}
+          {{ "INVALID_FILE_SIZE" | translate: { size: "100 KB" } }}
         </p>
       }
     </section>
 
     <form class="form-container" id="complaint-form">
       <mat-form-field appearance="outline" color="accent">
-        <mat-label>{{ 'LABEL_CUSTOMER' | translate }}</mat-label>
+        <mat-label>{{ "LABEL_CUSTOMER" | translate }}</mat-label>
         <input
           [formControl]="customerControl"
           type="text"
@@ -36,10 +36,10 @@
       </mat-form-field>
 
       <mat-form-field appearance="outline" color="accent">
-        <mat-label>{{ 'LABEL_MESSAGE' | translate }}</mat-label>
+        <mat-label>{{ "LABEL_MESSAGE" | translate }}</mat-label>
         <mat-hint>
           <i class="fas fa-exclamation-circle"></i>
-          <em>{{ 'MAX_TEXTAREA_LENGTH' | translate: { length: '160' } }}</em>
+          <em>{{ "MAX_TEXTAREA_LENGTH" | translate: { length: "160" } }}</em>
         </mat-hint>
         <textarea
           #complaintMessage
@@ -57,7 +57,7 @@
           aria-describedby="messageCounter"
         ></textarea>
         @if (messageControl.invalid && messageControl?.errors.required) {
-          <mat-error role="alert">{{ 'MANDATORY_MESSAGE' | translate }} </mat-error>
+          <mat-error role="alert">{{ "MANDATORY_MESSAGE" | translate }} </mat-error>
         }
         <mat-hint align="end" id="messageCounter">
           <output>{{ complaintMessage.value?.length || 0 }}</output
@@ -66,7 +66,7 @@
       </mat-form-field>
 
       <p class="invoice">
-        <label for="file">{{ 'LABEL_INVOICE' | translate }}<span>:</span></label>
+        <label for="file">{{ "LABEL_INVOICE" | translate }}<span>:</span></label>
         <input
           #fileControl
           ng2FileSelect
@@ -89,7 +89,7 @@
       aria-label="Button to send the complaint"
     >
       <mat-icon> send </mat-icon>
-      {{ 'BTN_SUBMIT' | translate }}
+      {{ "BTN_SUBMIT" | translate }}
     </button>
   </mat-card>
 </main>

--- a/frontend/src/app/complaint/complaint.component.html
+++ b/frontend/src/app/complaint/complaint.component.html
@@ -3,65 +3,93 @@
   ~ SPDX-License-Identifier: MIT
 -->
 
-<div class="center-container">
+<main class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6">
-    <div class="mdc-card">
+    <h1>{{ 'NAV_COMPLAIN' | translate }}</h1>
 
-      <h1>{{"NAV_COMPLAIN" | translate}}</h1>
+    <section aria-live="polite">
+      <p class="confirmation" [hidden]="!(confirmation && !messageControl.dirty)">
+        {{ confirmation }}
+      </p>
 
-      <div class="confirmation" [hidden]="!(confirmation && !messageControl.dirty)">{{ confirmation }}</div>
-
-      @if ((fileUploadError && fileUploadError.name == 'mimeType')) {
-        <div class="error fileUploadError">{{
-          "INVALID_FILE_TYPE" | translate: { type: 'PDF, ZIP' } }}
-        </div>
+      @if (fileUploadError && fileUploadError.name == 'mimeType') {
+        <p class="error fileUploadError" role="alert">
+          {{ 'INVALID_FILE_TYPE' | translate: { type: 'PDF, ZIP' } }}
+        </p>
       }
-      @if ((fileUploadError && fileUploadError.name == 'fileSize')) {
-        <div class="error fileUploadError">{{
-          "INVALID_FILE_SIZE" | translate: { size: '100 KB' } }}
-        </div>
+      @if (fileUploadError && fileUploadError.name == 'fileSize') {
+        <p class="error fileUploadError" role="alert">
+          {{ 'INVALID_FILE_SIZE' | translate: { size: '100 KB' } }}
+        </p>
       }
+    </section>
 
-      <div class="form-container" id="complaint-form">
+    <form class="form-container" id="complaint-form">
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>{{ 'LABEL_CUSTOMER' | translate }}</mat-label>
+        <input
+          [formControl]="customerControl"
+          type="text"
+          matInput
+          aria-label="Text field for the mail address of the user"
+        />
+      </mat-form-field>
 
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label >{{"LABEL_CUSTOMER" | translate }}</mat-label>
-          <input [formControl]="customerControl" type="text" matInput aria-label="Text field for the mail address of the user">
-        </mat-form-field>
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>{{ 'LABEL_MESSAGE' | translate }}</mat-label>
+        <mat-hint>
+          <i class="fas fa-exclamation-circle"></i>
+          <em>{{ 'MAX_TEXTAREA_LENGTH' | translate: { length: '160' } }}</em>
+        </mat-hint>
+        <textarea
+          #complaintMessage
+          id="complaintMessage"
+          [formControl]="messageControl"
+          matAutosizeMinRows="4"
+          matAutosizeMaxRows="4"
+          matTextareaAutosize
+          cols="50"
+          maxlength="160"
+          matInput
+          placeholder="{{ 'WRITE_MESSAGE_PLACEHOLDER' | translate }}"
+          aria-label="Field for entering the complaint"
+          aria-required="true"
+          aria-describedby="messageCounter"
+        ></textarea>
+        @if (messageControl.invalid && messageControl?.errors.required) {
+          <mat-error role="alert">{{ 'MANDATORY_MESSAGE' | translate }} </mat-error>
+        }
+        <mat-hint align="end" id="messageCounter">
+          <output>{{ complaintMessage.value?.length || 0 }}</output
+          >/160
+        </mat-hint>
+      </mat-form-field>
 
-        <mat-form-field appearance="outline" color="accent">
-          <mat-label>{{"LABEL_MESSAGE" | translate}}</mat-label>
-          <mat-hint>
-            <i class="fas fa-exclamation-circle"></i>
-            <em style="margin-left:5px;">{{ 'MAX_TEXTAREA_LENGTH' | translate: {length: '160'} }}</em>
-          </mat-hint>
-          <textarea #complaintMessage id="complaintMessage" [formControl]="messageControl" matAutosizeMinRows="4" matAutosizeMaxRows="4"
-            matTextareaAutosize cols="50" maxlength="160" matInput
-            placeholder="{{ 'WRITE_MESSAGE_PLACEHOLDER' | translate}}"
-          aria-label="Field for entering the complaint"></textarea>
-          @if (messageControl.invalid && messageControl?.errors.required) {
-            <mat-error>{{"MANDATORY_MESSAGE" |
-              translate}}
-            </mat-error>
-          }
-          <mat-hint align="end">{{complaintMessage.value?.length || 0}}/160</mat-hint>
-        </mat-form-field>
+      <p class="invoice">
+        <label for="file">{{ 'LABEL_INVOICE' | translate }}<span>:</span></label>
+        <input
+          #fileControl
+          ng2FileSelect
+          [uploader]="uploader"
+          id="file"
+          type="file"
+          accept=".pdf,.zip"
+          aria-label="Input area for uploading a single invoice PDF or XML B2B order file or a ZIP archive containing multiple invoices or orders<!---->"
+        />
+      </p>
+    </form>
 
-        <div class="invoice">
-          <label for="file">{{"LABEL_INVOICE" | translate }}<span>:</span></label>
-          <input #fileControl ng2FileSelect [uploader]="uploader" id="file" type="file" accept=".pdf,.zip" style="margin-left: 10px;" aria-label="Input area for uploading a single invoice PDF or XML B2B order file or a ZIP archive containing multiple invoices or orders<!---->">
-        </div>
-
-      </div>
-
-      <button type="submit" id="submitButton" [disabled]="messageControl.invalid || fileUploadError" (click)="save()"
-        mat-raised-button color="primary" aria-label="Button to send the complaint">
-        <mat-icon>
-          send
-        </mat-icon>
-        {{'BTN_SUBMIT' | translate}}
-      </button>
-
-    </div>
+    <button
+      type="submit"
+      id="submitButton"
+      [disabled]="messageControl.invalid || fileUploadError"
+      (click)="save()"
+      mat-raised-button
+      color="primary"
+      aria-label="Button to send the complaint"
+    >
+      <mat-icon> send </mat-icon>
+      {{ 'BTN_SUBMIT' | translate }}
+    </button>
   </mat-card>
-</div>
+</main>

--- a/frontend/src/app/complaint/complaint.component.scss
+++ b/frontend/src/app/complaint/complaint.component.scss
@@ -6,8 +6,8 @@
 mat-card {
   height: auto;
   min-width: 320px;
-  width: 30%;
   padding: 16px;
+  width: 30%;
 }
 
 mat-form-field {

--- a/frontend/src/app/complaint/complaint.component.scss
+++ b/frontend/src/app/complaint/complaint.component.scss
@@ -7,6 +7,7 @@ mat-card {
   height: auto;
   min-width: 320px;
   width: 30%;
+  padding: 16px;
 }
 
 mat-form-field {
@@ -25,6 +26,10 @@ mat-form-field {
   width: 60%;
 }
 
+#file {
+  margin-left: 10px;
+}
+
 .mdc-card {
   border: 0;
 }
@@ -39,6 +44,7 @@ em {
   color: var(--theme-text-fade-30) !important;
   display: flex;
   font-size: 11px;
+  margin-left: 5px;
   white-space: nowrap;
 }
 
@@ -55,4 +61,8 @@ em {
   align-items: stretch;
   display: flex;
   justify-content: center;
+}
+
+p {
+  margin: 0;
 }

--- a/frontend/src/app/last-login-ip/last-login-ip.component.html
+++ b/frontend/src/app/last-login-ip/last-login-ip.component.html
@@ -3,9 +3,10 @@
   ~ SPDX-License-Identifier: MIT
   -->
 
-<mat-card appearance="outlined" class="ipCard mat-elevation-z6" >
-  <div class="mdc-card">
-    <h1 translate>LAST_LOGIN_IP</h1>
-    <p style="margin-bottom: 15px;"><span translate>IP_ADDRESS</span>&nbsp;&nbsp;<span [innerHTML]="lastLoginIp"></span></p>
-  </div>
+<mat-card appearance="outlined" class="ipCard mat-elevation-z6">
+  <h1 translate>LAST_LOGIN_IP</h1>
+  <dl>
+    <dt translate>IP_ADDRESS</dt>
+    <dd [innerHTML]="lastLoginIp"></dd>
+  </dl>
 </mat-card>

--- a/frontend/src/app/last-login-ip/last-login-ip.component.html
+++ b/frontend/src/app/last-login-ip/last-login-ip.component.html
@@ -2,11 +2,12 @@
   ~ Copyright (c) 2014-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
   ~ SPDX-License-Identifier: MIT
   -->
-
-<mat-card appearance="outlined" class="ipCard mat-elevation-z6">
-  <h1 translate>LAST_LOGIN_IP</h1>
-  <dl>
-    <dt translate>IP_ADDRESS</dt>
-    <dd [innerHTML]="lastLoginIp"></dd>
-  </dl>
-</mat-card>
+<main>
+  <mat-card appearance="outlined" class="ipCard mat-elevation-z6">
+    <h1 translate>LAST_LOGIN_IP</h1>
+    <dl>
+      <dt translate>IP_ADDRESS</dt>
+      <dd [innerHTML]="lastLoginIp"></dd>
+    </dl>
+  </mat-card>
+</main>

--- a/frontend/src/app/last-login-ip/last-login-ip.component.scss
+++ b/frontend/src/app/last-login-ip/last-login-ip.component.scss
@@ -10,5 +10,17 @@
   margin-right: auto;
   margin-top: 0;
   min-width: 320px;
+  padding: 16px;
   width: 25%;
+}
+
+
+dl {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto 1fr;
+}
+
+dd {
+  margin: 0;
 }


### PR DESCRIPTION
### Description
This PR enhances the **Last Login IP** and **Complain** pages by improving its semantic structure and accessibility while maintaining the existing visual design. It continues the effort to refactor the codebase and enhance the separation of markup and styles, as part of the upcoming [Signal migration](https://github.com/juice-shop/juice-shop/issues/2653).

### Changes made
#### Last Login IP
- Replaced non-semantic elements with a definition list (`<dl>`, `<dt>`, `<dd>`) to properly associate labels and values.  
- Removed unnecessary inline styles

##### Complain
- Replaced outer `<div>` with `<main>` for main content.  
- Added `<section aria-live="polite">` around confirmation and error messages.  
- Changed error and confirmation `<div>` elements to `<p>` for proper semantics.  
- Added `role="alert"` to error messages for accessibility.  
- Replaced the wrapper `<div class="form-container">` with a `<form>` element.  
- Added `aria-required` and `aria-describedby` to inputs and textarea.  
- Used `<output>` for the live character counter.  
- Changed `<div class="invoice">` to `<p class="invoice">`.  
- Removed unnecessary inner `<div class="mdc-card">`.  
- Cleaned up spacing and standardized translation quotes.

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines