### PR TITLE
Fix/2818 add types basket component

### DIFF
--- a/frontend/src/app/basket/basket.component.spec.ts
+++ b/frontend/src/app/basket/basket.component.spec.ts
@@ -79,6 +79,6 @@ describe('BasketComponent', () => {
   it('should store itemTotal in session storage', () => {
     spyOn(sessionStorage, 'setItem')
     component.getBonusPoints([1, 10])
-    expect(sessionStorage.setItem).toHaveBeenCalledWith('itemTotal', 1 as any)
+    expect(sessionStorage.setItem).toHaveBeenCalledWith('itemTotal', '1')
   })
 })

--- a/frontend/src/app/basket/basket.component.ts
+++ b/frontend/src/app/basket/basket.component.ts
@@ -24,19 +24,19 @@ export class BasketComponent {
   private readonly router = inject(Router);
   private readonly ngZone = inject(NgZone);
 
-  public productCount = 0
-  public bonus = 0
+  public productCount: number = 0
+  public bonus: number = 0
 
-  checkout () {
+  checkout (): void {
     this.ngZone.run(async () => await this.router.navigate(['/address/select']))
   }
 
-  getProductCount (total) {
+  getProductCount (total: number): void {
     this.productCount = total
   }
 
-  getBonusPoints (total) {
-    sessionStorage.setItem('itemTotal', total[0])
+  getBonusPoints (total: [number, number]): void {
+    sessionStorage.setItem('itemTotal', total[0].toString())
     this.bonus = total[1]
   }
 }

--- a/frontend/src/app/basket/basket.component.ts
+++ b/frontend/src/app/basket/basket.component.ts
@@ -24,8 +24,8 @@ export class BasketComponent {
   private readonly router = inject(Router);
   private readonly ngZone = inject(NgZone);
 
-  public productCount: number = 0
-  public bonus: number = 0
+  public productCount = 0
+  public bonus = 0
 
   checkout (): void {
     this.ngZone.run(async () => await this.router.navigate(['/address/select']))


### PR DESCRIPTION
### Description
This pull request adds missing TypeScript type annotations to the BasketComponent as described in issue #2818.
These methods previously used implicit `any` types, which reduced type safety and IDE support.

### Changes included
- Added `number` type to `getProductCount(total: number)`
- Added tuple type `[number, number]` to `getBonusPoints(total: [number, number])`
- Added explicit return type `void` to `checkout(): void`

Preserves existing logic while improving type safety and maintainability.

Fixes #2818

### Tests
All unit, integration, and end-to-end tests pass locally.

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
