### PR TITLE
fix(auth): Prevent 401 on valid signed/forged tokens during challenges (Fixes #1788)

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -116,7 +116,7 @@ export const discountFromCoupon = (coupon?: string) => {
   }
 }
 
-function hasValidFormat (coupon: string) {
+function hasValidFormat(coupon: string) {
   return coupon.match(/(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)[0-9]{2}-[0-9]{2}/)
 }
 
@@ -177,7 +177,7 @@ export const isCustomer = (req: Request) => {
 export const appendUserId = () => {
   return (req: Request, res: Response, next: NextFunction) => {
     try {
-      req.body.UserId = authenticatedUsers.tokenMap[utils.jwtFrom(req)].data.id
+      req.body.UserId = (req as any).user?.data?.id || authenticatedUsers.tokenMap[utils.jwtFrom(req)]?.data?.id
       next()
     } catch (error: unknown) {
       res.status(401).json({ status: 'error', message: utils.getErrorMessage(error) })

--- a/test/api/basketApiSpec.ts
+++ b/test/api/basketApiSpec.ts
@@ -55,7 +55,7 @@ describe('/rest/basket/:id', () => {
   })
 
   // todo: Endpoint should return a 200, but returns a 401 right now, even though the challenges are marked as solved...
-  it.skip('GET basket should accept forged JWTs', () => {
+  it('GET basket should accept forged JWTs', () => {
     const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
     const payload = Buffer.from(JSON.stringify({ data: { email: 'jim@juice-sh.op' }, iat: 1508639612, exp: 9999999999 })).toString('base64url')
     const unsignedToken = `${header}.${payload}.`


### PR DESCRIPTION
*This is a clean re-submission to address the test failures and branch history issues from my previous PRs.*

### The Problem
As identified in #1788, the `express-jwt 0.1.3` library natively bypasses validation for tokens forged with the `none` algorithm. However, an unhandled `TypeError` inside the [appendUserId](cci:1://file:///c:/Users/harsh/Downloads/School%20management%20system/juice-shop/lib/insecurity.ts:176:0-185:1) middleware was causing the application to crash before the challenge logic could process the token, resulting in a generic `401 Unauthorized`.

### The Fix
I reviewed the exact test case provided by @bkimminich in `develop`. To allow the legacy vulnerability to trigger natively while preventing the crash, I un-skipped the maintainer test and applied an optional chaining patch (`?.`) directly to `req.user` within `insecurity.appendUserId()`.

typescript
// lib/insecurity.tsreq.body.UserId = (req as any).user?.data?.id || authenticatedUsers.tokenMap[utils.jwtFrom(req)]?.data?.id


### Verification
- [x] Cloned against upstream `develop` with clean git history (`fix/jwt-develop`).
- [x] Un-skipped and passed the maintainer test case.
- [x] `npm run test:api` locally passes 100% (200 OK for forged JWT challenge).

Thank you again for the guidance on the previous attempts! Let me know if any further tweaks are needed before this can be merged.
