### PR TITLE
fix(ui): use scalable dynamic subscript sizing to prevent registration text overlap (Fixes #3086)

### DIFF
--- a/frontend/src/app/register/register.component.html
+++ b/frontend/src/app/register/register.component.html
@@ -25,7 +25,7 @@
             }
           </mat-form-field>
 
-          <mat-form-field appearance="outline" color="accent">
+          <mat-form-field appearance="outline" color="accent" subscriptSizing="dynamic">
             <mat-label translate>LABEL_PASSWORD</mat-label>
             <input #password id="passwordControl" [formControl]="passwordControl" (focus)="this.error=null" type="password"
               matInput aria-label="Field for the password">
@@ -45,7 +45,7 @@
               }
             </mat-form-field>
 
-            <mat-form-field appearance="outline" color="accent">
+            <mat-form-field appearance="outline" color="accent" subscriptSizing="dynamic">
               <mat-label translate>LABEL_PASSWORD_REPEAT</mat-label>
               <input #repeatPassword id="repeatPasswordControl" [formControl]="repeatPasswordControl"
                 (focus)="this.error=null" type="password" matInput aria-label="Field to confirm the password">

--- a/frontend/src/app/register/register.component.scss
+++ b/frontend/src/app/register/register.component.scss
@@ -17,7 +17,7 @@ mat-form-field {
   display: flex;
   flex-direction: column;
   position: relative;
-
+  gap: 1rem;
 }
 
 #registerButton {


### PR DESCRIPTION
This is a clean re-submission for the text overlapping issue (#3086) following your feedback on PR #3088.

### The Problem
When the "Password must be 5-40 characters long" hint text wraps to a second line on narrower screens or in localized languages, it overflows its bounds and overlaps with the "Repeat Password" input field.

### The Fix
In my previous PR, I attempted to use a hardcoded margin which would break other responsive layouts. 

After digging deeper into how Angular Material handles these hints, I realized the issue is that the `<mat-form-field>` components natively default to `subscriptSizing="fixed"`, which reserves exactly one line of height. 

To fix this natively, I updated the `<mat-form-field>` wrappers for both password fields in [register.component.html](cci:7://file:///c:/Users/harsh/Downloads/School%20management%20system/juiceshop/frontend/src/app/register/register.component.html:0:0-0:0) to leverage `subscriptSizing="dynamic"`, and applied a responsive `gap: 1rem` to the `.form-container` in [register.component.scss](cci:7://file:///c:/Users/harsh/Downloads/School%20management%20system/juice-shop/frontend/src/app/register/register.component.scss:0:0-0:0). 

This natively instructs the Material fields to auto-expand their height whenever the hint text wraps, pushing the subsequent "Repeat Password" field down gracefully without requiring rigid magic margins.

### Verification
- [x] Successfully compiled frontend and verified dynamically via `npm start`.
- [x] Tested locally on narrow 400px viewports: the "Repeat Password" field dynamically shifts downward.
- [x] Tested against localized string alterations.
- [x] Fix applied cleanly against `master`.

Let me know if this native Angular approach aligns better with your codebase responsive standards!
