### PR TITLE
fix: change the behaviour of hints button to open the hints modal dir…

### DIFF
--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
@@ -90,9 +90,10 @@
         class="badge not-completable"
         [style.padding]="'0 6px 0 4px'"
         [matTooltip]="challenge.hintText + (challenge.nextHint ? '\n\n' + ('CLICK_TO_UNLOCK_NEXT_HINT' | translate: { next: challenge.hintsUnlocked+1, total: challenge.hintsAvailable}) : '')"
+        #hintTooltip="matTooltip"
         matTooltipClass="multiline-tooltip"
-        (click)="unlockHint(challenge.nextHint)"
-        [disabled]="!challenge.nextHint"
+        (click)="unlockHint(challenge.nextHint, challenge.key)"
+        [attr.aria-disabled]="!challenge.nextHint ? true : null"
         >
         <mat-icon>{{ challenge.nextHint ? 'lightbulb_outlined' : 'lightbulb' }}</mat-icon>
         {{ challenge.hintsUnlocked }}/{{ challenge.hintsAvailable }}

--- a/frontend/src/app/score-board/score-board.component.html
+++ b/frontend/src/app/score-board/score-board.component.html
@@ -38,6 +38,7 @@
           [openCodingChallengeDialog]="openCodingChallengeDialog.bind(this)"
           [repeatChallengeNotification]="repeatChallengeNotification.bind(this)"
           [unlockHint]="unlockHint.bind(this)"
+          [lastUnlockedChallengeKey]="lastUnlockedChallengeKey"
           [ngClass]="{ solved: challenge.solved, unsolved: !challenge.solved, disabled: challenge.disabledEnv !== null }"
           />
       }

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -59,6 +59,7 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
   public filteredChallenges: EnrichedChallenge[] = []
   public filterSetting: FilterSetting = structuredClone(DEFAULT_FILTER_SETTING)
   public applicationConfiguration: Config | null = null
+  public lastUnlockedChallengeKey: string | null = null
 
   public isInitialized = false
 
@@ -193,7 +194,8 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
     await firstValueFrom(this.challengeService.repeatNotification(encodeURIComponent(challenge.name)))
   }
 
-  unlockHint (hintId: number) {
+    unlockHint (hintId: number, challengeKey?: string) {
+    this.lastUnlockedChallengeKey = challengeKey ?? null
     this.hintService.put(hintId, { unlocked: true }).subscribe({
       next: () => {
         this.ngOnInit()


### PR DESCRIPTION
## change the behaviour of hints button to open the hints modal directly after clicking it

<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
This is a draft PR to check if my commit passes the tests

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->none

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
