### PR TITLE
docs: improve Windows setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ For a detailed introduction, full list of features and architecture overview ple
    of the repository)
 3. Go into the cloned folder with `cd juice-shop`
 4. Run `npm install` (only has to be done before first start or when you change the source code)
+
+   > ⚠️ **Note for Windows users**
+   > Running `npm install` on **native Windows shells (PowerShell / CMD / Git Bash)** may
+   > fail when compiling native Node.js modules (e.g., `sqlite3`, `libxmljs2`).
+   >
+   > For the smoothest experience, we recommend installing and running Juice Shop in
+   > **WSL2** or using **Docker**.
+   >
+   > If you prefer native Windows, ensure the required build tools for `node-gyp`
+   > are installed (C++ Build Tools + Python 3).
+
 5. Run `npm start`
 6. Browse to <http://localhost:3000>
 


### PR DESCRIPTION
### Description

Improve the "From Sources" setup instructions in the README by adding a clear note for Windows users. Running `npm install`
on native Windows shells (PowerShell, CMD, Git Bash) can fail when compiling native modules such as `sqlite3` or `libxmljs2`.

This update helps prevent common setup issues for contributors on Windows machines.

### Changes

- Added a warning block under step 4 (`npm install`) in the "From Sources" setup instructions.
- Recommend using **WSL2 (Ubuntu)** or **Docker** for a smooth installation.
- Specify required build tools for native Windows setups (C++ Build Tools + Python 3).

### Motivation

Windows users frequently encounter build errors due to native module compilation. 
This clarification in the README reduces setup friction, improves contributor onboarding, and ensures reproducibility across environments.

### Scope

Documentation update only; no code changes.

### Checklist

- [x] PR is based off the `develop` branch
- [x] Change is scoped to a single purpose
- [x] No AI-generated noise included
- [x] Signed commits included
- [x] README updated in human-readable style
- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
