### PR TITLE
UI/UX issues in the registration form

### DIFF
--- a/frontend/src/app/register/register.component.html
+++ b/frontend/src/app/register/register.component.html
@@ -29,11 +29,13 @@
             <mat-label translate>LABEL_PASSWORD</mat-label>
             <input #password id="passwordControl" [formControl]="passwordControl" (focus)="this.error=null" type="password"
               matInput aria-label="Field for the password">
+            <span matTextSuffix class="character-counter">{{password.value?.length || 0}}/40</span>
+            @if (passwordControl.pristine) {
               <mat-hint translate>
                 <i class="fas fa-exclamation-circle"></i>
                 <em class="hint-spacing" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
               </mat-hint>
-              <mat-hint align="end">{{password.value?.length || 0}}/20</mat-hint>
+              }
               @if (passwordControl.invalid && passwordControl.errors.required) {
                 <mat-error translate>MANDATORY_PASSWORD
                 </mat-error>
@@ -49,19 +51,19 @@
               <mat-label translate>LABEL_PASSWORD_REPEAT</mat-label>
               <input #repeatPassword id="repeatPasswordControl" [formControl]="repeatPasswordControl"
                 (focus)="this.error=null" type="password" matInput aria-label="Field to confirm the password">
-                <mat-hint align="end">{{repeatPassword.value?.length || 0}}/40</mat-hint>
+               <span matTextSuffix class="character-counter">{{repeatPassword.value?.length || 0}}/40</span>
                 @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.required) {
                   <mat-error translate>
                     MANDATORY_PASSWORD_REPEAT
                   </mat-error>
-                }
-                @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame) {
+                } @else if (repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame) {
                   <mat-error translate>
                     PASSWORDS_NOT_MATCHING
                   </mat-error>
                 }
               </mat-form-field>
 
+            <div class="password-advice-wrapper">
               <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
               <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
               @if (passwordInfoToggle.checked) {
@@ -73,6 +75,7 @@
                   [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
                 </app-password-strength-info>
               }
+            </div>
 
               <div class="security-container">
 

--- a/frontend/src/app/register/register.component.scss
+++ b/frontend/src/app/register/register.component.scss
@@ -12,7 +12,12 @@ mat-card {
 }
 
 mat-form-field {
+  margin-bottom: $space-m;
   padding-top: $space-s;
+  
+  @media (max-width: 400px) {
+    margin-bottom: $space-ml;
+  }
 }
 
 .form-container {
@@ -52,4 +57,36 @@ mat-form-field {
 
 .hint-spacing {
   margin-left: $space-2xs;
+}
+
+.character-counter {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 12px;
+  margin-left: $space-xs;
+  white-space: nowrap;
+}
+
+.password-advice-wrapper {
+  margin-bottom: $space-m;
+  margin-top: $space-m;
+  
+  @media (max-width: 400px) {
+    margin-bottom: $space-ml;
+    margin-top: $space-ml;
+  }
+}
+
+mat-slide-toggle {
+  display: block;
+  margin-bottom: $space-xs;
+}
+
+app-password-strength {
+  display: block;
+  margin-bottom: $space-xs;
+}
+
+::ng-deep .mat-mdc-form-field-error {
+  line-height: 1.2;
+  margin-top: $space-3xs;
 }

--- a/frontend/src/app/register/register.component.spec.ts
+++ b/frontend/src/app/register/register.component.spec.ts
@@ -109,7 +109,7 @@ describe('RegisterComponent', () => {
     expect(component.passwordControl.valid).toBe(true)
   })
 
-  it('password should not be more than 20 characters', () => {
+  it('password should not be more than 40 characters', () => {
     let password = ''
     for (let i = 0; i < 41; i++) {
       password += 'a'

--- a/frontend/src/app/register/register.component.ts
+++ b/frontend/src/app/register/register.component.ts
@@ -109,6 +109,9 @@ function matchValidator (passwordControl: AbstractControl) {
   return function matchOtherValidate (repeatPasswordControl: UntypedFormControl) {
     const password = passwordControl.value
     const passwordRepeat = repeatPasswordControl.value
+    if (!passwordRepeat || passwordRepeat.length === 0) {
+      return null
+    }
     if (password !== passwordRepeat) {
       return { notSame: true }
     }


### PR DESCRIPTION
### Description

This PR addresses several UI/UX issues in the registration form that were affecting the user experience and form validation feedback.

**Changes:**

**1. Password hint visibility logic**  
The password requirement hint was displaying at all times, including when passwords were valid. Updated to only show the hint when the field is in its initial state (pristine), hiding it once the user begins interacting with valid input.

**2. Error message priority**  
The repeat password field was rendering both "required" and "not matching" errors simultaneously, causing visual overlap. Implemented a priority-based error display using `@else if` and updated the `matchValidator` to return null when the field is empty, ensuring the required validator takes precedence.

**3. Form field spacing**  
Error messages were rendering directly against the next field's border with no breathing room. Added `margin-bottom` to `mat-form-field` with responsive adjustments for mobile viewports.

**4. Password advice toggle isolation**  
Validation errors were flowing into the password advice toggle section, causing overlap. Wrapped the toggle and strength components in a container with proper margin isolation.

**5. Character counter consistency**  
The password field counter displayed `/20` while repeat password showed `/40`, despite both validating against a 40-character maximum. Standardized both to `/40` using `matTextSuffix` with consistent styling. Also updated the test description to reflect the actual validation behavior (40 characters, not 20).

All spacing changes use the project's design tokens and include mobile-responsive adjustments. Tested across desktop, tablet, and mobile viewports.

Resolved or fixed issue: none

### AI Tool Disclosure
- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines

@bkimminich 