### PR TITLE
Migrate star rating UI to <meter> element

### DIFF
--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
@@ -1,1 +1,7 @@
-<meter class="rating" [min]="0" [max]="6" [value]="difficulty"></meter>
+<span class="stars" 
+      role="img" 
+      [attr.aria-label]="'Difficulty ' + difficulty + ' of 6'">
+  @for (i of [1,2,3,4,5,6]; track i) {
+    <span class="star" [class.filled]="i <= difficulty" aria-hidden="true">★</span>
+  }
+</span>

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
@@ -1,7 +1,7 @@
-<span class="stars" 
-      role="img" 
-      [attr.aria-label]="'Difficulty ' + difficulty + ' of 6'">
-  @for (i of [1,2,3,4,5,6]; track i) {
-    <span class="star" [class.filled]="i <= difficulty" aria-hidden="true">★</span>
+<span class="stars"
+      role="img"
+      [attr.aria-label]="ariaLabel()">
+  @for (i of stars(); track i) {
+    <span class="star" [class.filled]="i <= difficulty()" aria-hidden="true">★</span>
   }
 </span>

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
@@ -1,14 +1,1 @@
-@for (_ of [].constructor(difficulty); track _) {
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 14 13"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    >
-    <path
-      d="M6.56386 0.511963L8.10332 5.24992H13.0851L9.05475 8.17813L10.5942 12.9161L6.56386 9.98787L2.53352 12.9161L4.07297 8.17813L0.0426283 5.24992H5.02441L6.56386 0.511963Z"
-      fill="var(--theme-text)"
-      />
-    </svg>
-  }
+<meter class="rating" [min]="0" [max]="6" [value]="difficulty"></meter>

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.html
@@ -2,6 +2,6 @@
       role="img"
       [attr.aria-label]="ariaLabel()">
   @for (i of stars(); track i) {
-    <span class="star" [class.filled]="i <= difficulty()" aria-hidden="true">★</span>
+    <span class="star" aria-hidden="true">★</span>
   }
 </span>

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
@@ -1,3 +1,43 @@
-:host {
-  display: flex;
+.rating {
+  $total: 6;
+  $star-size: 16px;
+  $stars-gap: 3px;
+  $section: $star-size + $stars-gap;
+  $bg-shift: $stars-gap / -2;
+
+  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' width='16' height='16' xmlns='http://www.w3.org/2000/svg'><path fill='%23DDD' stroke-linejoin='round' stroke='%23DDD' d='M 525.333 570.775 L 528.39 578.125 L 536.325 578.761 L 530.28 583.94 L 532.127 591.684 L 525.333 587.534 L 518.539 591.684 L 520.386 583.94 L 514.341 578.761 L 522.276 578.125 Z' transform='matrix(-0.809017, 0.587785, -0.587785, -0.809017, 779.285368, 175.34678)'></path></svg>");
+  background-position: $bg-shift 0;
+  background-repeat: repeat-x;
+  background-size: $section $star-size;
+  border-radius: 0;
+  display: block;
+  height: $star-size;
+  position: relative;
+  width: $section * $total - $stars-gap;
+
+  // firefox bar
+  &:-moz-meter-optimum::-moz-meter-bar {
+    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' width='16' height='16' xmlns='http://www.w3.org/2000/svg'><path fill='orange' stroke-linejoin='round' stroke='orange' d='M 525.333 570.775 L 528.39 578.125 L 536.325 578.761 L 530.28 583.94 L 532.127 591.684 L 525.333 587.534 L 518.539 591.684 L 520.386 583.94 L 514.341 578.761 L 522.276 578.125 Z' transform='matrix(-0.809017, 0.587785, -0.587785, -0.809017, 779.285368, 175.34678)'></path></svg>");
+    background-position: $bg-shift 0;
+    background-repeat: repeat-x;
+    background-size: $section $star-size;
+  }
+
+  // webkit gray background
+  &::-webkit-meter-bar {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    height: $star-size;
+  }
+
+  // webkit bar
+  &::-webkit-meter-optimum-value {
+    background-color: transparent;
+    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' width='16' height='16' xmlns='http://www.w3.org/2000/svg'><path fill='orange' stroke-linejoin='round' stroke='orange' d='M 525.333 570.775 L 528.39 578.125 L 536.325 578.761 L 530.28 583.94 L 532.127 591.684 L 525.333 587.534 L 518.539 591.684 L 520.386 583.94 L 514.341 578.761 L 522.276 578.125 Z' transform='matrix(-0.809017, 0.587785, -0.587785, -0.809017, 779.285368, 175.34678)'></path></svg>");
+    background-position: $bg-shift 0;
+    background-repeat: repeat-x;
+    background-size: $section $star-size;
+    height: 100%;
+  }
 }

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
@@ -1,9 +1,11 @@
+@use 'sass:math';
+
 .rating {
   $total: 6;
   $star-size: 16px;
   $stars-gap: 3px;
   $section: $star-size + $stars-gap;
-  $bg-shift: $stars-gap / -2;
+  $bg-shift: math.div($stars-gap, -2);
 
   background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' width='16' height='16' xmlns='http://www.w3.org/2000/svg'><path fill='%23DDD' stroke-linejoin='round' stroke='%23DDD' d='M 525.333 570.775 L 528.39 578.125 L 536.325 578.761 L 530.28 583.94 L 532.127 591.684 L 525.333 587.534 L 518.539 591.684 L 520.386 583.94 L 514.341 578.761 L 522.276 578.125 Z' transform='matrix(-0.809017, 0.587785, -0.587785, -0.809017, 779.285368, 175.34678)'></path></svg>");
   background-position: $bg-shift 0;

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
@@ -1,45 +1,13 @@
-@use 'sass:math';
+.stars {
+  display: inline-flex;
+  gap: 2px;
+}
 
-.rating {
-  $total: 6;
-  $star-size: 16px;
-  $stars-gap: 3px;
-  $section: $star-size + $stars-gap;
-  $bg-shift: math.div($stars-gap, -2);
+.star {
+  color: #ddd;
+  font-size: 24px;
 
-  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' width='16' height='16' xmlns='http://www.w3.org/2000/svg'><path fill='%23DDD' stroke-linejoin='round' stroke='%23DDD' d='M 525.333 570.775 L 528.39 578.125 L 536.325 578.761 L 530.28 583.94 L 532.127 591.684 L 525.333 587.534 L 518.539 591.684 L 520.386 583.94 L 514.341 578.761 L 522.276 578.125 Z' transform='matrix(-0.809017, 0.587785, -0.587785, -0.809017, 779.285368, 175.34678)'></path></svg>");
-  background-position: $bg-shift 0;
-  background-repeat: repeat-x;
-  background-size: $section $star-size;
-  border-radius: 0;
-  display: block;
-  height: $star-size;
-  position: relative;
-  width: $section * $total - $stars-gap;
-
-  // firefox bar
-  &:-moz-meter-optimum::-moz-meter-bar {
-    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' width='16' height='16' xmlns='http://www.w3.org/2000/svg'><path fill='orange' stroke-linejoin='round' stroke='orange' d='M 525.333 570.775 L 528.39 578.125 L 536.325 578.761 L 530.28 583.94 L 532.127 591.684 L 525.333 587.534 L 518.539 591.684 L 520.386 583.94 L 514.341 578.761 L 522.276 578.125 Z' transform='matrix(-0.809017, 0.587785, -0.587785, -0.809017, 779.285368, 175.34678)'></path></svg>");
-    background-position: $bg-shift 0;
-    background-repeat: repeat-x;
-    background-size: $section $star-size;
-  }
-
-  // webkit gray background
-  &::-webkit-meter-bar {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
-    height: $star-size;
-  }
-
-  // webkit bar
-  &::-webkit-meter-optimum-value {
-    background-color: transparent;
-    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' width='16' height='16' xmlns='http://www.w3.org/2000/svg'><path fill='orange' stroke-linejoin='round' stroke='orange' d='M 525.333 570.775 L 528.39 578.125 L 536.325 578.761 L 530.28 583.94 L 532.127 591.684 L 525.333 587.534 L 518.539 591.684 L 520.386 583.94 L 514.341 578.761 L 522.276 578.125 Z' transform='matrix(-0.809017, 0.587785, -0.587785, -0.809017, 779.285368, 175.34678)'></path></svg>");
-    background-position: $bg-shift 0;
-    background-repeat: repeat-x;
-    background-size: $section $star-size;
-    height: 100%;
+  &.filled {
+    color: #ffa500;
   }
 }

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.scss
@@ -1,13 +1,9 @@
 .stars {
   display: inline-flex;
-  gap: 2px;
+  gap: 0.125rem;
 }
 
 .star {
-  color: #ddd;
-  font-size: 24px;
-
-  &.filled {
-    color: #ffa500;
-  }
+  color: #ffa500;
+  font-size: 1.5rem;
 }

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.ts
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.ts
@@ -1,12 +1,18 @@
-import { Component, Input } from '@angular/core'
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core'
 
 @Component({
   selector: 'difficulty-stars',
   templateUrl: './difficulty-stars.component.html',
   styleUrls: ['./difficulty-stars.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: []
 })
 export class DifficultyStarsComponent {
-  @Input()
-    difficulty: 1 | 2 | 3 | 4 | 5 | 6
+  // difficulty value between 0 and maxDifficulty
+  readonly difficulty = input.required<number>()
+  readonly maxDifficulty = input(6)
+
+  readonly stars = computed(() => Array.from({ length: this.maxDifficulty() }, (_, i) => i + 1))
+
+  readonly ariaLabel = computed(() => `Difficulty ${this.difficulty()} of ${this.maxDifficulty()}`)
 }

--- a/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.ts
+++ b/frontend/src/app/score-board/components/difficulty-stars/difficulty-stars.component.ts
@@ -8,11 +8,10 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
   imports: []
 })
 export class DifficultyStarsComponent {
-  // difficulty value between 0 and maxDifficulty
-  readonly difficulty = input.required<number>()
-  readonly maxDifficulty = input(6)
 
-  readonly stars = computed(() => Array.from({ length: this.maxDifficulty() }, (_, i) => i + 1))
+  readonly difficulty = input.required<1 | 2 | 3 | 4 | 5 | 6>()
+  // only filled stars shown per difficulty level
+  readonly stars = computed(() => Array.from({ length: this.difficulty() }, (_, i) => i + 1))
+  readonly ariaLabel = computed(() => `Difficulty ${this.difficulty()} of 6`)
 
-  readonly ariaLabel = computed(() => `Difficulty ${this.difficulty()} of ${this.maxDifficulty()}`)
 }


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
This replaces the existing star rating UI with a semantic and accessible <meter> element. 
This change is mentioned in "Accessibility" section of meta-issue. #2868
Please let me know if any adjustments or styling refinements are required.

UI now:
<img width="435" height="147" alt="image" src="https://github.com/user-attachments/assets/a2ec53aa-44d4-4a0c-b0c6-7b9cfd14afb7" />
<img width="447" height="363" alt="image" src="https://github.com/user-attachments/assets/3dce5ea1-ea28-4cd5-9104-f9be2e11b140" />
Mobile View: 
<img width="722" height="461" alt="image" src="https://github.com/user-attachments/assets/6b1ba804-f7ac-4a89-aab6-d222cc5ab7d8" />


Resolved or fixed issue: #2868<!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
