### PR TITLE
Prevent negative wallet balance update

### DIFF
--- a/routes/wallet.ts
+++ b/routes/wallet.ts
@@ -20,11 +20,16 @@ export function getWalletBalance () {
 
 export function addWalletBalance () {
   return async (req: Request, res: Response, next: NextFunction) => {
+    const balance = parseFloat(req.body.balance)
+    if (isNaN(balance) || balance <= 0) {
+      res.status(400).json({ status: 'error', message: 'Invalid balance amount.' })
+      return
+    }
     const cardId = req.body.paymentId
     const card = cardId ? await CardModel.findOne({ where: { id: cardId, UserId: req.body.UserId } }) : null
     if (card != null) {
-      WalletModel.increment({ balance: req.body.balance }, { where: { UserId: req.body.UserId } }).then(() => {
-        res.status(200).json({ status: 'success', data: req.body.balance })
+      WalletModel.increment({ balance }, { where: { UserId: req.body.UserId } }).then(() => {
+        res.status(200).json({ status: 'success', data: balance })
       }).catch(() => {
         res.status(404).json({ status: 'error' })
       })


### PR DESCRIPTION
### Description

This PR adds backend input validation to the wallet top-up endpoint to prevent non-positive balance values from being applied.

While the UI already enforces a minimum deposit amount, the backend previously accepted crafted requests with negative or zero values, resulting in corrupted wallet balances. This change validates the balance before incrementing the wallet, preserving existing behavior and patterns without affecting any Juice Shop challenges.

Resolved or fixed issue:  #2935 

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
