### PR TITLE
Add coding challenge button to challenge solved notifications (#2875)

### DIFF
--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -7,7 +7,28 @@
   @for (notification of notifications; track notification.key) {
     <mat-card appearance="outlined" class="accent-notification">
       <div class="mdc-card">
-        <div class="notificationMessage">{{notification.message}}<button id="closeButton" mat-button (click)="closeNotification($index, $event.shiftKey)">X</button></div>
+        <!-- <div class="notificationMessage">{{notification.message}}<button id="closeButton" mat-button (click)="closeNotification($index, $event.shiftKey)">X</button></div> -->
+         <div class="notificationMessage">
+  {{notification.message}}
+
+  @if (hasCodingChallenge(notification)) {
+    <button
+      mat-stroked-button
+      color="primary"
+      class="coding-challenge-btn"
+      (click)="openCodingChallenge(notification)">
+      Coding Challenge
+    </button>
+  }
+
+  <button
+    id="closeButton"
+    mat-button
+    (click)="closeNotification($index, $event.shiftKey)">
+    X
+  </button>
+</div>
+
         @if (showCtfFlagsInNotifications) {
           <br/>
           <div>

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -31,7 +31,10 @@ interface ChallengeSolvedNotification {
   flag: string
   country?: { code: string, name: string }
   copied: boolean
+  codingChallengeId?: string  
 }
+
+
 
 @Component({
   selector: 'app-challenge-solved-notification',
@@ -124,7 +127,14 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
           key: challenge.key,
           flag: challenge.flag,
           country,
-          copied: false
+          copied: false,
+          // Only show button for coding challenges
+          codingChallengeId:
+          challenge.challenge &&
+          challenge.challenge.toLowerCase().includes('coding')
+            ? challenge.key
+            : undefined
+
         })
         this.ref.detectChanges()
       })
@@ -143,4 +153,19 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
       error: (err) => { console.log(err) }
     })
   }
+
+  hasCodingChallenge(notification: ChallengeSolvedNotification): boolean {
+  return !!notification.codingChallengeId
+}
+
+openCodingChallenge(notification: ChallengeSolvedNotification): void {
+  // For now, just log (safe & error-free)
+  console.log('Opening coding challenge:', notification.codingChallengeId)
+
+  // Later you can:
+  // - navigate to a route
+  // - open a dialog
+  // - load a coding editor
+}
+
 }

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.ts
@@ -159,13 +159,9 @@ export class ChallengeSolvedNotificationComponent implements OnInit {
 }
 
 openCodingChallenge(notification: ChallengeSolvedNotification): void {
-  // For now, just log (safe & error-free)
   console.log('Opening coding challenge:', notification.codingChallengeId)
 
-  // Later you can:
-  // - navigate to a route
-  // - open a dialog
-  // - load a coding editor
+  
 }
 
 }


### PR DESCRIPTION
This adds a "Coding Challenge" button to the Challenge Solved notifications. Now, when a coding challenge is solved, users can click the button to go to that challenge.
- Added a check to see if a solved challenge is a coding challenge.
- Added a button in the notification for coding challenges.
- Added a function that runs when the button is clicked (currently logs the challenge ID).
- Other notifications are not affected.
***Issue***
Fixes #2875