### PR TITLE
feat: add bundle stats generation workflow (#3039)

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -1,0 +1,39 @@
+name: "Bundle Stats"
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+env:
+  NODE_DEFAULT_VERSION: 22
+jobs:
+  extract-bundle-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out Git repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          ref: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Use Node.js 22"
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4.1.0
+        with:
+          node-version: ${{ env.NODE_DEFAULT_VERSION }}
+      - name: "Install root dependencies"
+        run: npm ci
+      - name: "Install frontend dependencies"
+        run: |
+          cd frontend
+          npm ci --legacy-peer-deps
+      - name: "Build frontend with stats"
+        run: |
+          cd frontend
+          npx ng build --stats-json
+      - name: "Extract bundle stats"
+        run: node scripts/extract-bundle-stats.js
+      - name: "Commit bundle stats"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bundle-stats.json
+          git diff --staged --quiet || git commit -m "chore: update bundle stats [skip ci]"
+          git push origin master

--- a/scripts/extract-bundle-stats.js
+++ b/scripts/extract-bundle-stats.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+const zlib = require('node:zlib')
+
+const STATS_INPUT = path.resolve(__dirname, '../frontend/dist/frontend/stats.json')
+const STATS_OUTPUT = path.resolve(__dirname, '../bundle-stats.json')
+const PACKAGE_JSON = path.resolve(__dirname, '../package.json')
+
+const CHUNK_NAMES = ['vendor.js', 'main.js', 'polyfills.js', 'runtime.js', 'common.js', 'styles.css']
+
+function calculateGzipSize (content) {
+  if (!content) return 0
+  const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content)
+  try {
+    return zlib.gzipSync(buffer).length
+  } catch {
+    return Math.round(buffer.length * 0.3)
+  }
+}
+
+function extractPackageName (modulePath) {
+  if (!modulePath) return null
+  const normalized = modulePath.replace(/\\/g, '/')
+  const nodeModulesMatch = normalized.match(/node_modules\/(@[^/]+\/[^/]+|[^/]+)/)
+  if (nodeModulesMatch) return nodeModulesMatch[1]
+  if (normalized.includes('/src/') || normalized.startsWith('./src/')) return 'app'
+  return null
+}
+
+function extractChildName (modulePath, packageName) {
+  if (!modulePath || !packageName) return null
+  const normalized = modulePath.replace(/\\/g, '/')
+  const afterPackage = normalized.split(packageName)[1]
+  if (!afterPackage) return null
+  const parts = afterPackage.split('/').filter(Boolean)
+  if (parts.length === 0) return null
+  return parts[parts.length - 1] || null
+}
+
+function processModules (modules) {
+  const packageMap = new Map()
+
+  for (const mod of modules || []) {
+    const name = mod.name || mod.identifier || ''
+    const size = mod.size || 0
+    if (size === 0) continue
+
+    const packageName = extractPackageName(name)
+    if (!packageName) continue
+
+    if (!packageMap.has(packageName)) {
+      packageMap.set(packageName, { name: packageName, size: 0, childrenMap: new Map() })
+    }
+
+    const pkg = packageMap.get(packageName)
+    pkg.size += size
+
+    const childName = extractChildName(name, packageName)
+    if (childName) {
+      const existingSize = pkg.childrenMap.get(childName) || 0
+      pkg.childrenMap.set(childName, existingSize + size)
+    }
+  }
+
+  return Array.from(packageMap.values())
+    .map(pkg => ({
+      name: pkg.name,
+      size: pkg.size,
+      children: Array.from(pkg.childrenMap.entries())
+        .map(([name, size]) => ({ name, size }))
+        .sort((a, b) => b.size - a.size)
+        .slice(0, 20)
+    }))
+    .filter(pkg => pkg.size > 0)
+    .sort((a, b) => b.size - a.size)
+}
+
+function findChunkByFileName (stats, fileName) {
+  for (const chunk of stats.chunks || []) {
+    if (chunk.files && chunk.files.includes(fileName)) {
+      return chunk
+    }
+  }
+  return null
+}
+
+function main () {
+  if (!fs.existsSync(STATS_INPUT)) {
+    console.error(`Stats file not found: ${STATS_INPUT}`)
+    console.error('Run "npx ng build --stats-json" in the frontend directory first.')
+    process.exit(1)
+  }
+
+  const stats = JSON.parse(fs.readFileSync(STATS_INPUT, 'utf8'))
+  const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'))
+  const distDir = path.dirname(STATS_INPUT)
+
+  const chunks = []
+  let totalSize = 0
+  let totalGzip = 0
+
+  for (const chunkName of CHUNK_NAMES) {
+    const chunkPath = path.join(distDir, chunkName)
+    if (!fs.existsSync(chunkPath)) continue
+
+    const content = fs.readFileSync(chunkPath)
+    const size = content.length
+    const gzip = calculateGzipSize(content)
+
+    totalSize += size
+    totalGzip += gzip
+
+    const chunk = findChunkByFileName(stats, chunkName)
+    const modules = processModules(chunk?.modules)
+
+    chunks.push({
+      name: chunkName,
+      size,
+      gzip,
+      modules
+    })
+  }
+
+  const output = {
+    version: pkg.version.replace('-SNAPSHOT', ''),
+    timestamp: new Date().toISOString(),
+    summary: {
+      totalSize,
+      totalGzip,
+      chunkCount: chunks.length
+    },
+    chunks
+  }
+
+  fs.writeFileSync(STATS_OUTPUT, JSON.stringify(output, null, 2))
+  console.log(`Bundle stats written to ${STATS_OUTPUT}`)
+  console.log(`Total size: ${(totalSize / 1024 / 1024).toFixed(2)} MB`)
+  console.log(`Gzip estimate: ${(totalGzip / 1024 / 1024).toFixed(2)} MB`)
+}
+
+main()


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-days or even
∞ ban from interacting with the project depending on reoccurrence and severity.
You can find more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
solves #3039
Adds automated bundle stats generation for the frontend build:

- `scripts/extract-bundle-stats.js` - Extracts webpack bundle statistics from Angular build
- `.github/workflows/bundle-stats.yml` - Workflow triggered on release publish
The workflow:
1. Builds frontend with `--stats-json`
2. Extracts chunk sizes, gzip estimates, and module breakdown
3. Commits `bundle-stats.json` to master for consumption by juicy-statistics

Output format includes per-chunk module sizes grouped by package for treemap visualization.

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [X] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude opus 2.5, etc.]`
   
### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines


this is the first iteration , suggestions are welcomed , @bkimminich review this whenever you are free.