### PR TITLE
Fix request button icon and spacing on data export page

### DIFF
--- a/frontend/src/app/data-export/data-export.component.html
+++ b/frontend/src/app/data-export/data-export.component.html
@@ -49,7 +49,7 @@
         <button type="submit" id="submitButton" color="primary" mat-raised-button (click)="save()"
           [disabled]="formatControl.invalid || (captchaControl.invalid && presenceOfCaptcha)"
           aria-label="Button to send the request">
-          <mat-icon aria-hidden="true">file_download</mat-icon>
+          <mat-icon aria-hidden="true" fontIcon="file_download"></mat-icon>
           {{'BTN_REQUEST' | translate}}
         </button>
         <div class="hint">

--- a/frontend/src/app/data-export/data-export.component.html
+++ b/frontend/src/app/data-export/data-export.component.html
@@ -46,10 +46,10 @@
             </div>
           }
         </div>
-        <button type="submit" style="margin-top: 15px;" id="submitButton" color="primary" mat-raised-button (click)="save()"
+        <button type="submit" id="submitButton" color="primary" mat-raised-button (click)="save()"
           [disabled]="formatControl.invalid || (captchaControl.invalid && presenceOfCaptcha)"
           aria-label="Button to send the request">
-          <mat-icon>download</mat-icon>
+          <mat-icon aria-hidden="true">file_download</mat-icon>
           {{'BTN_REQUEST' | translate}}
         </button>
         <div class="hint">

--- a/frontend/src/app/data-export/data-export.component.html
+++ b/frontend/src/app/data-export/data-export.component.html
@@ -52,9 +52,9 @@
           <mat-icon aria-hidden="true" fontIcon="file_download"></mat-icon>
           {{'BTN_REQUEST' | translate}}
         </button>
-        <div class="hint">
+        <p class="hint">
           <span translate>DATA_EXPORT_HINT</span>
-        </div>
+        </p>
       </div>
     </mat-card>
   </div>

--- a/frontend/src/app/data-export/data-export.component.scss
+++ b/frontend/src/app/data-export/data-export.component.scss
@@ -13,8 +13,8 @@ mat-card {
 }
 
 #submitButton {
-  margin-top: 30px;
   margin-left: 20%;
+  margin-top: 30px;
   width: 60%;
 }
 

--- a/frontend/src/app/data-export/data-export.component.scss
+++ b/frontend/src/app/data-export/data-export.component.scss
@@ -13,6 +13,7 @@ mat-card {
 }
 
 #submitButton {
+  margin-top: 30px;
   margin-left: 20%;
   width: 60%;
 }

--- a/frontend/src/app/data-export/data-export.component.scss
+++ b/frontend/src/app/data-export/data-export.component.scss
@@ -22,6 +22,7 @@ mat-card {
   display: flex;
   font-size: 10px;
   justify-content: center;
+  margin-bottom: 0;
   margin-top: 5px;
 }
 


### PR DESCRIPTION
### Description

Fixed icon rendering problem in request button on data export page. This problem is related with #2844 and #2835.

Screenshots were taken using Chrome DevTools → Device Toolbar → Samsung Galaxy S8+ (360x740px).
<img width="734" height="747" alt="image" src="https://github.com/user-attachments/assets/491709b1-45ea-40c7-af27-08b45936d308" />


### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
