### PR TITLE
Fix/hint-tool-tip modal re-trigger

### DIFF
--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
@@ -91,8 +91,9 @@
         class="badge not-completable"
         [style.padding]="'0 6px 0 4px'"
         [matTooltip]="challenge.hintText + (challenge.nextHint ? '\n\n' + ('CLICK_TO_UNLOCK_NEXT_HINT' | translate: { next: challenge.hintsUnlocked+1, total: challenge.hintsAvailable}) : '')"
+        #hintTooltip="matTooltip"
         matTooltipClass="multiline-tooltip"
-        (click)="unlockHint(challenge.nextHint)"
+        (click)="unlockHint(challenge.nextHint, challenge.key)"
         [disabled]="!challenge.nextHint"
         >
         <mat-icon>{{ challenge.nextHint ? 'lightbulb_outlined' : 'lightbulb' }}</mat-icon>

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, type OnInit, inject } from '@angular/core'
+import { Component, Input, type OnInit, inject, type OnChanges, type SimpleChanges, ViewChild } from '@angular/core'
 import { EnrichedChallenge } from '../../types/EnrichedChallenge'
 import { Config } from 'src/app/Services/configuration.service'
 import { TranslateModule } from '@ngx-translate/core'
@@ -14,7 +14,7 @@ import { SnackBarHelperService } from 'src/app/Services/snack-bar-helper.service
   styleUrls: ['./challenge-card.component.scss'],
   imports: [DifficultyStarsComponent, MatTooltip, MatIconModule, NgClass, TranslateModule]
 })
-export class ChallengeCardComponent implements OnInit {
+export class ChallengeCardComponent implements OnInit, OnChanges {
   private readonly snackBarHelperService = inject(SnackBarHelperService)
 
   @Input()
@@ -27,10 +27,18 @@ export class ChallengeCardComponent implements OnInit {
   public repeatChallengeNotification: (challengeKey: string) => void
 
   @Input()
-  public unlockHint: (hintId: number) => void
+  public unlockHint: (hintId: number, challengeKey?: string) => void
 
   @Input()
   public applicationConfiguration: Config
+
+  @Input()
+  public lastUnlockedChallengeKey: string | null = null
+
+  @ViewChild('hintTooltip')
+  public hintTooltip?: MatTooltip
+
+  private previousHintsUnlocked?: number
 
   public hasInstructions: (challengeName: string) => boolean = () => false
   public startHackingInstructorFor: (challengeName: string) => Promise<void> = async () => {}
@@ -39,6 +47,20 @@ export class ChallengeCardComponent implements OnInit {
     const { hasInstructions, startHackingInstructorFor } = await import('../../../../hacking-instructor')
     this.hasInstructions = hasInstructions
     this.startHackingInstructorFor = startHackingInstructorFor
+  }
+
+  ngOnChanges (changes: SimpleChanges): void {
+    if (changes['challenge']?.currentValue) {
+      const currentHintsUnlocked = this.challenge?.hintsUnlocked
+      if (
+        this.lastUnlockedChallengeKey === this.challenge?.key &&
+        this.previousHintsUnlocked !== undefined &&
+        currentHintsUnlocked !== this.previousHintsUnlocked
+      ) {
+        queueMicrotask(() => setTimeout(()=>{this.hintTooltip?.show()}, 50))
+      }
+      this.previousHintsUnlocked = currentHintsUnlocked
+    }
   }
 
   copyPayload (event: MouseEvent) {

--- a/frontend/src/app/score-board/score-board.component.html
+++ b/frontend/src/app/score-board/score-board.component.html
@@ -38,6 +38,7 @@
           [openCodingChallengeDialog]="openCodingChallengeDialog.bind(this)"
           [repeatChallengeNotification]="repeatChallengeNotification.bind(this)"
           [unlockHint]="unlockHint.bind(this)"
+          [lastUnlockedChallengeKey]="lastUnlockedChallengeKey"
           [ngClass]="{ solved: challenge.solved, unsolved: !challenge.solved, disabled: challenge.disabledEnv !== null }"
           />
       }

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -59,6 +59,7 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
   public filteredChallenges: EnrichedChallenge[] = []
   public filterSetting: FilterSetting = structuredClone(DEFAULT_FILTER_SETTING)
   public applicationConfiguration: Config | null = null
+  public lastUnlockedChallengeKey: string | null = null
 
   public isInitialized = false
 
@@ -193,7 +194,8 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
     await firstValueFrom(this.challengeService.repeatNotification(encodeURIComponent(challenge.name)))
   }
 
-  unlockHint (hintId: number) {
+  unlockHint (hintId: number, challengeKey?: string) {
+    this.lastUnlockedChallengeKey = challengeKey ?? null
     this.hintService.put(hintId, { unlocked: true }).subscribe({
       next: () => {
         this.ngOnInit()


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description
continuing #2926 
<!-- ✍️-->
This PR improves the user experience of the hint system.
Previously, when a user hovered over the Hints button, the ```hintTooltip``` modal appeared, but after clicking to unlock the next hint, the modal immediately disappeared. The user then had to hover again to see the newly unlocked hint.

This change ensures the modal stays open and automatically displays the updated hint list after unlocking a hint.

#### What Was Changed

Added additional trigger logic so the modal re-renders and remains visible when ```hintsUnlocked``` changes.

The hint modal now updates in place instead of closing and requiring another hover.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->none



### Demo GIFs
#### before
![before](https://github.com/user-attachments/assets/8d46262a-5f89-4182-b204-6902ec6eb4fe)
#### after
![after](https://github.com/user-attachments/assets/42dc42a4-e9ba-4811-a3f1-48b725edfbdf)


### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
