### PR TITLE
refactor: use dynamic config domain in password strength tutorial

### DIFF
--- a/frontend/src/hacking-instructor/challenges/passwordStrength.ts
+++ b/frontend/src/hacking-instructor/challenges/passwordStrength.ts
@@ -40,7 +40,7 @@ export const PasswordStrengthInstruction: ChallengeInstruction = {
       text: "Enter the admin's email address into the **email field**.",
       fixture: '#email',
       unskippable: true,
-      resolved: waitForInputToHaveValue('#email', 'admin@juice-sh.op', { ignoreCase: true, replacement: ['juice-sh.op', 'application.domain'] })
+      resolved: waitForInputToHaveValue('#email', 'admin@juice-sh.op', { replacement: ['juice-sh.op', 'application.domain'] })
     },
     {
       text: 'Now for the password. Lucky for us, the admin chose a really, really, **really** stupid one. Just try any that comes to your mind!',

--- a/frontend/src/hacking-instructor/challenges/passwordStrength.ts
+++ b/frontend/src/hacking-instructor/challenges/passwordStrength.ts
@@ -40,7 +40,7 @@ export const PasswordStrengthInstruction: ChallengeInstruction = {
       text: "Enter the admin's email address into the **email field**.",
       fixture: '#email',
       unskippable: true,
-      resolved: waitForInputToHaveValue('#email', 'admin@juice-sh.op') // TODO Use domain from config instead
+      resolved: waitForInputToHaveValue('#email', 'admin@juice-sh.op', { ignoreCase: true, replacement: ['juice-sh.op', 'application.domain'] })
     },
     {
       text: 'Now for the password. Lucky for us, the admin chose a really, really, **really** stupid one. Just try any that comes to your mind!',


### PR DESCRIPTION
### Description
This Pull Request addresses the existing technical debt related to hardcoded values in the Hacking Instructor.

The "Password Strength" tutorial currently validates the user email against a static string (admin@juice-sh.op), which causes the tutorial to fail or become confusing for users running Juice Shop on a custom domain.

### Changes Implemented

1. Location: frontend/src/hacking-instructor/challenges/passwordStrength.ts

2. Fix: Refactored the waitForInputToHaveValue call to use the replacement option, dynamically substituting the domain from     the application's configuration (application.domain).

3. Cleanup: Removed the explicit TODO comment related to this hardcoded value.


Closes #2927 
