### PR TITLE
fix: prevent unnecessary DOM re-creation and resolve NG0956 warnings 

### DIFF
--- a/frontend/src/app/payment-method/payment-method.component.html
+++ b/frontend/src/app/payment-method/payment-method.component.html
@@ -33,7 +33,7 @@
           </mat-cell>
         </ng-container>
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-        <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns; trackBy: trackByCardId"></mat-row>
       </mat-table>
     </div>
   }
@@ -75,7 +75,7 @@
         <mat-form-field class="half-field" appearance="outline" color="accent">
           <mat-label translate>LABEL_EXPIRY_MONTH</mat-label>
           <select matNativeControl [formControl]="monthControl" required>
-            @for (i of monthRange; track i) {
+            @for (i of monthRange; track $index) {
               <option value="{{ i }}">{{ i }}</option>
             }
           </select>
@@ -88,7 +88,7 @@
         <mat-form-field class="half-field" appearance="outline" color="accent">
           <mat-label translate>LABEL_EXPIRY_YEAR</mat-label>
           <select matNativeControl [formControl]="yearControl" required>
-            @for (i of yearRange; track i) {
+            @for (i of yearRange; track $index) {
               <option value="{{ i }}">{{ i }}</option>
             }
           </select>

--- a/frontend/src/app/payment-method/payment-method.component.ts
+++ b/frontend/src/app/payment-method/payment-method.component.ts
@@ -22,6 +22,10 @@ import { MatIconModule } from '@angular/material/icon'
 
 library.add(faPaperPlane, faTrashAlt)
 
+interface PaymentCard {
+  id: number
+}
+
 @Component({
   selector: 'app-payment-method',
   templateUrl: './payment-method.component.html',
@@ -46,9 +50,9 @@ export class PaymentMethodComponent implements OnInit {
   public error: any
   public storedCards: any
   public card: any = {}
-  public dataSource
-  public monthRange: any[]
-  public yearRange: any[]
+  public dataSource: any
+  public monthRange!: any[]
+  public yearRange!: any[]
   public cardsExist = false
   public paymentId: any = undefined
 
@@ -68,7 +72,7 @@ export class PaymentMethodComponent implements OnInit {
       next: (cards) => {
         this.cardsExist = cards.length
         this.storedCards = cards
-        this.dataSource = new MatTableDataSource<Element>(this.storedCards)
+        this.dataSource = new MatTableDataSource(this.storedCards)
       },
       error: (err) => { console.log(err) }
     })
@@ -100,7 +104,7 @@ export class PaymentMethodComponent implements OnInit {
     })
   }
 
-  delete (id) {
+  delete (id: any) {
     this.paymentService.del(id).subscribe({
       next: () => {
         this.load()
@@ -128,11 +132,7 @@ export class PaymentMethodComponent implements OnInit {
     this.yearControl.setValue('')
   }
 
-  trackByValue(index: number, value: any): any {
-    return value;
-  }
-
-  trackByCardId(index: number, item: any): any {
-    return item.id || index;
+  trackByCardId(index: number, item: PaymentCard): number {
+    return item.id ?? index;
   }
 }

--- a/frontend/src/app/payment-method/payment-method.component.ts
+++ b/frontend/src/app/payment-method/payment-method.component.ts
@@ -127,4 +127,12 @@ export class PaymentMethodComponent implements OnInit {
     this.yearControl.markAsPristine()
     this.yearControl.setValue('')
   }
+
+  trackByValue(index: number, value: any): any {
+    return value;
+  }
+
+  trackByCardId(index: number, item: any): any {
+    return item.id || index;
+  }
 }

--- a/frontend/src/app/search-result/search-result.component.html
+++ b/frontend/src/app/search-result/search-result.component.html
@@ -21,7 +21,7 @@
     @if (!emptyState) {
       <div>
         <mat-grid-list #table (window:resize)="onResize($event)" [cols]="breakpoint" gutterSize="30px">
-          @for (item of gridDataSource | async; track item) {
+          @for (item of gridDataSource | async; track trackByProductId($index, item)) {
             <mat-grid-tile>
               <mat-card appearance="outlined" [style.width]="'100%'" class="mat-elevation-z6 ribbon-card">
                 <div class="mdc-card">

--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -297,7 +297,7 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
     return this.deluxeGuard.isDeluxe()
   }
 
-  trackByProductId(index: number, item: any): any {
-    return item.id || index;
+  trackByProductId(index: number, item: Product): number {
+    return item.id ?? index;
   }
 }

--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -296,4 +296,8 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
   isDeluxe () {
     return this.deluxeGuard.isDeluxe()
   }
+
+  trackByProductId(index: number, item: any): any {
+    return item.id || index;
+  }
 }


### PR DESCRIPTION
### Description
This PR fixes Angular’s NG0956 warning that appeared in the PaymentMethodComponent and SearchResultComponent due to unstable tracking expressions in @for loops and mat-table rows.

### Problem
Some template loops were using tracking expressions that did not uniquely identify items in the collection.
As a result, Angular recreated entire DOM lists on each change detection cycle, which could reduce rendering efficiency.

### Fix Implemented
Added trackByValue() and trackByCardId() functions in PaymentMethodComponent.
Added trackByProductId() in SearchResultComponent.
Updated templates to use stable tracking for all @for and *matRowDef directives.
Verified that UI behavior and data bindings remain unchanged

### Result
Removes NG0956 warnings from console.
Improves rendering performance by allowing Angular to reuse DOM nodes.
Aligns templates with recommended best practices for list rendering.

Fixes #2837 

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines