### PR TITLE
feat: implement click-to-copy for flag codes from challenge solved notifications (#2898)

### DIFF
--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -11,12 +11,9 @@
         @if (showCtfFlagsInNotifications) {
           <br/>
           <div>
-            <span class="icon-box"><mat-icon>outlined_flag</mat-icon> {{notification.flag}}</span>&nbsp;
-            <button ngxClipboard mat-stroked-button [cbContent]="notification.flag" (cbOnSuccess)="notification.copied = true" [disabled]="notification.copied">
-              <mat-icon>content_copy</mat-icon>
-              <span [hidden]="!notification.copied">{{"COPY_SUCCESS" | translate}}</span>
-              <span [hidden]="notification.copied">{{"COPY_TO_CLIPBOARD" | translate}}</span>
-            </button>
+            <span class="icon-box flag-box" (click)="copyToClipboard(notification.flag)" [matTooltip]="'COPY_TO_CLIPBOARD' | translate">
+              <mat-icon>outlined_flag</mat-icon> {{notification.flag}}
+            </span>
             <br/>
             @if (showCtfCountryDetailsInNotifications !== 'none') {
               <span class="icon-box">

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
@@ -27,3 +27,14 @@ mat-card {
   display: inline-flex;
   vertical-align: middle;
 }
+
+.flag-box {
+  border-radius: 4px;
+  cursor: copy;
+  padding: 2px 4px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+}

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ClipboardModule } from 'ngx-clipboard'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
 import { CountryMappingService } from '../Services/country-mapping.service'
@@ -58,7 +57,6 @@ describe('ChallengeSolvedNotificationComponent', () => {
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(),
         CookieModule.forRoot(),
-        ClipboardModule,
         MatCardModule,
         MatButtonModule,
         MatIconModule,

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -10,12 +10,12 @@ import { ChangeDetectorRef, Component, NgZone, type OnInit, inject } from '@angu
 import { CookieService } from 'ngy-cookie'
 import { CountryMappingService } from '../Services/country-mapping.service'
 import { SocketIoService } from '../Services/socket-io.service'
-import { ClipboardModule } from 'ngx-clipboard'
 import { MatIconModule } from '@angular/material/icon'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
 import { LowerCasePipe } from '@angular/common'
 import { firstValueFrom } from 'rxjs'
+import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 interface ChallengeSolvedMessage {
   challenge: string
@@ -37,7 +37,7 @@ interface ChallengeSolvedNotification {
   selector: 'app-challenge-solved-notification',
   templateUrl: './challenge-solved-notification.component.html',
   styleUrls: ['./challenge-solved-notification.component.scss'],
-  imports: [MatCardModule, MatButtonModule, MatIconModule, ClipboardModule, LowerCasePipe, TranslateModule]
+  imports: [MatCardModule, MatButtonModule, MatIconModule, LowerCasePipe, TranslateModule]
 })
 export class ChallengeSolvedNotificationComponent implements OnInit {
   private readonly ngZone = inject(NgZone);
@@ -48,6 +48,7 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
   private readonly cookieService = inject(CookieService);
   private readonly ref = inject(ChangeDetectorRef);
   private readonly io = inject(SocketIoService);
+  private readonly snackBarHelperService = inject(SnackBarHelperService);
 
   public notifications: ChallengeSolvedNotification[] = []
   public showCtfFlagsInNotifications = false
@@ -142,5 +143,13 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
       },
       error: (err) => { console.log(err) }
     })
+  }
+
+  copyToClipboard (text: string) {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(() => {
+        this.snackBarHelperService.open('COPY_SUCCESS', 'confirmBar')
+      })
+    }
   }
 }


### PR DESCRIPTION
### Description
This PR addresses issue #2898. It replaces the "Copy to clipboard" button in the Challenge Solved notifications (CTF mode) with a click-to-copy functionality on the flag code itself.

### Implementation Details
- Removed the explicit "Copy to clipboard" button to reduce UI clutter.
- Made the flag code text clickable.
- Integrated `SnackBarHelperService` to provide visual feedback ("Copied!") upon clicking.
- Added hover styles (cursor pointer) to indicate interactivity.
- Updated unit tests to reflect the removal of the button and dependency changes.

### Visual Proof
Verified locally. The button is gone, and clicking the flag copies it to the clipboard:
<img width="1909" height="922" alt="Screenshot 2025-12-01 215302" src="https://github.com/user-attachments/assets/d22960a0-2d58-4860-b33c-724371cc0cce" />
