### PR TITLE
fix: remove hardcoded RSA private key and load from environment variable

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,4 +1,5 @@
 name: SonarCloud
+
 on:
   push:
     branches:
@@ -24,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
-          SONAR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "24"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,30 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - master
+      - fix/**
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Build & Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Environment
+.env
+
 # App
 node_modules/
 juiceshop.sqlite

--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+import 'dotenv/config';
 import fs from 'node:fs'
 import crypto from 'node:crypto'
 import { type Request, type Response, type NextFunction } from 'express'
@@ -20,8 +21,7 @@ import * as utils from './utils'
 import * as z85 from 'z85'
 
 export const publicKey = fs ? fs.readFileSync('encryptionkeys/jwt.pub', 'utf8') : 'placeholder-public-key'
-const privateKey = '-----BEGIN RSA PRIVATE KEY-----\r\nMIICXAIBAAKBgQDNwqLEe9wgTXCbC7+RPdDbBbeqjdbs4kOPOIGzqLpXvJXlxxW8iMz0EaM4BKUqYsIa+ndv3NAn2RxCd5ubVdJJcX43zO6Ko0TFEZx/65gY3BE0O6syCEmUP4qbSd6exou/F+WTISzbQ5FBVPVmhnYhG/kpwt/cIxK5iUn5hm+4tQIDAQABAoGBAI+8xiPoOrA+KMnG/T4jJsG6TsHQcDHvJi7o1IKC/hnIXha0atTX5AUkRRce95qSfvKFweXdJXSQ0JMGJyfuXgU6dI0TcseFRfewXAa/ssxAC+iUVR6KUMh1PE2wXLitfeI6JLvVtrBYswm2I7CtY0q8n5AGimHWVXJPLfGV7m0BAkEA+fqFt2LXbLtyg6wZyxMA/cnmt5Nt3U2dAu77MzFJvibANUNHE4HPLZxjGNXN+a6m0K6TD4kDdh5HfUYLWWRBYQJBANK3carmulBwqzcDBjsJ0YrIONBpCAsXxk8idXb8jL9aNIg15Wumm2enqqObahDHB5jnGOLmbasizvSVqypfM9UCQCQl8xIqy+YgURXzXCN+kwUgHinrutZms87Jyi+D8Br8NY0+Nlf+zHvXAomD2W5CsEK7C+8SLBr3k/TsnRWHJuECQHFE9RA2OP8WoaLPuGCyFXaxzICThSRZYluVnWkZtxsBhW2W8z1b8PvWUE7kMy7TnkzeJS2LSnaNHoyxi7IaPQUCQCwWU4U+v4lD7uYBw00Ga/xt+7+UqFPlPVdz1yyr4q24Zxaw0LgmuEvgU5dycq8N7JxjTubX0MIRR+G9fmDBBl8=\r\n-----END RSA PRIVATE KEY-----'
-
+const privateKey = process.env.RSA_PRIVATE_KEY ?? '';
 interface ResponseWithUser {
   status?: string
   data: UserModel

--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import 'dotenv/config';
+import 'dotenv/config'
 import fs from 'node:fs'
 import crypto from 'node:crypto'
 import { type Request, type Response, type NextFunction } from 'express'
@@ -21,7 +21,7 @@ import * as utils from './utils'
 import * as z85 from 'z85'
 
 export const publicKey = fs ? fs.readFileSync('encryptionkeys/jwt.pub', 'utf8') : 'placeholder-public-key'
-const privateKey = process.env.RSA_PRIVATE_KEY ?? '';
+const privateKey = process.env.RSA_PRIVATE_KEY ?? ''
 interface ResponseWithUser {
   status?: string
   data: UserModel

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "config": "^3.3.12",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.3",
     "dottie": "^2.0.6",
     "download": "^8.0.0",
     "errorhandler": "^1.5.1",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=saadi-09
+sonar.organization=Saadi-09
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.sources=.
+sonar.exclusions=**/node_modules/**,**/dist/**,**/.env


### PR DESCRIPTION
PR Description
✅ Summary

This PR removes a critical security vulnerability: the hardcoded RSA private key in the source file (insecurity.ts).
Instead of embedding the private key in code (which exposes it in version control and makes it visible to SAST tools), the key is now loaded from an environment variable at runtime. This matches secure coding practices and prevents accidental exposure of sensitive data.

🔧 What was done

Created an .env file (not committed) to store RSA_PRIVATE_KEY.

Added the .env file (and other environment files if generated) to .gitignore to prevent accidental commits of secrets.

Updated insecurity.ts (and any other relevant source points) to load the private key via process.env.RSA_PRIVATE_KEY instead of a hardcoded string.

(If needed) Installed dotenv (or equivalent) and ensured environment variables are loaded early in the server startup code.

Ensured all existing uses of the private key reference the environment variable, with no hardcoded fallback.

✅ Why this is necessary

Hardcoded private keys are a critical security flaw — they risk exposure via source control, build logs, or accidental sharing.

This change mitigates the flaw and brings the code in line with secure development best practices (separation of secrets from source code).

Prevents future SAST (static-analysis) findings for “hardcoded secret” issues.

🧪 Verification

Locally tested the application under Node 24 (as proposed for this fork) the app starts without runtime errors and the private key is correctly read from the environment.

With this change, no hardcoded key remains in the committed source code.

🔐 Notes / Recommendations

The real RSA private key must never be committed, the .env approach ensures it remains local/secret.