### PR TITLE
Add educational hint explaining password length exposure in Login Amy challenge

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -608,6 +608,7 @@
     - 'You might be lucky with a dedicated attack pattern even if you have no clue about the admin email address.'
     - 'If you harvested the admin’s password hash, you can of course try to attack that instead of using SQL Injection.'
     - 'Alternatively you can solve this challenge as a combo with the Log in with the administrator’s user credentials without previously changing them or applying SQL Injection challenge.'
+    - 'Even when characters are masked, revealing the exact password length can significantly reduce the search space and help attackers optimize guessing attempts.'
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html'
   key: loginAdminChallenge
   tutorial:


### PR DESCRIPTION
… challenge

<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

Added an educational hint to the Login Amy challenge (`loginAmyChallenge`) in `challenges.yml`. 
The hint explains that the challenge **exposes the password length**, which can help learners understand why this is a security concern.

Resolved or fixed issue: none


### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
