### PR TITLE
Replace hardcoded pixel spacing values with rem-based spacing tokens in contact component

### DIFF
--- a/frontend/src/app/contact/contact.component.scss
+++ b/frontend/src/app/contact/contact.component.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+@use '../../styles/variables' as *;
+
 $star-off: #c8c8c8;
 $star-on: #ffd700;
 
@@ -25,8 +27,8 @@ mat-card {
 .rating-container {
   align-items: center;
   display: flex;
-  margin-bottom: 15px;
-  margin-top: 15px;
+  margin-bottom: $space-m;
+  margin-top: $space-m;
 }
 
 .rating-label {
@@ -95,7 +97,7 @@ mat-hint {
 
 #submitButton {
   margin-left: 20%;
-  margin-top: 30px;
+  margin-top: $space-xl;
   width: 60%;
 }
 


### PR DESCRIPTION
### Description
Replace hardcoded pixel spacing values with rem-based spacing tokens in contact component, following the approach discussed and established in previous PRs.

This migrates 3 hardcoded px values (15px, 30px) to the new rem-based spacing system.

**Changes:**
- Imported spacing variables from `styles/variables`
- Replaced hardcoded spacing values with tokens:
  - 15px → $space-m
  - 30px → $space-l

**Testing:**
- Tested on desktop - no visual changes
- Tested on tablet view - no visual changes
- Tested on mobile view - no visual changes
- Contact form spacing matches previous implementation

Resolved or fixed issue: #2915

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines