### PR TITLE
refactor: replace inline styles with CSS class in AddressComponent

### DIFF
--- a/frontend/src/app/address/address.component.html
+++ b/frontend/src/app/address/address.component.html
@@ -14,7 +14,7 @@
     @if (addressExist) {
       <mat-table [dataSource]="dataSource" class="address-table">
         <ng-container matColumnDef="Selection">
-          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="hidden-header"></mat-header-cell>
           <mat-cell *matCellDef="let element; let row">
             <mat-radio-button
               (click)="emitSelectionToParent(element.id)"
@@ -24,25 +24,25 @@
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="Name">
-          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="hidden-header"></mat-header-cell>
           <mat-cell *matCellDef="let element">
             {{ element?.fullName }}
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="Address">
-          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="hidden-header"></mat-header-cell>
           <mat-cell *matCellDef="let element">
             {{ element?.streetAddress }}, {{ element?.city }}, {{ element?.state }}, {{ element?.zipCode }}
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="Country">
-          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="hidden-header"></mat-header-cell>
           <mat-cell *matCellDef="let element">
             {{ element?.country }}
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="Edit">
-          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="hidden-header"></mat-header-cell>
           <mat-cell *matCellDef="let element">
             <button mat-icon-button routerLink="/address/edit/{{ element.id }}">
               <i class="far fa-edit"></i>
@@ -50,7 +50,7 @@
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="Remove">
-          <mat-header-cell *matHeaderCellDef style="display: none;"></mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="hidden-header"></mat-header-cell>
           <mat-cell *matCellDef="let element">
             <button mat-icon-button (click)="deleteAddress(element.id)">
               <i class="far fa-trash-alt"></i>

--- a/frontend/src/app/address/address.component.scss
+++ b/frontend/src/app/address/address.component.scss
@@ -76,3 +76,8 @@ svg {
 .add-new-address {
   margin-top: 20px;
 }
+
+/* Refactoring inline styles */
+.hidden-header {
+  display: none;
+}


### PR DESCRIPTION
### Description

Refactored inline styles in `AddressComponent` to use proper SCSS classes. 
Specifically, replaced multiple instances of `style="display: none;"` with a new `.hidden-header` class defined in the component's SCSS file. 
This aligns with the project's goal of frontend modernization and removing inline styles for better maintainability.

Resolved or fixed issue: none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines