### PR TITLE
Bug Report – Deluxe Membership Page UI Issues (#2832)

### DIFF
--- a/frontend/src/app/deluxe-user/deluxe-user.component.html
+++ b/frontend/src/app/deluxe-user/deluxe-user.component.html
@@ -22,9 +22,10 @@
     <strong class="item-name" translate="">LABEL_DELUXE_MEMBERSHIP</strong>
     <span translate [translateParams]="{appname: applicationName}">DESCRIPTION_DELUXE_MEMBERSHIP</span>
     @if (!error) {
-      <span>
-        {{ membershipCost }}&curren;
-      </span>
+      <div class="price-section">
+        <span class="amount">{{ membershipCost }}</span>
+        <span class="currency">¤</span>
+      </div>
       <button (click)="upgradeToDeluxe()" aria-label="Become deluxe member" class="btn-become-member" color="primary"
         mat-button mat-raised-button>
         <span translate>LABEL_BECOME_MEMBER</span>

--- a/frontend/src/app/deluxe-user/deluxe-user.component.scss
+++ b/frontend/src/app/deluxe-user/deluxe-user.component.scss
@@ -31,18 +31,48 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    padding: 16px;
+    gap: 16px;
+    padding: 24px;
     text-align: center;
   }
 
+  .price-section {
+    align-items: baseline;
+    display: flex;
+    gap: 4px;
+    margin: 8px 0;
+  }
+
   .btn-become-member {
-    width: min-content;
+    border-radius: 8px;
+    font-weight: 500;
+    min-width: 160px;
+    padding: 12px 24px;
+    text-transform: uppercase;
+    transition: all 0.2s ease-in-out;
+    white-space: nowrap;
   }
 
   @media screen and (max-width: 768px) {
     grid-template-columns: 1fr;
   }
+}
+
+.amount {
+  color: #1976d2;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.currency {
+  color: #666;
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.btn-become-member:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  transform: translateY(-1px);
 }
 
 .feature-cards-container {


### PR DESCRIPTION
### Description
The Deluxe Membership page had visual rendering issues that affected user experience:

Currency symbol displayed as corrupted "ə" instead of proper "¤"

"Become a member" button lacked proper spacing and styling

Poor visual hierarchy in price display
Fixes #2832 

### Screenshots
### BEFORE FIX
<img width="1483" height="745" alt="Screenshot from 2025-11-05 23-21-22" src="https://github.com/user-attachments/assets/9630c98b-5caa-4830-8f4a-b2216d3d61ab" />

### AFTER FIX
<img width="1846" height="956" alt="Screenshot from 2025-11-06 00-36-51" src="https://github.com/user-attachments/assets/9b5bc321-06fd-49ca-99b7-5930018c7ec4" />

### Changes Made

 Price Display: Separated amount and currency with proper spacing
Button Styling: Adjusted spacing and visual hierarchy for better clarity
Overall Layout: Fixed alignment and spacing issues to improve readability

### Know Issues
All tests relevant to this feature pass.

Note: The test suite chatBotSpec.ts currently fails due to an empty/corrupt JSON file in data/chatbot/. This is unrelated to the Deluxe Membership changes and does not affect functionality

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines

