### PR TITLE
refactor: replace any with unknown in backend catch blocks

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -179,8 +179,8 @@ export const appendUserId = () => {
     try {
       req.body.UserId = authenticatedUsers.tokenMap[utils.jwtFrom(req)].data.id
       next()
-    } catch (error: any) {
-      res.status(401).json({ status: 'error', message: error })
+    } catch (error: unknown) {
+      res.status(401).json({ status: 'error', message: utils.getErrorMessage(error) })
     }
   }
 }

--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -85,8 +85,9 @@ function handleXmlUpload ({ file }: Request, res: Response, next: NextFunction) 
         challengeUtils.solveIf(challenges.xxeFileDisclosureChallenge, () => { return (utils.matchesEtcPasswdFile(xmlString) || utils.matchesSystemIniFile(xmlString)) })
         res.status(410)
         next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + utils.trunc(xmlString, 400) + ' (' + file.originalname + ')'))
-      } catch (err: any) { // TODO: Remove any
-        if (utils.contains(err.message, 'Script execution timed out')) {
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err)
+        if (utils.contains(errorMessage, 'Script execution timed out')) {
           if (challengeUtils.notSolved(challenges.xxeDosChallenge)) {
             challengeUtils.solve(challenges.xxeDosChallenge)
           }
@@ -94,7 +95,7 @@ function handleXmlUpload ({ file }: Request, res: Response, next: NextFunction) 
           next(new Error('Sorry, we are temporarily not available! Please try again later.'))
         } else {
           res.status(410)
-          next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + err.message + ' (' + file.originalname + ')'))
+          next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + errorMessage + ' (' + file.originalname + ')'))
         }
       }
     } else {
@@ -116,8 +117,9 @@ function handleYamlUpload ({ file }: Request, res: Response, next: NextFunction)
         const yamlString = vm.runInContext('JSON.stringify(yaml.load(data))', sandbox, { timeout: 2000 })
         res.status(410)
         next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + utils.trunc(yamlString, 400) + ' (' + file.originalname + ')'))
-      } catch (err: any) { // TODO: Remove any
-        if (utils.contains(err.message, 'Invalid string length') || utils.contains(err.message, 'Script execution timed out')) {
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err)
+        if (utils.contains(errorMessage, 'Invalid string length') || utils.contains(errorMessage, 'Script execution timed out')) {
           if (challengeUtils.notSolved(challenges.yamlBombChallenge)) {
             challengeUtils.solve(challenges.yamlBombChallenge)
           }
@@ -125,7 +127,7 @@ function handleYamlUpload ({ file }: Request, res: Response, next: NextFunction)
           next(new Error('Sorry, we are temporarily not available! Please try again later.'))
         } else {
           res.status(410)
-          next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + err.message + ' (' + file.originalname + ')'))
+          next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + errorMessage + ' (' + file.originalname + ')'))
         }
       }
     } else {


### PR DESCRIPTION
### Description

This PR removes remaining any types from backend catch blocks and replaces them with the safer and TypeScript-recommended unknown type. It then applies proper error narrowing using 
err instanceof Error ? err.message : String(err)

This improves type safety, aligns error-handling with existing backend conventions , and resolves the TODO comments in the affected files.

### Files updated:

1.routes/fileUpload.ts – replaced two catch (err: any) blocks with unknown and added safe narrowing
2. lib/insecurity.ts – replaced catch (error: any) with unknown and updated the response to use utils.getErrorMessage(error)
No logic changes were made; only type-safety improvements.

Fixes #2883 

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
