### PR TITLE
Clarify application setup help instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Please make sure you stay up to date with your chosen version.
 
 [![Gitter](http://img.shields.io/badge/gitter-join%20chat-1dce73.svg)](https://gitter.im/bkimminich/juice-shop)
 
-If you need help with the application setup please check our
+If you need help with the application setup please check 
 [our existing _Troubleshooting_](https://pwning.owasp-juice.shop/companion-guide/latest/part4/troubleshooting.html)
 guide. If this does not solve your issue please post your specific problem or question in the
 [Gitter Chat](https://gitter.im/bkimminich/juice-shop) where community members can best try to help you.


### PR DESCRIPTION
Hi,

I was reading the `README.md` file and found a small typo in the "Troubleshooting" section.

The file contains a repeated word:
"If you need help with the application setup please check our [our existing _Troubleshooting_] guide."

This PR removes the extra "our" (on line 158) for clarity.