### PR TITLE
Fix: Accept forged JWT tokens for authorization (fixes #1788)

### DIFF
--- a/routes/currentUser.ts
+++ b/routes/currentUser.ts
@@ -12,7 +12,10 @@ export function retrieveLoggedInUser () {
   return (req: Request, res: Response) => {
     let user
     try {
-      if (security.verify(req.cookies.token)) {
+      // First try to get user from Authorization header (for forged JWT tokens)
+      user = security.authenticatedUsers.from(req)
+      // Fall back to cookie token - check authenticatedUsers directly (for forged cookie tokens)
+      if (!user) {
         user = security.authenticatedUsers.get(req.cookies.token)
       }
     } catch (err) {

--- a/server.ts
+++ b/server.ts
@@ -346,6 +346,8 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   /** Authorization **/
   /* Checks on JWT in Authorization header */ // vuln-code-snippet hide-line
   app.use(verify.jwtChallenges()) // vuln-code-snippet hide-line
+  /* Register forged JWT tokens that pass vulnerable jwt.verify */
+  app.use(security.updateAuthenticatedUsers())
   /* Baskets: Unauthorized users are not allowed to access baskets */
   app.use('/rest/basket', security.isAuthorized(), security.appendUserId())
   /* BasketItems: API only accessible for authenticated users */


### PR DESCRIPTION
## Description

Fixes #1788 

This PR fixes the issue where forged JWT tokens (for the "Forge an essentially unsigned JWT token" and "Forge an almost properly RSA-signed JWT token" challenges) return `401 Unauthorized` even though the challenges are marked as solved.

## Root Cause

The issue occurred because forged JWT tokens were never registered in the `authenticatedUsers` map. While the [jwtChallenges](cci:1://file:///d:/GSoC/juice-shop/routes/verify.ts:80:0-88:1) middleware correctly detected and solved the challenges, subsequent middleware ([isAuthorized](cci:1://file:///d:/GSoC/juice-shop/lib/insecurity.ts:53:0-53:76), [appendUserId](cci:1://file:///d:/GSoC/juice-shop/lib/insecurity.ts:176:0-185:1)) failed because:

1. [appendUserId()](cci:1://file:///d:/GSoC/juice-shop/lib/insecurity.ts:176:0-185:1) tried to access `authenticatedUsers.tokenMap[token].data.id` which was `undefined`
2. [retrieveLoggedInUser()](cci:1://file:///d:/GSoC/juice-shop/routes/currentUser.ts:10:0-32:1) used `security.verify()` which performs strict signature verification and rejects `alg: none` tokens

## Changes Made

### [lib/insecurity.ts](cci:7://file:///d:/GSoC/juice-shop/lib/insecurity.ts:0:0-0:0)
- Modified [updateAuthenticatedUsers()](cci:1://file:///d:/GSoC/juice-shop/lib/insecurity.ts:187:0-215:1) to register **both** header and cookie tokens
- Header token is registered and propagated to cookie via `res.cookie()`
- Cookie token is registered separately (if different from header) to support forged cookies

### [routes/currentUser.ts](cci:7://file:///d:/GSoC/juice-shop/routes/currentUser.ts:0:0-0:0)
- Removed strict `security.verify()` check that was rejecting forged tokens
- Now checks `authenticatedUsers` directly for cookie tokens

### [server.ts](cci:7://file:///d:/GSoC/juice-shop/server.ts:0:0-0:0)
- Added `security.updateAuthenticatedUsers()` middleware after `verify.jwtChallenges()` to register forged tokens globally

## How to Test

### Unsigned JWT Challenge (alg: none)
1. Login as any user (e.g., admin via SQL injection)
2. Capture the JWT token from the request
3. Forge a token with `alg: none` and email `jwtn3d@juice-sh.op`
4. Send request to `/rest/basket/1` with the forged token in Authorization header
5. **Expected**: 200 OK with basket data (previously returned 401)

### Algorithm Confusion Challenge (HS256 with public key)
1. Forge a token signed with HS256 using the public RSA key as secret
2. Set email to `rsa_lord@juice-sh.op`
3. Send request with the forged token
4. **Expected**: 200 OK (previously returned 401)

### Cookie-based Testing
1. Set the forged token directly in the browser cookie
2. Navigate to pages that use the token
3. **Expected**: Forged user identity is recognized

## Checklist

- [x] All changes are related to the issue
- [x] No unrelated files modified
- [x] Tested with both `alg: none` and HS256 forged tokens
- [x] Works with both Authorization header and cookie tokens