### PR TITLE
Replace throw with throwError in catchError and add types to parameters

### DIFF
--- a/frontend/src/app/Services/address.service.ts
+++ b/frontend/src/app/Services/address.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,24 +19,24 @@ export class AddressService {
   private readonly host = this.hostServer + '/api/Addresss'
 
   get () {
-    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
-  getById (id) {
+  getById (id:any) {
 
-    return this.http.get(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((err: Error) => { throw err }))
+    return this.http.get(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((error: Error) => throwError(() => error)))
   }
 
-  save (params) {
-    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+  save (params:any) {
+    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
-  put (id, params) {
+  put (id:any, params:any) {
 
-    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   del (id: number) {
-    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/administration.service.ts
+++ b/frontend/src/app/Services/administration.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +21,7 @@ export class AdministrationService {
   getApplicationVersion () {
     return this.http.get(this.host + '/application-version').pipe(
       map((response: any) => response.version),
-      catchError((error: Error) => { throw error })
+      catchError(catchError((error: Error) => throwError(() => error)))
     )
   }
 }

--- a/frontend/src/app/Services/basket.service.ts
+++ b/frontend/src/app/Services/basket.service.ts
@@ -7,7 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
-import { type Observable, Subject } from 'rxjs'
+import { type Observable, Subject, throwError } from 'rxjs'
 
 interface OrderDetail {
   paymentId: string
@@ -26,38 +26,38 @@ export class BasketService {
   private readonly host = this.hostServer + '/api/BasketItems'
 
   find (id?: number) {
-    return this.http.get(`${this.hostServer}/rest/basket/${id}`).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+    return this.http.get(`${this.hostServer}/rest/basket/${id}`).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 
   get (id: number) {
-    return this.http.get(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+    return this.http.get(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 
   put (id: number, params: any) {
-    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 
   del (id: number) {
-    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 
   save (params?: any) {
-    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 
   checkout (id?: number, couponData?: string, orderDetails?: OrderDetail) {
-    return this.http.post(`${this.hostServer}/rest/basket/${id}/checkout`, { couponData, orderDetails }).pipe(map((response: any) => response.orderConfirmation), catchError((error) => { throw error }))
+    return this.http.post(`${this.hostServer}/rest/basket/${id}/checkout`, { couponData, orderDetails }).pipe(map((response: any) => response.orderConfirmation), catchError(error=>throwError(()=>error)))
   }
 
   applyCoupon (id?: number, coupon?: string) {
-    return this.http.put(`${this.hostServer}/rest/basket/${id}/coupon/${coupon}`, {}).pipe(map((response: any) => response.discount), catchError((error) => { throw error }))
+    return this.http.put(`${this.hostServer}/rest/basket/${id}/coupon/${coupon}`, {}).pipe(map((response: any) => response.discount), catchError(error=>throwError(()=>error)))
   }
 
   updateNumberOfCartItems () {
     this.find(parseInt(sessionStorage.getItem('bid'), 10)).subscribe({
       next: (basket) => {
 
-        this.itemTotal.next(basket.Products.reduce((itemTotal, product) => itemTotal + product.BasketItem.quantity, 0))
+        this.itemTotal.next(basket.Products.reduce((itemTotal:any, product:any) => itemTotal + product.BasketItem.quantity, 0))
       },
       error: (err) => { console.log(err) }
     })

--- a/frontend/src/app/Services/captcha.service.ts
+++ b/frontend/src/app/Services/captcha.service.ts
@@ -7,6 +7,7 @@ import { HttpClient } from '@angular/common/http'
 import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { catchError } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,6 +19,6 @@ export class CaptchaService {
   private readonly host = this.hostServer + '/rest/captcha'
 
   getCaptcha () {
-    return this.http.get(this.host + '/').pipe(catchError((err) => { throw err }))
+    return this.http.get(this.host + '/').pipe(catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/challenge.service.ts
+++ b/frontend/src/app/Services/challenge.service.ts
@@ -9,6 +9,7 @@ import { Injectable, inject } from '@angular/core'
 import { type Observable } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
 import { type Challenge } from '../Models/challenge.model'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -20,34 +21,34 @@ export class ChallengeService {
   private readonly host = this.hostServer + '/api/Challenges'
 
   find (params?: any): Observable<Challenge[]> {
-    return this.http.get(this.host + '/', { params }).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host + '/', { params }).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   repeatNotification (challengeName: string) {
-    return this.http.get(this.hostServer + '/rest/repeat-notification', { params: { challenge: challengeName }, responseType: 'text' as const }).pipe(catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/repeat-notification', { params: { challenge: challengeName }, responseType: 'text' as const }).pipe(catchError(err=>throwError(()=>err)))
   }
 
   continueCode () {
-    return this.http.get(this.hostServer + '/rest/continue-code').pipe(map((response: any) => response.continueCode), catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/continue-code').pipe(map((response: any) => response.continueCode), catchError(err=>throwError(()=>err)))
   }
 
   continueCodeFindIt () {
-    return this.http.get(this.hostServer + '/rest/continue-code-findIt').pipe(map((response: any) => response.continueCode), catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/continue-code-findIt').pipe(map((response: any) => response.continueCode), catchError(err=>throwError(()=>err)))
   }
 
   continueCodeFixIt () {
-    return this.http.get(this.hostServer + '/rest/continue-code-fixIt').pipe(map((response: any) => response.continueCode), catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/continue-code-fixIt').pipe(map((response: any) => response.continueCode), catchError(err=>throwError(()=>err)))
   }
 
   restoreProgress (continueCode: string) {
-    return this.http.put(this.hostServer + '/rest/continue-code/apply/' + continueCode, {}).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.put(this.hostServer + '/rest/continue-code/apply/' + continueCode, {}).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   restoreProgressFindIt (continueCode: string) {
-    return this.http.put(this.hostServer + '/rest/continue-code-findIt/apply/' + continueCode, {}).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.put(this.hostServer + '/rest/continue-code-findIt/apply/' + continueCode, {}).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   restoreProgressFixIt (continueCode: string) {
-    return this.http.put(this.hostServer + '/rest/continue-code-fixIt/apply/' + continueCode, {}).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.put(this.hostServer + '/rest/continue-code-fixIt/apply/' + continueCode, {}).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/chatbot.service.ts
+++ b/frontend/src/app/Services/chatbot.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,10 +19,10 @@ export class ChatbotService {
   private readonly host = this.hostServer + '/rest/chatbot'
 
   getChatbotStatus () {
-    return this.http.get(this.host + '/status').pipe(map((response: any) => response), catchError((error: Error) => { throw error }))
+    return this.http.get(this.host + '/status').pipe(map((response: any) => response), catchError((error: Error) => throwError(() => error)))
   }
 
-  getResponse (action, query) {
-    return this.http.post(this.host + '/respond', { action, query }).pipe(map((response: any) => response), catchError((error: Error) => { throw error }))
+  getResponse (action:any, query:any) {
+    return this.http.post(this.host + '/respond', { action, query }).pipe(map((response: any) => response), catchError((error: Error) => throwError(() => error)))
   }
 }

--- a/frontend/src/app/Services/code-fixes.service.ts
+++ b/frontend/src/app/Services/code-fixes.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core'
 import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
-import { type Observable } from 'rxjs'
+import { type Observable, throwError } from 'rxjs'
 
 export interface result {
   verdict: boolean
@@ -26,13 +26,13 @@ export class CodeFixesService {
   private readonly host = this.hostServer + '/snippets/fixes'
 
   get (key: string): Observable<Fixes> {
-    return this.http.get(this.host + `/${key}`).pipe(map((response: Fixes) => response), catchError((error: any) => { throw error }))
+    return this.http.get(this.host + `/${key}`).pipe(map((response: Fixes) => response), catchError((error: Error) => throwError(() => error)))
   }
 
   check (key: string, selectedFix: number): any {
     return this.http.post(this.host, {
       key,
       selectedFix
-    }).pipe(map((response: result) => response), catchError((error: any) => { throw error }))
+    }).pipe(map((response: result) => response), catchError((error: Error) => throwError(() => error)))
   }
 }

--- a/frontend/src/app/Services/code-snippet.service.ts
+++ b/frontend/src/app/Services/code-snippet.service.ts
@@ -7,7 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
-import { type Observable } from 'rxjs'
+import { type Observable, throwError } from 'rxjs'
 
 export interface CodeSnippet {
   vulnLines?: number[]
@@ -28,6 +28,6 @@ export class CodeSnippetService {
   private readonly host = this.hostServer + '/snippets'
 
   get (key: string): Observable<CodeSnippet> {
-    return this.http.get<CodeSnippet>(`${this.host}/${key}`).pipe(map((response: CodeSnippet) => response), catchError((err) => { throw err }))
+    return this.http.get<CodeSnippet>(`${this.host}/${key}`).pipe(map((response: CodeSnippet) => response), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/complaint.service.ts
+++ b/frontend/src/app/Services/complaint.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,6 +19,6 @@ export class ComplaintService {
   private readonly host = this.hostServer + '/api/Complaints'
 
   save (params: any) {
-    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/configuration.service.ts
+++ b/frontend/src/app/Services/configuration.service.ts
@@ -7,7 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
-import { type Observable } from 'rxjs'
+import { type Observable, throwError } from 'rxjs'
 
 interface ConfigResponse {
   config: Config
@@ -109,7 +109,7 @@ export class ConfigurationService {
     if (this.configObservable) {
       return this.configObservable
     } else {
-      this.configObservable = this.http.get<ConfigResponse>(this.host + '/application-configuration').pipe(map((response: ConfigResponse) => response.config, catchError((err) => { throw err })))
+      this.configObservable = this.http.get<ConfigResponse>(this.host + '/application-configuration').pipe(map((response: ConfigResponse) => response.config, catchError(err=>throwError(()=>err))))
       return this.configObservable
     }
   }

--- a/frontend/src/app/Services/country-mapping.service.ts
+++ b/frontend/src/app/Services/country-mapping.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { catchError } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -17,6 +18,6 @@ export class CountryMappingService {
   private readonly hostServer = environment.hostServer
 
   getCountryMapping () {
-    return this.http.get(this.hostServer + '/rest/country-mapping').pipe(catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/country-mapping').pipe(catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/data-subject.service.ts
+++ b/frontend/src/app/Services/data-subject.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { catchError } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -19,11 +20,11 @@ export class DataSubjectService {
   private readonly host = this.hostServer + '/rest/user'
 
   erase (params: any) {
-    return this.http.post(this.host + '/erasure-request', params).pipe(catchError((error: Error) => { throw error })
+    return this.http.post(this.host + '/erasure-request', params).pipe(catchError((error: Error) => throwError(() => error))
     )
   }
 
   dataExport (params: any) {
-    return this.http.post(this.host + '/data-export', params).pipe(catchError((err) => { throw err }))
+    return this.http.post(this.host + '/data-export', params).pipe(catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/delivery.service.ts
+++ b/frontend/src/app/Services/delivery.service.ts
@@ -8,6 +8,7 @@ import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
 import { type DeliveryMethod } from '../Models/deliveryMethod.model'
+import {throwError} from 'rxjs'
 
 interface DeliveryMultipleMethodResponse {
   status: string
@@ -29,11 +30,11 @@ export class DeliveryService {
   private readonly host = this.hostServer + '/api/Deliverys'
 
   get () {
-    return this.http.get(this.host).pipe(map((response: DeliveryMultipleMethodResponse) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host).pipe(map((response: DeliveryMultipleMethodResponse) => response.data), catchError(err=>throwError(()=>err)))
   }
 
-  getById (id) {
+  getById (id:any) {
 
-    return this.http.get(`${this.host}/${id}`).pipe(map((response: DeliverySingleMethodResponse) => response.data), catchError((err) => { throw err }))
+    return this.http.get(`${this.host}/${id}`).pipe(map((response: DeliverySingleMethodResponse) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/feedback.service.ts
+++ b/frontend/src/app/Services/feedback.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -20,14 +21,14 @@ export class FeedbackService {
   find (params?: any) {
     return this.http.get(this.host + '/', {
       params
-    }).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    }).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   save (params: any) {
-    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   del (id: number) {
-    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/hint.service.ts
+++ b/frontend/src/app/Services/hint.service.ts
@@ -9,6 +9,7 @@ import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
 import type { Observable } from 'rxjs'
 import { Hint } from '../Models/hint.model'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -20,10 +21,10 @@ export class HintService {
   private readonly host = this.hostServer + '/api/Hints'
 
   getAll (): Observable<Hint[]> {
-    return this.http.get(this.host + '/').pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host + '/').pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
-  put (id: number, params): Observable<Hint> {
-    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+  put (id: number, params:any): Observable<Hint> {
+    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 }

--- a/frontend/src/app/Services/image-captcha.service.ts
+++ b/frontend/src/app/Services/image-captcha.service.ts
@@ -7,6 +7,7 @@ import { HttpClient } from '@angular/common/http'
 import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { catchError } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -17,6 +18,6 @@ export class ImageCaptchaService {
   private readonly hostServer = environment.hostServer
 
   getCaptcha () {
-    return this.http.get(this.hostServer + '/rest/image-captcha/').pipe(catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/image-captcha/').pipe(catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/keys.service.ts
+++ b/frontend/src/app/Services/keys.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
 import { environment } from '../../environments/environment'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -15,27 +16,21 @@ export class KeysService {
   nftUnlocked () {
     return this.http.get(this.host + '/nftUnlocked').pipe(
       map((response: any) => response),
-      catchError((err) => {
-        throw err
-      })
+      catchError(err=>throwError(()=>err))
     )
   }
 
   nftMintListen () {
     return this.http.get(this.host + '/nftMintListen').pipe(
       map((response: any) => response),
-      catchError((err) => {
-        throw err
-      })
+      catchError(err=>throwError(()=>err))
     )
   }
 
   checkNftMinted () {
     return this.http.get(this.hostServer + '/api/Challenges/?key=nftMintChallenge').pipe(
       map((response: any) => response),
-      catchError((err) => {
-        throw err
-      })
+      catchError(err=>throwError(()=>err))
     )
   }
 
@@ -44,9 +39,7 @@ export class KeysService {
     const params = { privateKey }
     return this.http.post(endpoint, params).pipe(
       map((response: any) => response),
-      catchError((err) => {
-        throw err
-      })
+      catchError(err=>throwError(()=>err))
     )
   }
 
@@ -55,9 +48,7 @@ export class KeysService {
     const params = { walletAddress }
     return this.http.post(endpoint, params).pipe(
       map((response: any) => response),
-      catchError((err) => {
-        throw err
-      })
+      catchError(err=>throwError(()=>err))
     )
   }
 
@@ -66,9 +57,7 @@ export class KeysService {
     const params = { walletAddress }
     return this.http.post(endpoint, params).pipe(
       map((response: any) => response),
-      catchError((err) => {
-        throw err
-      })
+      catchError(err=>throwError(()=>err))
     )
   }
 }

--- a/frontend/src/app/Services/languages.service.ts
+++ b/frontend/src/app/Services/languages.service.ts
@@ -7,6 +7,7 @@ import { Injectable, inject } from '@angular/core'
 import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { catchError } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -17,6 +18,6 @@ export class LanguagesService {
   private readonly hostServer = environment.hostServer
 
   getLanguages () {
-    return this.http.get(`${this.hostServer}/rest/languages`).pipe(catchError((err) => { throw err }))
+    return this.http.get(`${this.hostServer}/rest/languages`).pipe(catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/order-history.service.ts
+++ b/frontend/src/app/Services/order-history.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,14 +19,14 @@ export class OrderHistoryService {
   private readonly host = this.hostServer + '/rest/order-history'
 
   get () {
-    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   getAll () {
-    return this.http.get(this.host + '/orders').pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host + '/orders').pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   toggleDeliveryStatus (id: number, params) {
-    return this.http.put(`${this.host}/${id}/delivery-status`, params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.put(`${this.host}/${id}/delivery-status`, params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/payment.service.ts
+++ b/frontend/src/app/Services/payment.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import { throwError } from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,19 +19,19 @@ export class PaymentService {
   private readonly host = this.hostServer + '/api/Cards'
 
   get () {
-    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
-  getById (id) {
+  getById (id:any) {
 
-    return this.http.get(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((err: Error) => { throw err }))
+    return this.http.get(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((error: Error) => throwError(() => error)))
   }
 
-  save (params) {
-    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+  save (params:any) {
+    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   del (id: number) {
-    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.delete(`${this.host}/${id}`).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/photo-wall.service.ts
+++ b/frontend/src/app/Services/photo-wall.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import { throwError } from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -21,10 +22,10 @@ export class PhotoWallService {
     const postData = new FormData()
     postData.append('image', image, caption)
     postData.append('caption', caption)
-    return this.http.post(this.host, postData).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.post(this.host, postData).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   get () {
-    return this.http.get(this.host + '/').pipe(map((response: any) => response.data), catchError((err: Error) => { throw err }))
+    return this.http.get(this.host + '/').pipe(map((response: any) => response.data), catchError((error: Error) => throwError(() => error)))
   }
 }

--- a/frontend/src/app/Services/product-review.service.ts
+++ b/frontend/src/app/Services/product-review.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -19,23 +20,21 @@ export class ProductReviewService {
 
   get (id: number) {
     return this.http.get(`${this.host}/${id}/reviews`).pipe(
-      map((response: any) => response.data), catchError((err: Error) => {
-        throw err
-      })
+      map((response: any) => response.data), catchError((error: Error) => throwError(() => error)) 
     )
   }
 
   create (id: number, review: { message: string, author: string }) {
     return this.http.put(`${this.host}/${id}/reviews`, review).pipe(map((response: any) => response.data),
-      catchError((err) => { throw err })
+      catchError(err=>throwError(()=>err))
     )
   }
 
   patch (review: { id: string, message: string }) {
-    return this.http.patch(this.host + '/reviews', review).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.patch(this.host + '/reviews', review).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   like (_id?: string) {
-    return this.http.post(this.host + '/reviews', { id: _id }).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.post(this.host + '/reviews', { id: _id }).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/product.service.ts
+++ b/frontend/src/app/Services/product.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,11 +19,11 @@ export class ProductService {
   private readonly host = this.hostServer + '/api/Products'
 
   search (criteria: string) {
-    return this.http.get(`${this.hostServer}/rest/products/search?q=${criteria}`).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(`${this.hostServer}/rest/products/search?q=${criteria}`).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   find (params: any) {
-    return this.http.get(this.host + '/', { params }).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host + '/', { params }).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   get (id: number) {
@@ -31,6 +32,6 @@ export class ProductService {
   }
 
   put (id: number, params) {
-    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/quantity.service.ts
+++ b/frontend/src/app/Services/quantity.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import { throwError } from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,10 +19,10 @@ export class QuantityService {
   private readonly host = this.hostServer + '/api/Quantitys'
 
   getAll () {
-    return this.http.get(this.host + '/').pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host + '/').pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
-  put (id: number, params) {
-    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+  put (id: number, params:any) {
+    return this.http.put(`${this.host}/${id}`, params).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 }

--- a/frontend/src/app/Services/recycle.service.ts
+++ b/frontend/src/app/Services/recycle.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -20,10 +21,10 @@ export class RecycleService {
   find (params?: any) {
     return this.http.get(this.host + '/', {
       params
-    }).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+    }).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 
   save (params: any) {
-    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
+    return this.http.post(this.host + '/', params).pipe(map((response: any) => response.data), catchError(error=>throwError(()=>error)))
   }
 }

--- a/frontend/src/app/Services/security-answer.service.ts
+++ b/frontend/src/app/Services/security-answer.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { catchError, map } from 'rxjs/operators'
+import {throwError} from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +21,7 @@ export class SecurityAnswerService {
   save (params: any) {
     return this.http.post(this.host + '/', params).pipe(
       map((response: any) => response.data),
-      catchError((err) => { throw err })
+      catchError(err=>throwError(()=>err))
     )
   }
 }

--- a/frontend/src/app/Services/security-question.service.ts
+++ b/frontend/src/app/Services/security-question.service.ts
@@ -7,6 +7,7 @@ import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
 import { environment } from 'src/environments/environment'
 import { catchError, map } from 'rxjs/operators'
+import { throwError } from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,13 +19,13 @@ export class SecurityQuestionService {
   private readonly host = this.hostServer + '/api/SecurityQuestions'
 
   find (params: any) {
-    return this.http.get(this.host + '/', { params }).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host + '/', { params }).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   findBy (email: string) {
     return this.http.get(this.hostServer + '/' + 'rest/user/security-question?email=' + email).pipe(
       map((response: any) => response.question),
-      catchError((error) => { throw error })
+      catchError(error=>throwError(()=>error))
     )
   }
 }

--- a/frontend/src/app/Services/track-order.service.ts
+++ b/frontend/src/app/Services/track-order.service.ts
@@ -7,6 +7,7 @@ import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { environment } from '../../environments/environment'
 import { catchError, map } from 'rxjs/operators'
+import { throwError } from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -19,6 +20,6 @@ export class TrackOrderService {
 
   find (params: string) {
     params = encodeURIComponent(params)
-    return this.http.get(`${this.host}/${params}`).pipe(map((response: any) => response), catchError((error) => { throw error }))
+    return this.http.get(`${this.host}/${params}`).pipe(map((response: any) => response), catchError(error=>throwError(()=>error)))
   }
 }

--- a/frontend/src/app/Services/two-factor-auth-service.ts
+++ b/frontend/src/app/Services/two-factor-auth-service.ts
@@ -7,7 +7,7 @@ import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
 import { environment } from '../../environments/environment'
-import { type Observable } from 'rxjs'
+import { type Observable, throwError } from 'rxjs'
 
 interface TwoFactorVerifyResponse {
   authentication: AuthenticationPayload
@@ -37,12 +37,12 @@ export class TwoFactorAuthService {
     return this.http.post<TwoFactorVerifyResponse>(`${environment.hostServer}/rest/2fa/verify`, {
       tmpToken: localStorage.getItem('totp_tmp_token'),
       totpToken
-    }).pipe(map((response: TwoFactorVerifyResponse) => response.authentication), catchError((error) => { throw error }))
+    }).pipe(map((response: TwoFactorVerifyResponse) => response.authentication), catchError(error=>throwError(()=>error)))
   }
 
   status (): Observable<TwoFactorAuthStatusPayload> {
     return this.http.get<TwoFactorAuthStatusPayload>(`${environment.hostServer}/rest/2fa/status`)
-      .pipe(map((response: TwoFactorAuthStatusPayload) => response), catchError((error) => { throw error }))
+      .pipe(map((response: TwoFactorAuthStatusPayload) => response), catchError(error=>throwError(()=>error)))
   }
 
   setup (password: string, initialToken: string, setupToken?: string): Observable<void> {
@@ -50,11 +50,11 @@ export class TwoFactorAuthService {
       password,
       setupToken,
       initialToken
-    }).pipe(map(() => undefined), catchError((error) => { throw error }))
+    }).pipe(map(() => undefined), catchError(error=>throwError(()=>error)))
   }
 
   disable (password: string): Observable<void> {
     return this.http.post(`${environment.hostServer}/rest/2fa/disable`, { password })
-      .pipe(map(() => undefined), catchError((error) => { throw error }))
+      .pipe(map(() => undefined), catchError(error=>throwError(()=>error)))
   }
 }

--- a/frontend/src/app/Services/user.service.ts
+++ b/frontend/src/app/Services/user.service.ts
@@ -7,7 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
-import { Subject } from 'rxjs'
+import { Subject,throwError } from 'rxjs'
 
 interface Passwords {
   current?: string
@@ -27,7 +27,7 @@ export class UserService {
 
   find (params?: any) {
     return this.http.get(this.hostServer + '/rest/user/authentication-details/', { params }).pipe(map((response: any) =>
-      response.data), catchError((err) => { throw err }))
+      response.data), catchError(err=>throwError(()=>err)))
   }
 
   get (id: number) {
@@ -37,13 +37,13 @@ export class UserService {
   save (params: any) {
     return this.http.post(this.host + '/', params).pipe(
       map((response: any) => response.data),
-      catchError((err) => { throw err })
+      catchError(err=>throwError(()=>err))
     )
   }
 
   login (params: any) {
     this.isLoggedIn.next(true)
-    return this.http.post(this.hostServer + '/rest/user/login', params).pipe(map((response: any) => response.authentication), catchError((err) => { throw err }))
+    return this.http.post(this.hostServer + '/rest/user/login', params).pipe(map((response: any) => response.authentication), catchError(err=>throwError(()=>err)))
   }
 
   getLoggedInState () {
@@ -52,15 +52,15 @@ export class UserService {
 
   changePassword (passwords: Passwords) {
     return this.http.get(this.hostServer + '/rest/user/change-password?current=' + passwords.current + '&new=' +
-    passwords.new + '&repeat=' + passwords.repeat).pipe(map((response: any) => response.user), catchError((err) => { throw err.error }))
+    passwords.new + '&repeat=' + passwords.repeat).pipe(map((response: any) => response.user), catchError(err=>throwError(()=>err.error)))
   }
 
   resetPassword (params: any) {
-    return this.http.post(this.hostServer + '/rest/user/reset-password', params).pipe(map((response: any) => response.user), catchError((err) => { throw err }))
+    return this.http.post(this.hostServer + '/rest/user/reset-password', params).pipe(map((response: any) => response.user), catchError(err=>throwError(()=>err)))
   }
 
   whoAmI () {
-    return this.http.get(this.hostServer + '/rest/user/whoami').pipe(map((response: any) => response.user), catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/user/whoami').pipe(map((response: any) => response.user), catchError(err=>throwError(()=>err)))
   }
 
   oauthLogin (accessToken: string) {
@@ -68,14 +68,14 @@ export class UserService {
   }
 
   saveLastLoginIp () {
-    return this.http.get(this.hostServer + '/rest/saveLoginIp').pipe(map((response: any) => response), catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/saveLoginIp').pipe(map((response: any) => response), catchError(err=>throwError(()=>err)))
   }
 
   deluxeStatus () {
-    return this.http.get(this.hostServer + '/rest/deluxe-membership').pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.hostServer + '/rest/deluxe-membership').pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   upgradeToDeluxe (paymentMode: string, paymentId: any) {
-    return this.http.post(this.hostServer + '/rest/deluxe-membership', { paymentMode, paymentId }).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.post(this.hostServer + '/rest/deluxe-membership', { paymentMode, paymentId }).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }

--- a/frontend/src/app/Services/vuln-lines.service.ts
+++ b/frontend/src/app/Services/vuln-lines.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core'
 import { environment } from '../../environments/environment'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import { throwError } from 'rxjs'
 
 export interface result {
   verdict: boolean
@@ -21,6 +22,6 @@ export class VulnLinesService {
     return this.http.post(this.host, {
       key,
       selectedLines
-    }).pipe(map((response: result) => response), catchError((error: any) => { throw error }))
+    }).pipe(map((response: result) => response), catchError((error: any) => throwError(() => error)))
   }
 }

--- a/frontend/src/app/Services/wallet.service.ts
+++ b/frontend/src/app/Services/wallet.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
+import { throwError } from 'rxjs'
 
 @Injectable({
   providedIn: 'root'
@@ -18,10 +19,10 @@ export class WalletService {
   private readonly host = this.hostServer + '/rest/wallet/balance'
 
   get () {
-    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.get(this.host).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 
   put (params) {
-    return this.http.put(this.host, params).pipe(map((response: any) => response.data), catchError((err) => { throw err }))
+    return this.http.put(this.host, params).pipe(map((response: any) => response.data), catchError(err=>throwError(()=>err)))
   }
 }


### PR DESCRIPTION
### Description

This PR improves the way HTTP errors are handled in our service methods. Previously, the code was using `throw` inside the `catchError` blocks like this:

catchError((error) => { throw error })

While this might seem fine at first glance, it actually breaks the observable stream and is not compliant with RxJS 7+ standards. To fix this, all instances of throw inside catchError have been replaced with:

catchError((error) => throwError(() => error))

This ensures that errors are properly propagated as observables, making the application more robust and consistent when handling HTTP failures. It also aligns all service methods with the recommended RxJS patterns.

No other functionality has been changed; this is purely an internal improvement to error handling logic.

 My contribution does not include any AI-generated content

My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines