### PR TITLE
fix(angular): Resolve NG0956 warning in payment method select loops

### DIFF
--- a/frontend/src/app/payment-method/payment-method.component.html
+++ b/frontend/src/app/payment-method/payment-method.component.html
@@ -75,7 +75,7 @@
         <mat-form-field class="half-field" appearance="outline" color="accent">
           <mat-label translate>LABEL_EXPIRY_MONTH</mat-label>
           <select matNativeControl [formControl]="monthControl" required>
-            @for (i of monthRange; track i) {
+            @for (i of monthRange; let idx = $index; track idx) {
               <option value="{{ i }}">{{ i }}</option>
             }
           </select>
@@ -88,7 +88,7 @@
         <mat-form-field class="half-field" appearance="outline" color="accent">
           <mat-label translate>LABEL_EXPIRY_YEAR</mat-label>
           <select matNativeControl [formControl]="yearControl" required>
-            @for (i of yearRange; track i) {
+            @for (i of yearRange; let idx = $index; track idx) {
               <option value="{{ i }}">{{ i }}</option>
             }
           </select>


### PR DESCRIPTION
This PR fixes the NG0956 warning that appears on the Payment Method page.

Angular showed this warning due to unstable tracking expressions in @for loops:
- @for (i of monthRange; track i)
- @for (i of yearRange; track i)

Angular re-created the entire DOM subtree on every change detection cycle,
causing performance issues and NG0956 warnings.

✔ Fix:
Replaced identity tracking with stable index tracking (track idx using $index).

✔ Testing:
- Opened Payment Method page
- NG0956 warnings no longer appear in the console
- UI behavior remains unchanged