### PR TITLE
Fix: Ignore WebGL exception in Easter Egg 2 test on headless Ubuntu C…

### DIFF
--- a/test/cypress/e2e/directAccess.spec.ts
+++ b/test/cypress/e2e/directAccess.spec.ts
@@ -1,6 +1,12 @@
 describe('/', () => {
   describe('challenge "easterEgg2"', () => {
     it('should be able to access "secret" url for easter egg', () => {
+      cy.on('uncaught:exception', (err) => {
+        if (err.message.includes('getExtension') || err.message.includes('Cannot read properties of null')) {
+          return false
+        }
+        return true
+      })
       cy.visit(
         '/the/devs/are/so/funny/they/hid/an/easter/egg/within/the/easter/egg'
       )


### PR DESCRIPTION
### Description
Fixed a Cypress test failure in the "Nested Easter Egg" challenge that occurs when running tests in headless Chrome on Ubuntu/Linux environments.

**Issue**
The test for the easterEgg2 challenge (/the/devs/are/so/funny/they/hid/an/easter/egg/within/the/easter/egg) was failing in CI/CD pipelines and headless Chrome environments due to a WebGL initialization error in three.js. The error "Cannot read properties of null (reading 'getExtension')" was thrown as an uncaught exception, causing the Cypress test to fail even though the application functionality works correctly in normal browser environments.

**Solution**
Added a targeted exception handler using Cypress.on('uncaught:exception') within the specific test to catch and ignore WebGL-related errors that only occur in headless environments. 
The handler only suppresses errors containing "getExtension" or "Cannot read properties of null" , allows all other exceptions to fail the test normally and is scoped to this single test only, not affecting other tests

Resolved or fixed issue : #3070 

### AI Tool Disclosure
- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
