### PR TITLE
feat: implemented click-to-copy functionality for Score Board

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -317,7 +317,9 @@ mentioned or used!
 
 #### 2025
 
-* :date: [OWASP Juice Shop Workshop](https://www.meetup.com/it-security-kassel/events/306942921)
+* [News from the Juice Shop ecosystem](https://god.owasp.de/2025/program-detail.html?talk=talkTwentytwo) by Björn Kimminich, German OWASP Day 2025, Düsseldorf, 26.11.2025
+* [All the WAF power to the devs - why it reduces friction… and where it backfires](https://god.owasp.de/2025/program-detail.html?talk=talkSix) by Lukas Funk, German OWASP Day 2025, Düsseldorf, 26.11.2025 :mega:
+* [OWASP Juice Shop Workshop](https://www.meetup.com/it-security-kassel/events/306942921)
   with Björn Kimminich, [93. IT-Security-Meetup Kassel](https://www.meetup.com/it-security-kassel/), 10.09.2025
 * [OWASP Juice Shop Demo: Your vitamin shot for security awareness & education](https://owasp2025globalappseceu.sched.com/event/1yOPV/owasp-juice-shop-demo-your-vitamin-shot-for-security-awareness-education) with Björn Kimminich, [OWASP Global AppSec EU 2025, Barcelona](https://owasp.glueup.com/event/owasp-global-appsec-eu-2025-123983), 29.05.2025
 * [OWASP Juice Shop Demo: Your vitamin shot for security awareness & education](https://owasp2025globalappseceu.sched.com/event/1yPXh/owasp-juice-shop-demo-your-vitamin-shot-for-security-awareness-education) with Björn Kimminich, [OWASP Global AppSec EU 2025, Barcelona](https://owasp.glueup.com/event/owasp-global-appsec-eu-2025-123983), 30.05.2025

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
@@ -7,8 +7,13 @@
     [difficulty]="challenge.difficulty"
   ></difficulty-stars>
 </div>
-<div class="description-row" [innerHtml]="challenge.description"></div>
-<div class="bottom-row">
+    
+<div class="description-row" 
+     [innerHtml]="challenge.description" 
+     (click)="copyPayload($event)">
+</div>
+
+  <div class="bottom-row">
   <div class="tags">
     @for (tag of challenge.tagList; track tag) {
       <span class="tag" [matTooltip]="('TAG_' + tag?.toUpperCase().split(' ').join('_') + '_DESCRIPTION' | translate)">{{ tag }}</span>

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
@@ -201,3 +201,29 @@ $badge-size: 24px;
     color: var(--theme-accent);
   }
 }
+::ng-deep .description-row code {
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 0 4px;
+  transition: background-color 0.2s;
+
+  // Visual feedback when hovering
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.2); 
+  }
+
+  // A fake "Tooltip" using CSS
+  &:hover::after {
+    content: "Click to copy";
+    position: absolute;
+    background-color: #333;
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    margin-left: 8px;
+    white-space: nowrap;
+    z-index: 10;
+    pointer-events: none;
+  }
+}

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
@@ -37,4 +37,13 @@ export class ChallengeCardComponent implements OnInit {
     this.hasInstructions = hasInstructions
     this.startHackingInstructorFor = startHackingInstructorFor
   }
+  copyPayload(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    // Check if the user clicked on a <code> tag inside the description
+    if (target.tagName === 'CODE') {
+      const payload = target.innerText;
+      
+      navigator.clipboard.writeText(payload)
+    }
+  }
 }


### PR DESCRIPTION
### Description
This PR addresses issue #2876. 

It improves the UX of the Score Board by allowing users to click on code snippets (payloads) to copy them directly to the clipboard.

### Changes
- Added `(click)` event listener to the challenge description in `challenge-card.component.html`.
- Implemented `copyPayload()` method in `challenge-card.component.ts` using `navigator.clipboard`.
- Added CSS in `challenge-card.component.scss` to change cursor to pointer and show a "Click to copy" tooltip on hover.

### Testing
- Verified manually by hovering over payloads (cursor changes to pointer).
- Verified clicking copies the text to the system clipboard.
