### PR TITLE
fix(score-board): improve input field focus visibility

### DIFF
--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
@@ -33,6 +33,7 @@
 .search-icon {
   color: var(--theme-text-fade-30);
 }
+
 :host ::ng-deep .mat-mdc-form-field.mat-focused {
   .mdc-floating-label {
     color: var(--theme-accent) !important;

--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
@@ -34,8 +34,17 @@
   color: var(--theme-text-fade-30);
 }
 
-:host ::ng-deep .mat-mdc-form-field.mat-focused .mdc-floating-label {
-  color: var(--theme-text-fade-30) !important;
+// accent color for better contrast
+:host ::ng-deep .mat-mdc-form-field.mat-focused {
+  // Label should be clearly visible with full accent color
+  .mdc-floating-label {
+    color: var(--theme-accent) !important;
+  }
+  
+  // Bottom indicator line should be prominent with accent color
+  .mdc-line-ripple::after {
+    border-bottom-color: var(--theme-accent) !important;
+  }
 }
 
 .reset-filters-wrapper {
@@ -68,3 +77,4 @@
     width: 16px;
   }
 }
+

--- a/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
+++ b/frontend/src/app/score-board/components/filter-settings/filter-settings.component.scss
@@ -33,15 +33,11 @@
 .search-icon {
   color: var(--theme-text-fade-30);
 }
-
-// accent color for better contrast
 :host ::ng-deep .mat-mdc-form-field.mat-focused {
-  // Label should be clearly visible with full accent color
   .mdc-floating-label {
     color: var(--theme-accent) !important;
   }
   
-  // Bottom indicator line should be prominent with accent color
   .mdc-line-ripple::after {
     border-bottom-color: var(--theme-accent) !important;
   }


### PR DESCRIPTION
## Description
Fixes visibility issues with input field focus states in the score-board filter settings. The focused label and bottom indicator were using low-opacity colors, making them hard to see, especially in dark themes.

## Changes
- Changed focused label color from `var(--theme-text-fade-30)` to `var(--theme-accent)` for better contrast
- Added accent color styling to the bottom indicator line (`mdc-line-ripple`)
- Affects search input and all filter dropdowns (Difficulty, Status, Tags)

## Testing
- Tested on default theme (bluegrey-lightgreen)
- Verified focus states on all input fields in score-board
- Confirmed green accent color appears on both label and bottom line when focused

## Related Issue
Part of #2868 - Frontend Modernization tracking issue

Specifically addresses:
> Fix visibility issues in input fields (label + bottom bar colors on focus, e.g. in score-board) for default theme.

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are limited to the specific issue
- [x] Tested locally and verified fix works
- [x] Commit includes sign-off
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
