### PR TITLE
fix: solve unsigned JWT challenge without verification

### DIFF
--- a/routes/verify.ts
+++ b/routes/verify.ts
@@ -114,13 +114,19 @@ function jwtChallenge (challenge: Challenge, req: Request, algorithm: string, em
       return
     }
 
-    jwt.verify(token, security.publicKey, (err: jwt.VerifyErrors | null) => {
-      if (err === null) {
-        challengeUtils.solveIf(challenge, () => {
-          return hasAlgorithm(token, algorithm) && hasEmail(decoded as { data: { email: string } }, email)
-        })
-      }
-    })
+    if (!hasAlgorithm(token, algorithm) || !hasEmail(decoded as { data: { email: string } }, email)) {
+      return
+    }
+
+    if (algorithm === 'none') {
+      challengeUtils.solve(challenge)
+    } else if (algorithm === 'HS256') {
+      jwt.verify(token, security.publicKey, { algorithms: ['HS256'] }, (err: jwt.VerifyErrors | null) => {
+        if (err === null) {
+          challengeUtils.solve(challenge)
+        }
+      })
+    }
   }
 }
 


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 7 / 30 / ∞ days ban from
interacting with the project depending on reoccurrence and severity. You can find more
information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description
Fixed the unsigned JWT challenge which was failing with 401 Unauthorized errors when using unsigned/fake-signed JWT tokens. The issue occurred because `jwt.verify()` was being called on all tokens, including those with `alg: none`, causing verification to always fail for unsigned tokens.

**Changes:**
- Skip `jwt.verify()` for tokens with `alg: none` and solve challenge immediately
- Add early validation for algorithm and email before attempting to solve
- Specify `algorithms: ['HS256']` option when verifying HS256 tokens to maintain security
<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->#1788

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
