### PR TITLE
fix: make product search results keyboard accessible via tabindex

### DIFF
--- a/frontend/src/app/search-result/search-result.component.html
+++ b/frontend/src/app/search-result/search-result.component.html
@@ -35,7 +35,7 @@
                       <span>{{"LABEL_SOLD_OUT" | translate }}</span>
                     </div>
                   }
-                  <div class="product" (click)="showDetail(item)" aria-label="Click for more information about the product"
+                  <div class="product" tabindex="0" (keydown.enter)="showDetail(item)" role="button" (click)="showDetail(item)" aria-label="Click for more information about the product"
                     matTooltip="Click for more information" matTooltipPosition="above">
                     <img mat-card-image [src]="'assets/public/images/products/'+item.image" alt={{item.name}}
                       class="img-responsive img-thumbnail" role="button">


### PR DESCRIPTION
### Description

Currently, the product cards in the search result grid are `div` elements. This makes them inaccessible to keyboard-only users because they cannot be focused via the `Tab` key, nor activated via the `Enter` key.

This PR improves accessibility by:
- Adding `tabindex="0"` to make the product cards focusable.
- Adding `role="button"` to correctly identify the element to screen readers.
- Adding a `(keydown.enter)` event handler so the product details can be opened using the `Enter` key.

Resolved or fixed issue: #2868

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines