### PR TITLE
Chatbot user info leak

### DIFF
--- a/config/fbctf.yml
+++ b/config/fbctf.yml
@@ -347,3 +347,7 @@ ctf:
     passwordHashLeakChallenge:
       name: Italy
       code: IT
+    chatbotUserInfoChallenge:
+      name: Finland
+      code: FI
+

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -1544,3 +1544,15 @@
     - 'Find the place where the API call happens — as stated above, it is not in the web application — and then look for the API key itself.'
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html'
   key: leakedApiKeyChallenge
+-
+  name: 'Chatbot Data Exposure'
+  category: 'Broken Access Control'
+  description: 'Retrieve sensitive user information through the support chatbot for a user account that does not belong to you.'
+  difficulty: 3
+  hints:
+    - 'The support chatbot is quite talkative when you ask it the right questions.'
+    - 'Perhaps the chatbot has been given access to more than just product information.'
+    - 'Try asking the chatbot about things you''ve encountered while exploring the shop.'
+    - 'Sometimes aggregate information about users can enable more sophisticated attacks.'
+  mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html'
+  key: chatbotUserInfoChallenge

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -124,7 +124,8 @@ const CHALLENGE_KEYS = [
   'csafChallenge',
   'exposedCredentialsChallenge',
   'leakedApiKeyChallenge',
-  'passwordHashLeakChallenge'
+  'passwordHashLeakChallenge',
+  'chatbotUserInfoChallenge'
 ] as const
 
 export type ChallengeKey = typeof CHALLENGE_KEYS[number]

--- a/routes/chatbot.ts
+++ b/routes/chatbot.ts
@@ -100,6 +100,13 @@ async function processQuery (user: User, req: Request, res: Response, next: Next
     return
   }
 
+  const emailPattern = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/
+  if (emailPattern.test(req.body.query) && /(user|info|about|know|profile)/i.test(req.body.query)) {
+    const userInfoResponse = await botUtils.userInfo(req.body.query, user)
+    res.status(200).json(userInfoResponse)
+    return
+  }
+
   try {
     const response = await bot.respond(req.body.query, `${user.id}`)
     if (response.action === 'function') {


### PR DESCRIPTION
### Description
A new 3⭐ Broken Access Control challenge Chatbot Data Exposure
The challenge demonstrates an authorization flaw in the existing support chatbot. Authenticated users can retrieve profile information about other users by asking natural-language questions, without proper access control checks.
```
Example
 What do you know about accountant@juice-sh.op?
 ```
The chatbot extracts the email address and queries user data, returning profile metadata such as role and account status even when the requested account does not belong to the requester.

Resolved or fixed issue: Fixes #3058  

### Implementation overview
Added a userInfo() helper in lib/botUtils.ts to aggregate user profile data
Extended routes/chatbot.ts to intercept user-related queries
Added a new challenge definition with progressive hints in data/static/challenges.yml
IP addresses are masked e.g. 192.168.xxx.xxx to avoid exposing real PII
No sensitive secrets are returned like passwords, tokens, hashes excluded
Existing chatbot challenges are not affected

### Files modified
lib/botUtils.ts – added a helper to aggregate user profile data for the chatbot
routes/chatbot.ts – extended chatbot routing to handle user-related queries
data/static/challenges.yml – added challenge definition and hints
models/challenge.ts – registered the new challenge key
config/fbctf.yml – added country mapping for consistency

### Screenshots
<img width="1414" height="777" alt="image" src="https://github.com/user-attachments/assets/17e0e6a9-d75a-486d-9fd2-3e4415487c9a" />

<img width="545" height="241" alt="image" src="https://github.com/user-attachments/assets/5f3476c0-c6ba-4618-9ed4-e54237d8c147" />

### Testing
Linting passes
Application builds and starts successfully
Challenge appears correctly in the UI
Challenge is solvable and does not interfere with existing challenge

### AI Tool Disclosure
- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
        - AI Tools: `Google Gemini (Antigravity IDE Assistant)`
        - LLMs and versions: `Gemini 2.0 Flash Thinking Experimental`
        - Prompts: `Initial request: "Add a chatbot challenge 
        
### Affirmation
- [x]  My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines