### PR TITLE
feat(a11y): replace non-semantic elements with semantic HTML in navbar

### DIFF
--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -13,19 +13,19 @@
     </button>
 
     <button mat-button routerLink="/search" style="height:60px;" class="buttons" aria-label="Back to homepage">
-      <div id="homeButton">
+      <span id="homeButton">
         <img [src]="logoSrc" class="logo" alt={{applicationName}}>
         <span class="hide-lt-sm" style="font-size: x-large"> {{applicationName}} </span>
-      </div>
+      </span>
     </button>
 
     <span class="fill-remaining-space"></span>
 
-    <div>
-      <div id="product-search-fixture"></div>
-    </div>
-    <app-mat-search-bar #searchControl id="searchQuery" (onEnter)="search(searchControl.value)"
-    aria-label="Click to search"></app-mat-search-bar>
+    <search role="search">
+      <span id="product-search-fixture"></span>
+      <app-mat-search-bar #searchControl id="searchQuery" (onEnter)="search(searchControl.value)"
+      aria-label="Click to search"></app-mat-search-bar>
+    </search>
 
     <button [matMenuTriggerFor]="userMenu" mat-button style="vertical-align: middle; height:48px;" class="buttons hide-lt-md"
       aria-label="Show/hide account menu" id="navbarAccount">
@@ -123,13 +123,13 @@
     </button>
 
     <mat-menu #menu="matMenu" [overlapTrigger]="true">
-      <div class="language-search-container" (click)="$event.stopPropagation()">
+      <search class="language-search-container" role="search" (click)="$event.stopPropagation()">
         <mat-form-field class="language-search-field">
           <mat-icon matPrefix class="search-icon">search</mat-icon>
           <mat-label>{{ 'SEARCH' | translate }}</mat-label>
           <input type="search" matInput [(ngModel)]="languageSearchQuery" (input)="filterLanguages()">
         </mat-form-field>
-      </div>
+      </search>
       @for (language of filteredLanguages; track language.key) {
         <mat-radio-button
           (click)="changeLanguage(language.key)"
@@ -139,12 +139,12 @@
           [checked]="selectedLanguage === language"
           [aria-label]="language.lang"
           >
-          <div class="mat-body" style="display: inline-block; width: 200px; margin-left: 5px;">
+          <span class="mat-body" style="display: inline-block; width: 200px; margin-left: 5px;">
             @for (icon of language.icons; track icon) {
               <span [class]="'fi fi-' + icon"></span>
             }
             {{language?.lang}}
-          </div>
+          </span>
           <i [class]="'fas fa-thermometer-' + language.gauge + (language.percentage > 70 ? ' confirmation' : ' error')"></i>
         </mat-radio-button>
       }


### PR DESCRIPTION
### Description

This PR replaces generic `<div>` elements with meaningful, semantic HTML tags in the navbar component to improve accessibility.

**Changes:**
- Replace outer div wrapper around search with `<search role="search">`
- Replace nested div (product-search-fixture) with `<span>`
- Replace `<div id="homeButton">` with `<span>` for inline content
- Replace language search `<div>` with `<search role="search">`
- Replace `<div class="mat-body">` with `<span>` (already inline-block)

**Benefits:**
- Assistive technologies can now identify search regions via `role="search"`
- Better semantic structure for screen readers
- Follows HTML5 best practices using the `<search>` element
- Inline elements now use appropriate inline tags (`<span>`)

Resolved or fixed issue: #2868

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Windsurf Cascade`
    - LLMs and versions: `Claude Sonnet 4`
    - Prompts: `Replace non-semantic div elements with semantic HTML in navbar component as proposed in issue #2868, including <search> elements with role="search" attribute`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=162055292