### PR TITLE
 modernize stylelint to v16 and remove legacy CI workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           npm install --ignore-scripts
           cd frontend
-          npm install --ignore-scripts --legacy-peer-deps
+          npm install --ignore-scripts
       - name: "Lint source code"
         run: npm run lint
       - name: "Lint customization configs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,9 +81,9 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "stylelint": "^13.8.0",
-    "stylelint-config-sass-guidelines": "^7.1.0",
-    "stylelint-scss": "^3.18.0",
+    "stylelint": "^16.10.0",
+    "stylelint-config-sass-guidelines": "^12.1.0",
+    "stylelint-scss": "^6.0.0",
     "ts-node": "^10.9.2",
     "typescript-eslint": "^8.42.0",
     "webpack-bundle-analyzer": "^5.2.0"

--- a/frontend/stylelint-plugin-spacing-fixer.mjs
+++ b/frontend/stylelint-plugin-spacing-fixer.mjs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const stylelint = require('stylelint');
+import stylelint from 'stylelint'
 
 const SPACING_VARIABLES = [
   { name: '$space-3xs', rem: 0.125, px: 2 },
@@ -80,7 +80,7 @@ function normalizeToPixels (value) {
 
 const ruleName = 'stylelint-plugin-spacing-fixer/declaration-property-value-disallowed-list';
 
-module.exports = stylelint.createPlugin(ruleName,
+const plugin = stylelint.createPlugin(ruleName,
   function (primaryOption, secondaryOption, context) {
     return function (root, result) {
       if (!primaryOption) return;
@@ -125,5 +125,4 @@ module.exports = stylelint.createPlugin(ruleName,
   }
 );
 
-module.exports.ruleName = ruleName;
-
+export default plugin

--- a/frontend/stylelint.config.mjs
+++ b/frontend/stylelint.config.mjs
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-module.exports = {
+export default {
   extends: 'stylelint-config-sass-guidelines',
   plugins: [
     'stylelint-scss',
-    './stylelint-plugin-spacing-fixer.js'
+    './stylelint-plugin-spacing-fixer.mjs'
   ],
   rules: {
     'selector-max-id': 1,
@@ -15,7 +15,7 @@ module.exports = {
     'selector-pseudo-element-no-unknown': [
       true,
       {
-        'ignorePseudoElements': ['ng-deep']
+        ignorePseudoElements: ['ng-deep']
       }
     ],
     'property-no-vendor-prefix': null,
@@ -31,4 +31,3 @@ module.exports = {
     }
   }
 }
-


### PR DESCRIPTION
### Description
This PR modernizes the frontend Stylelint tooling to align with the current Angular 20 / Node.js 20+ ecosystem.

### Changes
Upgraded Stylelint from v13 → v16

Updated related Stylelint plugins and configs to compatible versions

Migrated the custom stylelint-plugin-spacing-fixer from CommonJS → ESM

Introduced a modern stylelint.config.mjs

Removed the --legacy-peer-deps workaround from the frontend CI install step

### Impact
Frontend-only, SCSS-only changes
No runtime, build, or challenge behavior changes
Improves CI reliability and contributor experience

Resolved or fixed issue: Fixes #3047 

### AI Tool Disclosure

- [ x ] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [ x ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
