### PR TITLE
Replace hardcoded pixels in Photo-Wall page

### DIFF
--- a/frontend/src/app/photo-wall/photo-wall.component.scss
+++ b/frontend/src/app/photo-wall/photo-wall.component.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+@use '../../styles/variables' as *;
+
 mat-form-field {
   width: 100%;
 }
@@ -15,7 +17,7 @@ mat-form-field {
 
 #submitButton {
   margin-left: 20%;
-  margin-top: 10px;
+  margin-top: $space-s;
   width: 60%;
 }
 
@@ -78,7 +80,7 @@ input {
   font-size: 20px;
   left: 0;
   opacity: 0;
-  padding: 20px;
+  padding: $space-ms;
   position: absolute;
   right: 0;
   text-align: center;
@@ -92,7 +94,7 @@ input {
 .emptyState {
   display: block;
   height: auto !important;
-  margin: 20px auto;
+  margin: $space-ms auto;
   width: 50%;
 }
 
@@ -105,7 +107,7 @@ input {
 
 .noResultText {
   display: block;
-  margin-top: 10px;
+  margin-top: $space-s;
   text-align: center;
 }
 


### PR DESCRIPTION
This PR replaces hardcoded pixels in the photo-wall. page after investigation in [#2915](https://github.com/juice-shop/juice-shop/issues/2915).
### Description
Replaced hardcoded pixel spacing values with rem-based spacing tokens in `photo-wall.component.scss`

### Changes:
- Imported spacing variables from `styles/variables`
- Replaced hardcoded spacing values with tokens:
  - 10px → $space-s
  - 20px → $space-ms

### Testing:
- No visual changes

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
