### PR TITLE
test: add validation for challenge tags against i18n keys

### DIFF
--- a/test/api/challengeTagSpec.ts
+++ b/test/api/challengeTagSpec.ts
@@ -1,4 +1,3 @@
-
 import path = require('path')
 import fs = require('fs')
 import { load } from 'js-yaml'

--- a/test/api/challengeTagSpec.ts
+++ b/test/api/challengeTagSpec.ts
@@ -1,0 +1,21 @@
+
+import path = require('path')
+import fs = require('fs')
+import { load } from 'js-yaml'
+import { expect } from 'chai'
+
+const challenges = load(fs.readFileSync(path.resolve(__dirname, '../../data/static/challenges.yml'), 'utf8'))
+const en = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../frontend/src/assets/i18n/en.json'), 'utf8'))
+
+describe('Challenge Tags', () => {
+  it('should be present in en.json', () => {
+    challenges.forEach((challenge: any) => {
+      if (challenge.tags) {
+        challenge.tags.forEach((tag: string) => {
+          const tagKey = `TAG_${tag.toUpperCase().replace(/\s/g, '_')}`
+          expect(en[tagKey], `Tag "${tag}" of challenge "${challenge.name}" is missing in en.json (expected key: ${tagKey})`).to.not.equal(undefined)
+        })
+      }
+    })
+  })
+})

--- a/test/server/challengeTagSpec.ts
+++ b/test/server/challengeTagSpec.ts
@@ -17,7 +17,7 @@ describe('Challenge Tags', () => {
       if (challenge.tags) {
         challenge.tags.forEach((tag: string) => {
           const tagKey = `TAG_${tag.toUpperCase().replace(/\s/g, '_')}`
-          expect(en[tagKey], `Tag "${tag}" of challenge "${challenge.name}" is missing in en.json (expected key: ${tagKey})`).to.not.equal(undefined)
+          expect(en[tagKey], `Challenge "${challenge.name}" uses invalid tag "${tag}". All tags must be defined in generic keys starting with "TAG_" in "i18n/en.json". Expected key: "${tagKey}"`).to.not.equal(undefined)
         })
       }
     })

--- a/test/server/challengeTagSpec.ts
+++ b/test/server/challengeTagSpec.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import path = require('path')
 import fs = require('fs')
 import { load } from 'js-yaml'

--- a/test/server/challengeTagSpec.ts
+++ b/test/server/challengeTagSpec.ts
@@ -17,7 +17,7 @@ describe('Challenge Tags', () => {
       if (challenge.tags) {
         challenge.tags.forEach((tag: string) => {
           const tagKey = `TAG_${tag.toUpperCase().replace(/\s/g, '_')}`
-          expect(en[tagKey], `Challenge "${challenge.name}" uses invalid tag "${tag}". All tags must be defined in generic keys starting with "TAG_" in "i18n/en.json". Expected key: "${tagKey}"`).to.not.equal(undefined)
+          expect(en[tagKey], `Challenge "${challenge.name}" uses unsupported tag "${tag}". Only tags listed at https://pwning.owasp-juice.shop/companion-guide/latest/part1/challenges.html#_challenge_tags may be used.`).to.not.equal(undefined)
         })
       }
     })

--- a/test/server/challengeTagSpec.ts
+++ b/test/server/challengeTagSpec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-import path = require('path')
-import fs = require('fs')
+import path from 'path'
+import fs from 'fs'
 import { load } from 'js-yaml'
 import { expect } from 'chai'
 


### PR DESCRIPTION
Hi @tghosth 

Pls review the PR

Details:-
- Adds test/api/challengeTagSpec.ts to cross-reference tags in challenges.yml with en.json
- Ensures every tag used in a challenge has a corresponding TAG_ translation key
- Prevents introduction of non-existent tags

### Affirmation

- My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
