### PR TITLE
Feat/ Highlight Coding Challenges More by Including A Coding Challenge Button in Challenge Solved Notifications #2875

### DIFF
--- a/data/datacache.ts
+++ b/data/datacache.ts
@@ -27,6 +27,7 @@ export interface Notification {
   flag: string
   hidden: boolean
   isRestore: boolean
+  codingChallenge?: boolean
 }
 export const notifications: Notification[] = []
 

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -33,6 +33,17 @@
               }
             </div>
           }
+          @if (notification.hasCodingChallenge) {
+            <div class="notification-actions">
+              <button
+                class="view-challenge-button"
+                (click)="navigateToChallenge(notification.key)"
+              >
+                <mat-icon>code</mat-icon>
+                <span>{{ "LAUNCH ASSOCIATED CODING CHALLANGE" | translate }}</span>
+              </button>
+            </div>
+          }
         </div>
       </mat-card>
     }

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -7,7 +7,24 @@
   @for (notification of notifications; track notification.key) {
     <mat-card appearance="outlined" class="accent-notification">
       <div class="mdc-card">
-        <div class="notificationMessage">{{notification.message}}<button id="closeButton" mat-button (click)="closeNotification($index, $event.shiftKey)">X</button></div>
+        <div class="notificationMessage"><div class="contents">{{notification.message}}
+          
+          @if (notification.hasCodingChallenge && codingChallengesEnabled !==
+      'never') {
+            <div class="notification-actions">
+              <button
+                class="view-challenge-button"
+                mat-stroked-button 
+                color="white"     
+                (click)="navigateToChallenge(notification.key)"
+              >
+                <mat-icon>code</mat-icon>
+                <span>{{ "Launch associated Coding Challenge" | translate }}</span>
+              </button>
+            </div>
+          }</div>
+          
+          <button id="closeButton" mat-button (click)="closeNotification($index, $event.shiftKey)">X</button></div>
         @if (showCtfFlagsInNotifications) {
           <br/>
           <div>
@@ -31,17 +48,6 @@
                   }
                 </span>
               }
-            </div>
-          }
-          @if (notification.hasCodingChallenge) {
-            <div class="notification-actions">
-              <button
-                class="view-challenge-button"
-                (click)="navigateToChallenge(notification.key)"
-              >
-                <mat-icon>code</mat-icon>
-                <span>{{ "LAUNCH ASSOCIATED CODING CHALLANGE" | translate }}</span>
-              </button>
             </div>
           }
         </div>

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -9,17 +9,15 @@
       <div class="mdc-card">
         <div class="notificationMessage"><div class="contents">{{notification.message}}
           
-          @if (notification.hasCodingChallenge && codingChallengesEnabled !==
-      'never') {
+          @if (notification.codingChallenge) {
             <div class="notification-actions">
               <button
                 class="view-challenge-button"
                 mat-stroked-button 
-                color="white"     
                 (click)="navigateToChallenge(notification.key)"
               >
                 <mat-icon>code</mat-icon>
-                <span>{{ "Launch associated Coding Challenge" | translate }}</span>
+                <span>{{ "JUMP_TO_RELATED_CODING_CHALLENGE" | translate }}</span>
               </button>
             </div>
           }</div>

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
@@ -40,3 +40,47 @@ mat-card {
     background-color: rgba(0, 0, 0, 0.1);
   }
 }
+
+.notification-actions {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.view-challenge-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  padding: 6px 12px;
+  height: 32px;
+
+  background-color: #ffffff;
+  color: #2e7d32;
+  border-radius: 6px;
+  border: 1px solid rgba(46, 125, 50, 0.35);
+
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+
+  cursor: pointer;
+  transition: background-color 0.15s ease,
+              box-shadow 0.15s ease,
+              transform 0.05s ease;
+
+  mat-icon {
+    font-size: 18px;
+    height: 18px;
+    width: 18px;
+  }
+
+  &:hover {
+    background-color: #f1f8f4;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
+}

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
@@ -33,7 +33,11 @@ mat-card {
 .flag-box {
   border-radius: 4px;
   cursor: copy;
+<<<<<<< HEAD
   padding: $space-3xs $space-2xs;
+=======
+  padding: 2px 2px;
+>>>>>>> ab73e3962 (button style change + other config changes)
   transition: background-color 0.2s ease;
 
   &:hover {
@@ -41,33 +45,31 @@ mat-card {
   }
 }
 
-.notification-actions {
+.contents{
+  justify-content: space-around;
   display: flex;
-  justify-content: flex-start;
-  margin-top: 12px;
+  flex-direction: column;
+  gap: 6px;
 }
+
 
 .view-challenge-button {
   align-items: center;
-
-  background-color: #fff;
-  border: 1px solid rgba(46, 125, 50, 0.35);
-  border-radius: 6px;
-  color: #2e7d32;
+  backdrop-filter: saturate(1.1);
+  border: 3px solid ;
+  border-radius: 4px;
+  color: inherit;
 
   cursor: pointer;
   display: inline-flex;
 
-  font-size: 12px;
-  font-weight: 700;
-  gap: 6px;
+  font-size: 15px;
+  font-weight: 500;
+  gap: 2px;
   height: 32px;
-  letter-spacing: 0.3px;
-
-  padding: 6px 12px;
-  transition: background-color 0.15s ease,
-    box-shadow 0.15s ease,
-    transform 0.05s ease;
+  letter-spacing: normal;
+  padding: 0 12px;
+  transition: background-color 0.15s ease;
 
   mat-icon {
     font-size: 18px;
@@ -76,11 +78,11 @@ mat-card {
   }
 
   &:hover {
-    background-color: #f1f8f4;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    background-color: rgba(211, 211, 211, 0.04);
+    box-shadow: none;
   }
 
   &:active {
-    transform: translateY(1px);
+    transform: none;
   }
 }

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
@@ -30,33 +30,18 @@ mat-card {
   vertical-align: middle;
 }
 
-.flag-box {
-  border-radius: 4px;
-  cursor: copy;
-<<<<<<< HEAD
-  padding: $space-3xs $space-2xs;
-=======
-  padding: 2px 2px;
->>>>>>> ab73e3962 (button style change + other config changes)
-  transition: background-color 0.2s ease;
 
-  &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-  }
-}
-
-.contents{
-  justify-content: space-around;
+.contents {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: $space-2xs;
+  justify-content: space-around;
 }
-
 
 .view-challenge-button {
   align-items: center;
   backdrop-filter: saturate(1.1);
-  border: 3px solid ;
+  border: 3px solid;
   border-radius: 4px;
   color: inherit;
 
@@ -65,10 +50,10 @@ mat-card {
 
   font-size: 15px;
   font-weight: 500;
-  gap: 2px;
+  gap: $space-3xs;
   height: 32px;
   letter-spacing: normal;
-  padding: 0 12px;
+  padding: 0 $space-s;
   transition: background-color 0.15s ease;
 
   mat-icon {

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
@@ -42,32 +42,32 @@ mat-card {
 }
 
 .notification-actions {
-  margin-top: 12px;
   display: flex;
   justify-content: flex-start;
+  margin-top: 12px;
 }
 
 .view-challenge-button {
-  display: inline-flex;
   align-items: center;
-  gap: 6px;
 
-  padding: 6px 12px;
-  height: 32px;
-
-  background-color: #ffffff;
-  color: #2e7d32;
-  border-radius: 6px;
+  background-color: #fff;
   border: 1px solid rgba(46, 125, 50, 0.35);
+  border-radius: 6px;
+  color: #2e7d32;
+
+  cursor: pointer;
+  display: inline-flex;
 
   font-size: 12px;
   font-weight: 700;
+  gap: 6px;
+  height: 32px;
   letter-spacing: 0.3px;
 
-  cursor: pointer;
+  padding: 6px 12px;
   transition: background-color 0.15s ease,
-              box-shadow 0.15s ease,
-              transform 0.05s ease;
+    box-shadow 0.15s ease,
+    transform 0.05s ease;
 
   mat-icon {
     font-size: 18px;

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
@@ -30,6 +30,17 @@ mat-card {
   vertical-align: middle;
 }
 
+.flag-box {
+  border-radius: 4px;
+  cursor: copy;
+  padding: $space-3xs $space-2xs;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+}
+
 
 .contents {
   display: flex;

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
@@ -54,6 +54,7 @@ describe('ChallengeSolvedNotificationComponent', () => {
     translateService.onDefaultLangChange = new EventEmitter()
     cookieService = jasmine.createSpyObj('CookieService', ['put'])
     challengeService = jasmine.createSpyObj('ChallengeService', ['continueCode', 'find'])
+    challengeService.find.and.returnValue(of([]))
     configurationService = jasmine.createSpyObj('ConfigurationService', ['getApplicationConfiguration'])
     configurationService.getApplicationConfiguration.and.returnValue(of({}))
     countryMappingService = jasmine.createSpyObj('CountryMappingService', ['getCountryMapping'])
@@ -119,7 +120,7 @@ describe('ChallengeSolvedNotificationComponent', () => {
     tick()
 
     expect(translateService.get).toHaveBeenCalledWith('CHALLENGE_SOLVED', { challenge: 'Test' })
-    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: undefined }])
+    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: undefined, hasCodingChallenge: false }])
   }))
 
   it('should store retrieved continue code as cookie for 1 year', () => {
@@ -208,7 +209,7 @@ describe('ChallengeSolvedNotificationComponent', () => {
     component.showNotification({ key: 'test', challenge: 'Test', flag: '1234' })
     tick()
 
-    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: { name: 'Canada', code: 'CA' } }])
+    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: { name: 'Canada', code: 'CA' }, hasCodingChallenge: false }])
   }))
 
   it('should copy text to clipboard when navigator.clipboard is available', fakeAsync(() => {

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
@@ -120,7 +120,7 @@ describe('ChallengeSolvedNotificationComponent', () => {
     tick()
 
     expect(translateService.get).toHaveBeenCalledWith('CHALLENGE_SOLVED', { challenge: 'Test' })
-    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: undefined, hasCodingChallenge: false }])
+    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: undefined, codingChallenge: false }])
   }))
 
   it('should store retrieved continue code as cookie for 1 year', () => {
@@ -209,7 +209,7 @@ describe('ChallengeSolvedNotificationComponent', () => {
     component.showNotification({ key: 'test', challenge: 'Test', flag: '1234' })
     tick()
 
-    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: { name: 'Canada', code: 'CA' }, hasCodingChallenge: false }])
+    expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: { name: 'Canada', code: 'CA' }, codingChallenge: false }])
   }))
 
   it('should copy text to clipboard when navigator.clipboard is available', fakeAsync(() => {

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
@@ -53,7 +53,7 @@ describe('ChallengeSolvedNotificationComponent', () => {
     translateService.onTranslationChange = new EventEmitter()
     translateService.onDefaultLangChange = new EventEmitter()
     cookieService = jasmine.createSpyObj('CookieService', ['put'])
-    challengeService = jasmine.createSpyObj('ChallengeService', ['continueCode'])
+    challengeService = jasmine.createSpyObj('ChallengeService', ['continueCode', 'find'])
     configurationService = jasmine.createSpyObj('ConfigurationService', ['getApplicationConfiguration'])
     configurationService.getApplicationConfiguration.and.returnValue(of({}))
     countryMappingService = jasmine.createSpyObj('CountryMappingService', ['getCountryMapping'])

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -57,7 +57,7 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
   public showCtfFlagsInNotifications = false
   public showCtfCountryDetailsInNotifications = 'none'
   public countryMap?: any
-  public codingChallengesEnabled = "solved";
+  public codingChallengesEnabled = "solved"
 
   ngOnInit (): void {
     this.ngZone.runOutsideAngular(() => {
@@ -104,7 +104,7 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
       }
 
        if (config?.challenges?.codingChallengesEnabled) {
-          this.codingChallengesEnabled = config.challenges.codingChallengesEnabled;
+          this.codingChallengesEnabled = config.challenges.codingChallengesEnabled
         }
 
     })

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -51,7 +51,7 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
   private readonly ref = inject(ChangeDetectorRef)
   private readonly io = inject(SocketIoService)
   private readonly snackBarHelperService = inject(SnackBarHelperService)
-  private readonly router = inject(Router);
+  private readonly router = inject(Router)
 
   public notifications: ChallengeSolvedNotification[] = []
   public showCtfFlagsInNotifications = false
@@ -124,13 +124,13 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
           country = this.countryMap[challenge.key]
         }
 
-        let hasCodingChallenge = false;
+        let hasCodingChallenge = false
         this.challengeService.find().subscribe({
           next: (challenges) => {
             const matchingChallenge = challenges.find(
               (c) => c.key === challenge.key
-            );
-            hasCodingChallenge = matchingChallenge?.hasCodingChallenge ?? false;
+            )
+            hasCodingChallenge = matchingChallenge?.hasCodingChallenge ?? false
 
             this.notifications.push({
               message,
@@ -139,8 +139,8 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
               country,
               copied: false,
               hasCodingChallenge,
-            });
-            this.ref.detectChanges();
+            })
+            this.ref.detectChanges()
             
           },
           error: () => {
@@ -151,8 +151,8 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
               country,
               copied: false,
               hasCodingChallenge: false,
-            });
-            this.ref.detectChanges();
+            })
+            this.ref.detectChanges()
           },
         })
         this.ref.detectChanges()
@@ -183,12 +183,12 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
 
   navigateToChallenge(challengeKey: string) {
     if (!challengeKey) {
-      return;
+      return
     }
     this.ngZone.run(() => {
       void this.router.navigate(["/score-board"], {
         queryParams: { highlightChallenge: challengeKey },
-      });
-    });
+      })
+    })
   }
 }

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -24,6 +24,7 @@ interface ChallengeSolvedMessage {
   isRestore?: any
   flag: any
   key?: any
+  codingChallenge?: boolean
 }
 
 interface ChallengeSolvedNotification {
@@ -32,7 +33,7 @@ interface ChallengeSolvedNotification {
   flag: string
   country?: { code: string, name: string }
   copied: boolean
-  hasCodingChallenge?: boolean;
+  codingChallenge?: boolean;
 }
 
 @Component({
@@ -102,11 +103,6 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
           this.showCtfCountryDetailsInNotifications = 'none'
         }
       }
-
-       if (config?.challenges?.codingChallengesEnabled) {
-          this.codingChallengesEnabled = config.challenges.codingChallengesEnabled
-        }
-
     })
   }
 
@@ -129,37 +125,13 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
         if (this.showCtfCountryDetailsInNotifications && this.showCtfCountryDetailsInNotifications !== 'none') {
           country = this.countryMap[challenge.key]
         }
-
-        let hasCodingChallenge = false
-        this.challengeService.find().subscribe({
-          next: (challenges) => {
-            const matchingChallenge = challenges.find(
-              (c) => c.key === challenge.key
-            )
-            hasCodingChallenge = matchingChallenge?.hasCodingChallenge ?? false
-
-            this.notifications.push({
-              message,
-              key: challenge.key,
-              flag: challenge.flag,
-              country,
-              copied: false,
-              hasCodingChallenge,
-            })
-            this.ref.detectChanges()
-            
-          },
-          error: () => {
-            this.notifications.push({
-              message,
-              key: challenge.key,
-              flag: challenge.flag,
-              country,
-              copied: false,
-              hasCodingChallenge: false,
-            })
-            this.ref.detectChanges()
-          },
+        this.notifications.push({
+          message,
+          key: challenge.key,
+          flag: challenge.flag,
+          country,
+          copied: false,
+          codingChallenge: challenge.codingChallenge ?? false,
         })
         this.ref.detectChanges()
       })

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -57,6 +57,7 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
   public showCtfFlagsInNotifications = false
   public showCtfCountryDetailsInNotifications = 'none'
   public countryMap?: any
+  public codingChallengesEnabled = "solved";
 
   ngOnInit (): void {
     this.ngZone.runOutsideAngular(() => {
@@ -101,6 +102,11 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
           this.showCtfCountryDetailsInNotifications = 'none'
         }
       }
+
+       if (config?.challenges?.codingChallengesEnabled) {
+          this.codingChallengesEnabled = config.challenges.codingChallengesEnabled;
+        }
+
     })
   }
 

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.html
@@ -41,9 +41,11 @@
         [disabled]="challenge.solved === false && applicationConfiguration.challenges.codingChallengesEnabled !== 'always'"
       [ngClass]="{
         'partially-completed': challenge.codingChallengeStatus === 1,
-        'completed': challenge.codingChallengeStatus === 2
+        'completed': challenge.codingChallengeStatus === 2,
+        'flickering': highlightCodingButton
       }"
         [matTooltip]="(challenge.solved ? 'LAUNCH_CODING_CHALLENGE' : 'SOLVE_HACKING_CHALLENGE') | translate"
+        #codingChallengeTooltip="matTooltip"
         >
         @if (challenge.codingChallengeStatus !== 0) {
           <span class="badge-status">{{ challenge.codingChallengeStatus }}/2</span>

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
@@ -216,3 +216,22 @@ $badge-size: 24px;
     color: var(--theme-accent);
   }
 }
+
+.badge.not-completable.flickering {
+  animation: coding-button-flicker 0.7s ease-in-out infinite;
+  box-shadow: 0 0 0 0 rgba(133, 182, 158, 0.7);
+}
+
+@keyframes coding-button-flicker {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(95, 192, 145, 0.7);
+  }
+
+  50% {
+    opacity: 0.85;
+    transform: scale(1.08);
+    box-shadow: 0 0 20px 10px rgba(95, 192, 145, 0.9);
+  }
+}

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
@@ -219,19 +219,19 @@ $badge-size: 24px;
 
 .badge.not-completable.flickering {
   animation: coding-button-flicker 0.7s ease-in-out infinite;
-  box-shadow: 0 0 0 0 rgba(133, 182, 158, 0.7);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--theme-accent) 90%, transparent);
 }
 
 @keyframes coding-button-flicker {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(95, 192, 145, 0.7);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--theme-accent) 90%, transparent);
     opacity: 1;
     transform: scale(1);
   }
 
   50% {
-    box-shadow: 0 0 20px 10px rgba(95, 192, 145, 0.9);
+    box-shadow: 0 0 20px 10px color-mix(in srgb, var(--theme-accent) 90%, transparent);
     opacity: 0.85;
     transform: scale(1.08);
   }

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.scss
@@ -223,15 +223,16 @@ $badge-size: 24px;
 }
 
 @keyframes coding-button-flicker {
-  0%, 100% {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(95, 192, 145, 0.7);
     opacity: 1;
     transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(95, 192, 145, 0.7);
   }
 
   50% {
+    box-shadow: 0 0 20px 10px rgba(95, 192, 145, 0.9);
     opacity: 0.85;
     transform: scale(1.08);
-    box-shadow: 0 0 20px 10px rgba(95, 192, 145, 0.9);
   }
 }

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, type OnInit, inject, type OnChanges, type SimpleChanges, ViewChild } from '@angular/core'
+import { Component, Input, type OnInit, inject, type OnChanges, type SimpleChanges, ViewChild, HostBinding } from '@angular/core'
 import { EnrichedChallenge } from '../../types/EnrichedChallenge'
 import { Config } from 'src/app/Services/configuration.service'
 import { TranslateModule } from '@ngx-translate/core'
@@ -38,6 +38,16 @@ export class ChallengeCardComponent implements OnInit, OnChanges {
   @ViewChild('hintTooltip')
   public hintTooltip?: MatTooltip
 
+  @ViewChild('codingChallengeTooltip')
+  public codingChallengeTooltip?: MatTooltip
+
+  @Input()
+  public highlightCodingButton: boolean = false
+
+  @Input()
+  @HostBinding('attr.id')
+  public challengeId?: string
+
   private previousHintsUnlocked?: number
 
   public hasInstructions: (challengeName: string) => boolean = () => false
@@ -60,6 +70,18 @@ export class ChallengeCardComponent implements OnInit, OnChanges {
         queueMicrotask(() => setTimeout(()=>{this.hintTooltip?.show()}, 50))
       }
       this.previousHintsUnlocked = currentHintsUnlocked
+    }
+
+    if (changes['highlightCodingButton']) {
+      if (changes['highlightCodingButton'].currentValue === true) {
+        queueMicrotask(() => {
+          setTimeout(() => {
+            this.codingChallengeTooltip?.show()
+          }, 1000)
+        })
+      } else if (changes['highlightCodingButton'].previousValue === true && changes['highlightCodingButton'].currentValue === false) {
+        this.codingChallengeTooltip?.hide()
+      }
     }
   }
 

--- a/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
+++ b/frontend/src/app/score-board/components/challenge-card/challenge-card.component.ts
@@ -42,7 +42,7 @@ export class ChallengeCardComponent implements OnInit, OnChanges {
   public codingChallengeTooltip?: MatTooltip
 
   @Input()
-  public highlightCodingButton: boolean = false
+  public highlightCodingButton = false
 
   @Input()
   @HostBinding('attr.id')

--- a/frontend/src/app/score-board/score-board.component.html
+++ b/frontend/src/app/score-board/score-board.component.html
@@ -39,6 +39,8 @@
           [repeatChallengeNotification]="repeatChallengeNotification.bind(this)"
           [unlockHint]="unlockHint.bind(this)"
           [lastUnlockedChallengeKey]="lastUnlockedChallengeKey"
+          [highlightCodingButton]="highlightedChallengeKey === challenge.key"
+          [challengeId]="'challenge-' + challenge.key"
           [ngClass]="{ solved: challenge.solved, unsolved: !challenge.solved, disabled: challenge.disabledEnv !== null }"
           />
       }

--- a/frontend/src/app/score-board/score-board.component.ts
+++ b/frontend/src/app/score-board/score-board.component.ts
@@ -44,7 +44,7 @@ interface CodeChallengeSolvedWebsocket {
   styleUrls: ['./score-board.component.scss'],
   imports: [HackingChallengeProgressScoreCardComponent, CodingChallengeProgressScoreCardComponent, DifficultyOverviewScoreCardComponent, FilterSettingsComponent, MatProgressSpinner, ChallengesUnavailableWarningComponent, TutorialModeWarningComponent, ChallengeCardComponent, NgClass, TranslateModule]
 })
-export class ScoreBoardComponent implements OnInit, OnDestroy {
+export class ScoreBoardComponent implements OnInit, OnDestroy, AfterViewInit {
   private readonly challengeService = inject(ChallengeService)
   private readonly hintService = inject(HintService)
   private readonly configurationService = inject(ConfigurationService)
@@ -223,7 +223,7 @@ export class ScoreBoardComponent implements OnInit, OnDestroy {
         element.scrollIntoView({ behavior: 'smooth', block: 'center' })
       }
       else{
-        return;
+        return
       }
       setTimeout(() => {
         this.highlightedChallengeKey = null

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -422,6 +422,7 @@
   "CATEGORY_OBSERVABILITY_FAILURES_DESCRIPTION": "Insufficient logging, monitoring, and alerting makes it impossible to detect attacks and breaches. This occurs when auditable events are not logged, warnings and errors generate unclear messages, logs are not monitored for suspicious activity, appropriate alerting is missing or ineffective, or logs expose sensitive information. Without proper observability, organizations cannot detect active attacks in real-time, respond to security incidents effectively, or maintain an audit trail for forensic analysis.",
   "INSUFFICIENT_WALLET_BALANCE": "Insufficient wallet balance.",
   "LAUNCH_CODING_CHALLENGE": "Launch associated coding challenge.",
+  "JUMP_TO_RELATED_CODING_CHALLENGE": "Jump to related coding challenge",
   "LOADING_CODE_SNIPPET": "Loading code snippet...",
   "SOLVE_HACKING_CHALLENGE": "Solve the hacking challenge to unlock the associated coding challenge.",
   "LABEL_CORRECT_FIX": "Correct Fix",

--- a/frontend/src/hacking-instructor/index.ts
+++ b/frontend/src/hacking-instructor/index.ts
@@ -20,7 +20,6 @@ import { CodingChallengesInstruction } from './challenges/codingChallenges'
 import { AdminSectionInstruction } from './challenges/adminSection'
 import { ReflectedXssInstruction } from './challenges/reflectedXss'
 import { ExposedCredentialsInstruction } from './challenges/exposedCredentials'
-import { waitInMs } from './helpers/helpers'
 
 const challengeInstructions: ChallengeInstruction[] = [
   ScoreBoardInstruction,
@@ -40,15 +39,15 @@ const challengeInstructions: ChallengeInstruction[] = [
 ]
 
 challengeInstructions.map((challenge) => {
-  const lastHint = challenge.hints.at(-1);
+  const lastHint = challenge.hints.at(-1)
   if (lastHint) {
     lastHint.text +=
       `\n\n---\n\n` +
       `Liked this Challenge?... Solve some Coding-Challenges related to this challenge.\n\n` +
-      `##### [What are coding challenges?](https://demo.owasp-juice.shop/#/hacking-instructor?challenge=Coding%20Challenges)`;
+      `##### [What are coding challenges?](https://demo.owasp-juice.shop/#/hacking-instructor?challenge=Coding%20Challenges)`
   }
-  return challenge;
-});
+  return challenge
+})
 
 export interface ChallengeInstruction {
   name: string

--- a/frontend/src/hacking-instructor/index.ts
+++ b/frontend/src/hacking-instructor/index.ts
@@ -38,17 +38,6 @@ const challengeInstructions: ChallengeInstruction[] = [
   ExposedCredentialsInstruction
 ]
 
-challengeInstructions.map((challenge) => {
-  const lastHint = challenge.hints.at(-1)
-  if (lastHint) {
-    lastHint.text +=
-      `\n\n---\n\n` +
-      `Liked this Challenge?... Solve some Coding-Challenges related to this challenge.\n\n` +
-      `##### [What are coding challenges?](https://demo.owasp-juice.shop/#/hacking-instructor?challenge=Coding%20Challenges)`
-  }
-  return challenge
-})
-
 export interface ChallengeInstruction {
   name: string
   hints: ChallengeHint[]

--- a/frontend/src/hacking-instructor/index.ts
+++ b/frontend/src/hacking-instructor/index.ts
@@ -20,6 +20,7 @@ import { CodingChallengesInstruction } from './challenges/codingChallenges'
 import { AdminSectionInstruction } from './challenges/adminSection'
 import { ReflectedXssInstruction } from './challenges/reflectedXss'
 import { ExposedCredentialsInstruction } from './challenges/exposedCredentials'
+import { waitInMs } from './helpers/helpers'
 
 const challengeInstructions: ChallengeInstruction[] = [
   ScoreBoardInstruction,
@@ -37,6 +38,17 @@ const challengeInstructions: ChallengeInstruction[] = [
   ReflectedXssInstruction,
   ExposedCredentialsInstruction
 ]
+
+challengeInstructions.map((challenge) => {
+  const lastHint = challenge.hints.at(-1);
+  if (lastHint) {
+    lastHint.text +=
+      `\n\n---\n\n` +
+      `Liked this Challenge?... Solve some Coding-Challenges related to this challenge.\n\n` +
+      `##### [What are coding challenges?](https://demo.owasp-juice.shop/#/hacking-instructor?challenge=Coding%20Challenges)`;
+  }
+  return challenge;
+});
 
 export interface ChallengeInstruction {
   name: string

--- a/lib/challengeUtils.ts
+++ b/lib/challengeUtils.ts
@@ -46,13 +46,23 @@ export const solve = function (challenge: any, isRestore = false) {
 export const sendNotification = function (challenge: { difficulty?: number, key: any, name: any, description?: any }, isRestore: boolean) {
   if (!notSolved(challenge)) {
     const flag = utils.ctfFlag(challenge.name)
+
+    const challengeKey = challenge.key as ChallengeKey
+    const fullChallenge = challenges[challengeKey]
+
+    let hasCodingChallenge = false
+    if (fullChallenge) {
+      hasCodingChallenge = Boolean(fullChallenge.hasCodingChallenge) ?? false
+    }
+
     const notification = {
       key: challenge.key,
       name: challenge.name,
       challenge: challenge.name + ' (' + entities.decode(sanitizeHtml(challenge.description, { allowedTags: [], allowedAttributes: {} })) + ')',
       flag,
       hidden: !config.get('challenges.showSolvedNotifications'),
-      isRestore
+      isRestore,
+      codingChallenge: config.get('challenges.codingChallengesEnabled') !== 'never' && hasCodingChallenge
     }
     const wasPreviouslyShown = notifications.some(({ key }) => key === challenge.key)
     notifications.push(notification)


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
As mentioned in the issue, The "challenged solved" notification now has a `coding challenge button`. Clicking the button (from any page) will redirect to the `score-board` page with a query pointing to the specific challenge. The page then scrolls down to that challenge and the `coding challenge button` flickers for some seconds along with => the `hover-modal` (describing the button) also automatically opneing & closing after some seconds. 
If Hacking-instructor is enabled => on the last message of the instructor (after a challenge is solved), there contains a link to `What are Coding Challenges` as mentioned in the comments of the issue

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` --> #2875 

#### What's Changed?

1. A new button is added in the notification for challenge which does have a coding-challenge feature.
2. All the challenge components are assigned a unique `id` via the `@HostBinding` decorator and are used to find the challenge card once a URL with `/#/score-board?highlightChallenge=abcd` is hit. This triggers a scroll & flickering which focuses the Coding-Challenge button.
3. After ~4sec. The flickering is stopped and the Address Bar is cleaned to remove the query parameter, as it may interrupt further actions on the page.


https://github.com/user-attachments/assets/1ff1ad4e-dddd-4f91-98e7-c7f4599505d5



4. (`Hacking Instructor`) The index.ts file in the `frontend/hacking-instructor` folder imports hints of several Hacking Challenges from different other files. After the import => the last instruction (congratulations one) of every Challenge is modified so that it also contains the link to "What are Coding Challenges".
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3d59ef15-337e-44bb-b501-65a12a97f02c" />




### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines

Note for Code Reviewer: This PR has has 3 commits. First for notification behavior change, second one for Hacking Instructor, and third one was a `lint:fix`.