### PR TITLE
Add support for displaying ctf system wide notifications from MultiJuicer

### DIFF
--- a/config.schema.yml
+++ b/config.schema.yml
@@ -191,6 +191,11 @@ ctf:
     type: boolean
   showCountryDetailsInNotifications:
     type: string
+  systemWideNotifications:
+    url:
+      type: string
+    pollFrequencySeconds:
+      type: number
   countryMapping:
     scoreBoardChallenge:
       name:

--- a/config/default.yml
+++ b/config/default.yml
@@ -461,3 +461,6 @@ ctf:
   showFlagsInNotifications: false
   showCountryDetailsInNotifications: none # Options: none  name  flag  both
   countryMapping: ~
+  systemWideNotifications:
+    url: ~ # URL of an external endpoint returning { message, enabled, updatedAt }
+    pollFrequencySeconds: ~ # Required when url is set

--- a/frontend/src/app/Services/configuration.service.ts
+++ b/frontend/src/app/Services/configuration.service.ts
@@ -91,6 +91,10 @@ export interface Config {
     showFlagsInNotifications: boolean
     showCountryDetailsInNotifications: string
     countryMapping: any[]
+    systemWideNotifications?: {
+      url?: string
+      pollFrequencySeconds?: number
+    }
   }
 }
 

--- a/frontend/src/app/Services/ctf-system-wide-notification.service.ts
+++ b/frontend/src/app/Services/ctf-system-wide-notification.service.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Injectable, inject } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { type Observable } from 'rxjs'
+
+export interface SystemWideNotificationResponse {
+  message: string
+  enabled: boolean
+  updatedAt: string
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CtfSystemWideNotificationService {
+  private readonly http = inject(HttpClient)
+
+  fetchNotification (url: string): Observable<SystemWideNotificationResponse> {
+    return this.http.get<SystemWideNotificationResponse>(url)
+  }
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -9,6 +9,7 @@
   </mat-sidenav>
   <app-navbar (sidenavToggle)="sidenav.toggle()"></app-navbar>
   <app-server-started-notification></app-server-started-notification>
+  <app-ctf-system-wide-notification></app-ctf-system-wide-notification>
   <app-challenge-solved-notification></app-challenge-solved-notification>
   <app-welcome></app-welcome>
   <router-outlet></router-outlet>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { dom } from '@fortawesome/fontawesome-svg-core'
 import { RouterOutlet } from '@angular/router'
 import { WelcomeComponent } from './welcome/welcome.component'
 import { ChallengeSolvedNotificationComponent } from './challenge-solved-notification/challenge-solved-notification.component'
+import { CtfSystemWideNotificationComponent } from './ctf-system-wide-notification/ctf-system-wide-notification.component'
 import { ServerStartedNotificationComponent } from './server-started-notification/server-started-notification.component'
 import { NavbarComponent } from './navbar/navbar.component'
 import { SidenavComponent } from './sidenav/sidenav.component'
@@ -21,7 +22,7 @@ dom.watch()
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
-  imports: [MatSidenavContainer, MatSidenav, SidenavComponent, NavbarComponent, ServerStartedNotificationComponent, ChallengeSolvedNotificationComponent, WelcomeComponent, RouterOutlet]
+  imports: [MatSidenavContainer, MatSidenav, SidenavComponent, NavbarComponent, ServerStartedNotificationComponent, ChallengeSolvedNotificationComponent, CtfSystemWideNotificationComponent, WelcomeComponent, RouterOutlet]
 })
 export class AppComponent {
   private readonly _document = inject<HTMLDocument>(DOCUMENT)

--- a/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.html
+++ b/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.html
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+  ~ SPDX-License-Identifier: MIT
+-->
+
+@if (notification) {
+  <div class="container ctf-system-notification mat-elevation-z4">
+    <mat-card appearance="outlined" class="primary-notification">
+      <div class="mdc-card">
+        <div class="notificationMessage">
+          <div class="contents">{{notification.message}}</div>
+          <button id="closeButton" mat-button (click)="dismiss()">X</button>
+        </div>
+      </div>
+    </mat-card>
+  </div>
+}

--- a/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.scss
+++ b/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.scss
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+@use '../../styles/variables' as *;
+
+.container {
+  font-size: 14px;
+  margin: $space-2xl;
+}
+
+mat-card {
+  margin-bottom: $space-s;
+
+  .notificationMessage {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+#closeButton {
+  float: right;
+}
+
+.contents {
+  display: flex;
+  flex-direction: column;
+  gap: $space-2xs;
+  justify-content: space-around;
+}

--- a/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.spec.ts
+++ b/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.spec.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { MatButtonModule } from '@angular/material/button'
+import { MatCardModule } from '@angular/material/card'
+import { ConfigurationService } from '../Services/configuration.service'
+import { CtfSystemWideNotificationService } from '../Services/ctf-system-wide-notification.service'
+import { provideHttpClientTesting } from '@angular/common/http/testing'
+import { type ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing'
+import { of, throwError } from 'rxjs'
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
+
+import { CtfSystemWideNotificationComponent } from './ctf-system-wide-notification.component'
+
+const POLL_FREQUENCY = 30
+const BASE_CTF_CONFIG = {
+  ctf: {
+    showFlagsInNotifications: false,
+    showCountryDetailsInNotifications: 'none',
+    countryMapping: [],
+    systemWideNotifications: {
+      url: 'http://example.com/notify',
+      pollFrequencySeconds: POLL_FREQUENCY
+    }
+  }
+}
+
+describe('CtfSystemWideNotificationComponent', () => {
+  let component: CtfSystemWideNotificationComponent
+  let fixture: ComponentFixture<CtfSystemWideNotificationComponent>
+  let configurationService: any
+  let notificationService: any
+
+  beforeEach(waitForAsync(() => {
+    configurationService = jasmine.createSpyObj('ConfigurationService', ['getApplicationConfiguration'])
+    configurationService.getApplicationConfiguration.and.returnValue(of(BASE_CTF_CONFIG))
+    notificationService = jasmine.createSpyObj('CtfSystemWideNotificationService', ['fetchNotification'])
+    notificationService.fetchNotification.and.returnValue(of({ message: 'hello', enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+
+    TestBed.configureTestingModule({
+      imports: [
+        MatCardModule,
+        MatButtonModule,
+        CtfSystemWideNotificationComponent
+      ],
+      providers: [
+        { provide: ConfigurationService, useValue: configurationService },
+        { provide: CtfSystemWideNotificationService, useValue: notificationService },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(CtfSystemWideNotificationComponent)
+    component = fixture.componentInstance
+  }))
+
+  afterEach(() => {
+    component.ngOnDestroy()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should not start polling if ctf.systemWideNotifications.url is not configured', fakeAsync(() => {
+    configurationService.getApplicationConfiguration.and.returnValue(of({
+      ctf: { showFlagsInNotifications: false, showCountryDetailsInNotifications: 'none', countryMapping: [] }
+    }))
+    fixture.detectChanges()
+    tick(POLL_FREQUENCY * 1000)
+
+    expect(notificationService.fetchNotification).not.toHaveBeenCalled()
+    expect(component.notification).toBeNull()
+  }))
+
+  it('should not start polling if pollFrequencySeconds is not configured', fakeAsync(() => {
+    configurationService.getApplicationConfiguration.and.returnValue(of({
+      ctf: { systemWideNotifications: { url: 'http://example.com/notify' } }
+    }))
+    fixture.detectChanges()
+    tick(POLL_FREQUENCY * 1000)
+
+    expect(notificationService.fetchNotification).not.toHaveBeenCalled()
+    expect(component.notification).toBeNull()
+  }))
+
+  it('should show notification when enabled is true and message is non-empty', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: 'hello world', enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+
+    expect(component.notification).toEqual({ message: 'hello world', enabled: true, updatedAt: '2026-01-01T00:00:00Z' })
+  }))
+
+  it('should not show notification when enabled is false', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: 'hello world', enabled: false, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+
+    expect(component.notification).toBeNull()
+  }))
+
+  it('should not show notification when message is empty string', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: '', enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+
+    expect(component.notification).toBeNull()
+  }))
+
+  it('should not show notification when message is null', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: null, enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+
+    expect(component.notification).toBeNull()
+  }))
+
+  it('should hide notification and record dismissedAt when dismiss is called', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: 'hello', enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+
+    expect(component.notification).not.toBeNull()
+    component.dismiss()
+
+    expect(component.notification).toBeNull()
+    expect((component as any).dismissedAt).toBe('2026-01-01T00:00:00Z')
+  }))
+
+  it('should not show notification again after dismiss if updatedAt is unchanged', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: 'hello', enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+    component.dismiss()
+
+    tick(POLL_FREQUENCY * 1000)
+
+    expect(component.notification).toBeNull()
+  }))
+
+  it('should show notification again after dismiss if updatedAt changes', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: 'hello', enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+    component.dismiss()
+
+    notificationService.fetchNotification.and.returnValue(of({ message: 'new message', enabled: true, updatedAt: '2026-02-01T00:00:00Z' }))
+    tick(POLL_FREQUENCY * 1000)
+
+    expect(component.notification).toEqual({ message: 'new message', enabled: true, updatedAt: '2026-02-01T00:00:00Z' })
+  }))
+
+  it('should handle fetch errors gracefully and keep notification null', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(throwError(() => new Error('Network error')))
+    fixture.detectChanges()
+    tick(0)
+
+    expect(component.notification).toBeNull()
+  }))
+
+  it('should unsubscribe from polling on destroy', fakeAsync(() => {
+    notificationService.fetchNotification.and.returnValue(of({ message: 'hello', enabled: true, updatedAt: '2026-01-01T00:00:00Z' }))
+    fixture.detectChanges()
+    tick(0)
+    component.ngOnDestroy()
+
+    notificationService.fetchNotification.calls.reset()
+    tick(POLL_FREQUENCY * 1000)
+
+    expect(notificationService.fetchNotification).not.toHaveBeenCalled()
+  }))
+})

--- a/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.ts
+++ b/frontend/src/app/ctf-system-wide-notification/ctf-system-wide-notification.component.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { ChangeDetectorRef, Component, type OnDestroy, type OnInit, inject } from '@angular/core'
+import { interval, of, type Subscription } from 'rxjs'
+import { catchError, startWith, switchMap } from 'rxjs/operators'
+import { ConfigurationService } from '../Services/configuration.service'
+import { CtfSystemWideNotificationService, type SystemWideNotificationResponse } from '../Services/ctf-system-wide-notification.service'
+import { MatButtonModule } from '@angular/material/button'
+import { MatCardModule } from '@angular/material/card'
+
+@Component({
+  selector: 'app-ctf-system-wide-notification',
+  templateUrl: './ctf-system-wide-notification.component.html',
+  styleUrls: ['./ctf-system-wide-notification.component.scss'],
+  imports: [MatCardModule, MatButtonModule]
+})
+export class CtfSystemWideNotificationComponent implements OnInit, OnDestroy {
+  private readonly configurationService = inject(ConfigurationService)
+  private readonly notificationService = inject(CtfSystemWideNotificationService)
+  private readonly ref = inject(ChangeDetectorRef)
+
+  public notification: SystemWideNotificationResponse | null = null
+  private dismissedAt: string | null = null
+  private subscription: Subscription | null = null
+
+  ngOnInit (): void {
+    this.configurationService.getApplicationConfiguration().subscribe((config) => {
+      const url = config?.ctf?.systemWideNotifications?.url
+      const pollFrequencySeconds = config?.ctf?.systemWideNotifications?.pollFrequencySeconds
+      if (!url || !pollFrequencySeconds) {
+        return
+      }
+
+      this.subscription = interval(pollFrequencySeconds * 1000).pipe(
+        startWith(0),
+        switchMap(() => this.notificationService.fetchNotification(url).pipe(
+          catchError(() => of(null))
+        ))
+      ).subscribe((data) => {
+        if (data?.enabled && data.message && data.updatedAt !== this.dismissedAt) {
+          this.notification = data
+        } else {
+          this.notification = null
+        }
+        this.ref.detectChanges()
+      })
+    })
+  }
+
+  ngOnDestroy (): void {
+    this.subscription?.unsubscribe()
+  }
+
+  dismiss (): void {
+    if (this.notification) {
+      this.dismissedAt = this.notification.updatedAt
+      this.notification = null
+      this.ref.detectChanges()
+    }
+  }
+}

--- a/lib/config.types.ts
+++ b/lib/config.types.ts
@@ -124,6 +124,10 @@ export interface CtfConfig {
     name: string
     code: string
   }>
+  systemWideNotifications?: {
+    url?: string
+    pollFrequencySeconds?: number
+  }
 }
 
 export interface AppConfig {

--- a/lib/startup/validateConfig.ts
+++ b/lib/startup/validateConfig.ts
@@ -180,6 +180,13 @@ export const checkForIllogicalCombos = (configuration = config.util.toObject()) 
     logger.warn(`CTF country mappings for FBCTF are enabled while CTF flags are disabled (${colors.red('NOT OK')})`)
     success = false
   }
+  const notifications = configuration.ctf?.systemWideNotifications
+  if (notifications?.url) {
+    if (!notifications.pollFrequencySeconds || typeof notifications.pollFrequencySeconds !== 'number' || notifications.pollFrequencySeconds <= 0) {
+      logger.warn(`ctf.systemWideNotifications.url is set but pollFrequencySeconds is missing or not a positive number (${colors.red('NOT OK')})`)
+      success = false
+    }
+  }
   return success
 }
 


### PR DESCRIPTION
### Description

Adds support to display the ctf system wide notifications from MultiJuicer or other systems implementing this somewhat simple api endpoint contract.

Resolved or fixed issue: https://github.com/juice-shop/multi-juicer/issues/251

MultiJuicer PR to rollout the config for managed JS instances: https://github.com/juice-shop/multi-juicer/pull/448
Pwning Juice Shop Docs Changes: https://github.com/juice-shop/pwning-juice-shop/pull/283

<img width="610" height="505" alt="image" src="https://github.com/user-attachments/assets/4917e86a-6104-4127-b986-982a1a28980a" />

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: ClaudeCode
    - LLMs and versions: Claude Sonet 4.5
    - Prompts:  

<details><summary>Prompt</summary>
   
```
Please add the following config options to the JuiceShop config file:

ctf.systemWideNotifications.url
ctf.systemWideNotifications.pollFrequencySeconds

If this config is set the frontend should:

Poll the url regularly.

The endpoint returns data in the following format:

{"message":"hello world!","enabled":true,"updatedAt":"2026-02-14T12:44:38.423Z"}

If `enabled: true` and the message is not an empty string/null/undefiend the message should be shown in the JuiceShop Ui simmilar to the "Challenge Solved" notification.
The notification card should be dismissable, if dismissed the notification is hidden until the notification changes, use the updatedAt timestamp to track changes.

Please create a app-ctf-system-wide-notifications components which handles the rendering and a ctf system wide notifications service which handles the fetching.
When the config is not (no url present) the component should not render / do anything.

JuiceShop should validate this setting on startup to verify that the url and frequency are configured correctly (enforce that the frequency is set and in the right format when the url is set)

Beside the validation there should be little to no server side changes needed, the acutal endpoint for the notifications is not served by JuiceShop itself.

Please also review the documentation for JuiceShop configuration at https://github.com/juice-shop/pwning-juice-shop/raw/refs/heads/master/docs/modules/ROOT/pages/part4/customization.adoc an write a summary in documentation_changes.md detailing what needs to be updated in terms of this change.

Include tests. Specifically the server validation should be tested at: test/server/configValidationSpec.ts
and the ctf-system-wide-notification component should include angular tests to verify the varous different use cases
```
</details>

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
