### PR TITLE
[#2915] Refactor spacing tokens and update about us page

### DIFF
--- a/frontend/src/app/about/about.component.scss
+++ b/frontend/src/app/about/about.component.scss
@@ -6,7 +6,7 @@
 @use '../../styles/variables' as *;
 
 mat-card {
-  margin-bottom: $space-l;
+  margin-bottom: $space-xl;
   margin-left: auto;
   margin-right: auto;
   width: 80%;
@@ -34,7 +34,7 @@ mat-card {
 }
 
 button {
-  margin: $space-xxs;
+  margin: $space-2xs;
 }
 
 .text-justify {

--- a/frontend/src/styles/_variables.scss
+++ b/frontend/src/styles/_variables.scss
@@ -7,14 +7,16 @@
 // Standardized spacing for margins, paddings, and gaps using REM units.
 // Example: margin-bottom: $space-m;
 
-$space-xxxs: 0.125rem; // 2px
-$space-xxs: 0.25rem;   // 4px
-$space-xs: 0.5rem;     // 8px
-$space-s: 0.625rem;    // 10px
-$space-m: 1rem;        // 16px
-$space-ms: 1.25rem;    // 20px
-$space-ml: 1.5rem;     // 24px
-$space-l: 2rem;        // 32px
-$space-xls: 2.5rem;    // 40px
-$space-xl: 3rem;       // 48px
-$space-xxl: 4rem;      // 64px
+$space-3xs: 0.125rem; // 2px
+$space-2xs: 0.25rem; // 4px
+$space-xs: 0.5rem; // 8px
+$space-s: 0.625rem; // 10px
+
+$space-m: 1rem; // 16px
+
+$space-ml: 1.25rem; // 20px
+$space-l: 1.5rem; // 24px
+$space-xl: 2rem; // 32px
+$space-2xl: 2.5rem; // 40px
+$space-3xl: 3rem; // 48px
+$space-4xl: 4rem; // 64px


### PR DESCRIPTION
### Description
This PR updates the spacing tokens as suggested by @caffeine-rohit (see #2915).

In addition to renaming the token, it also adjusts the spacing used in the **About Us** component to align with the updated spacing scale.

### Updated spacing tokens

```scss
$space-3xs: 0.125rem;  // 2px
$space-2xs: 0.25rem;   // 4px
$space-xs:  0.5rem;    // 8px
$space-s:   0.625rem;  // 10px

$space-m:   1rem;      // 16px (base)

$space-ml:  1.25rem;   // 20px
$space-l:   1.5rem;    // 24px
$space-xl:  2rem;      // 32px
$space-2xl: 2.5rem;    // 40px
$space-3xl: 3rem;      // 48px
$space-4xl: 4rem;      // 64px
```

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
