### PR TITLE
Refactor: replace non-semantic div with header and h1/h2 tags

### DIFF
--- a/frontend/src/app/search-result/search-result.component.html
+++ b/frontend/src/app/search-result/search-result.component.html
@@ -6,17 +6,19 @@
 <div class="center-align">
   <div class="table-container custom-slate">
 
-    <div class="heading mat-elevation-z6">
-      @if (searchValue) {
-        <div>
-          <span>{{"TITLE_SEARCH_RESULTS" | translate}} - </span>
-          <span id="searchValue" [innerHTML]="searchValue"></span>
-        </div>
-      } @else {
-        <div>{{"TITLE_ALL_PRODUCTS" | translate}}</div>
-      }
-      <div id="search-result-heading"></div>
+    <header class="heading mat-elevation-z6">
+  @if (searchValue) {
+    <div>
+      <h2 style="display: inline; margin: 0; font-size: inherit;">
+        <span>{{"TITLE_SEARCH_RESULTS" | translate}} - </span>
+        <span id="searchValue" [innerHTML]="searchValue"></span>
+      </h2>
     </div>
+  } @else {
+    <h1 style="margin: 0; font-size: inherit;">{{"TITLE_ALL_PRODUCTS" | translate}}</h1>
+  }
+  <div id="search-result-heading"></div>
+</header>
 
     @if (!emptyState) {
       <div>


### PR DESCRIPTION
Refactored the SearchResultComponent to improve accessibility by replacing non-semantic <div> elements with meaningful HTML5 tags.

Changes:

    Replaced the header <div> with a semantic <header> element.

    Introduced <h1> and <h2> tags for product titles to provide proper heading hierarchy for screen readers.

    Maintained existing UI styling using inline CSS to ensure no visual regressions.

This is part of the ongoing accessibility modernization effort to help users with assistive technologies navigate the application more effectively.

Resolved or fixed issue: #2868
Affirmation

    [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines