### PR TITLE
test: add Selenium Java UI tests for login and registration

### DIFF
--- a/test/automation/selenium-java/src/test/java/com/juiceshop/tests/JuiceShopLoginTest.java
+++ b/test/automation/selenium-java/src/test/java/com/juiceshop/tests/JuiceShopLoginTest.java
@@ -1,0 +1,49 @@
+package com.juiceshop.tests;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import java.time.Duration;
+
+public class JuiceShopLoginTest {
+
+    private WebDriver driver;
+    private WebDriverWait wait;
+
+    @BeforeMethod
+
+    public void setUP(){
+
+        driver = new EdgeDriver();
+        driver.manage().window().maximize();
+        wait = new WebDriverWait(driver,Duration.ofSeconds(15));
+        driver.get("https://juice-shop.herokuapp.com/#/");
+
+    }
+
+    @Test
+
+    public void testSuccessfulAdminLogin(){
+        wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector("button[aria-label='Close Welcome Banner']"))).click();
+        wait.until(ExpectedConditions.elementToBeClickable(By.id("navbarAccount"))).click();
+        wait.until(ExpectedConditions.elementToBeClickable(By.id("navbarLoginButton"))).click();
+        Assert.assertTrue(wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("logo"))).isDisplayed());
+        Assert.assertTrue(wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".mat-toolbar-row.navbar-row"))).isDisplayed());
+        driver.findElement(By.id("email")).sendKeys("admin@juice-sh.op");
+        driver.findElement(By.id("password")).sendKeys("admin123");
+        wait.until(ExpectedConditions.elementToBeClickable(By.id("loginButton"))).click();
+        Assert.assertTrue(wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("button[aria-label='Show the shopping cart']"))).isDisplayed(), "Login failed - Basket icon is missing!");
+    }
+
+    @AfterMethod
+
+    public void tearDown(){
+        driver.quit();
+    }
+}

--- a/test/automation/selenium-java/src/test/java/com/juiceshop/tests/JuiceShopRegistrationTest.java
+++ b/test/automation/selenium-java/src/test/java/com/juiceshop/tests/JuiceShopRegistrationTest.java
@@ -1,0 +1,54 @@
+mport org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+public class JuiceShopRegistrationTest {
+
+    WebDriver driver;
+    WebDriverWait wait;
+
+    @BeforeMethod
+    private void setUP() {
+
+        driver = new EdgeDriver();
+        driver.manage().window().maximize();
+        driver.get("https://juice-shop.herokuapp.com/#/");
+        wait = new WebDriverWait(driver, Duration.ofSeconds(15));
+    }
+
+    @Test
+    private void testSuccessfulUserRegistration() {
+        wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector("button[aria-label='Close Welcome Banner']"))).click();
+        wait.until(ExpectedConditions.elementToBeClickable(By.id("navbarAccount"))).click();
+        wait.until(ExpectedConditions.elementToBeClickable(By.id("navbarLoginButton"))).click();
+        WebElement regLink = driver.findElement(By.cssSelector(".primary-link[routerlink='/register']"));
+        JavascriptExecutor Js = (JavascriptExecutor)driver;
+        Js.executeScript("arguments[0].click();",regLink);
+       // wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector(".primary-link[routerlink='/register']"))).click();
+        Assert.assertTrue(driver.getCurrentUrl().contains("register"), "fail to navigate to registration page ");
+        Assert.assertTrue(wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("div[class='mdc-card']"))).isDisplayed());
+        driver.findElement(By.id("emailControl")).sendKeys("script@test.com");
+        driver.findElement(By.id("passwordControl")).sendKeys("Password123!");
+        driver.findElement(By.id("repeatPasswordControl")).sendKeys("Password123!");
+        driver.findElement(By.name("securityQuestion")).click();
+        wait.until(ExpectedConditions.elementToBeClickable(By.xpath("(//mat-option)[7]]"))).click();
+        driver.findElement(By.id("securityAnswerControl")).sendKeys("secret answer");
+        wait.until(ExpectedConditions.elementToBeClickable(By.id("registerButton"))).click();
+        Assert.assertTrue(wait.until(ExpectedConditions.textToBePresentInElementLocated(By.id("mat-simple-snackbar-action-0"), "Registration completed successfully")));
+    }
+
+    @AfterMethod
+    private void tearDown(){
+        driver.quit();
+    }
+}


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

### Description

Adds two clean, fully functional Selenium Java UI tests using TestNG + explicit waits:

- `JuiceShopLoginTest.java` – verifies successful admin login  
- `JuiceShopRegistrationTest.java` – verifies user registration with dynamic email and security question

All tests run against the official live instance (https://juice-shop.herokuapp.com) – no local setup required.

These are my first open-source contributions and follow the project structure and coding style.

Resolved or fixed issue: none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
