### PR TITLE
fix(ui): use scalable dynamic subscript sizing to prevent registration text overlap (Fixes #3086)

### DIFF
--- a/frontend/src/app/register/register.component.html
+++ b/frontend/src/app/register/register.component.html
@@ -17,116 +17,112 @@
           <mat-label translate>LABEL_EMAIL</mat-label>
           <input id="emailControl" [formControl]="emailControl" (focus)="this.error=null" type="text" matInput
             aria-label="Email address field">
-            @if (emailControl.invalid && emailControl.errors.required) {
-              <mat-error translate>MANDATORY_EMAIL</mat-error>
-            }
-            @if (emailControl.invalid && emailControl.errors.email) {
-              <mat-error translate>INVALID_EMAIL</mat-error>
+          @if (emailControl.invalid && emailControl.errors.required) {
+          <mat-error translate>MANDATORY_EMAIL</mat-error>
+          }
+          @if (emailControl.invalid && emailControl.errors.email) {
+          <mat-error translate>INVALID_EMAIL</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" color="accent" subscriptSizing="dynamic">
+          <mat-label translate>LABEL_PASSWORD</mat-label>
+          <input #password id="passwordControl" [formControl]="passwordControl" (focus)="this.error=null"
+            type="password" matInput aria-label="Field for the password">
+          <mat-hint translate>
+            <i class="fas fa-exclamation-circle"></i>
+            <em class="hint-spacing" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
+          </mat-hint>
+          <mat-hint align="end">{{password.value?.length || 0}}/20</mat-hint>
+          @if (passwordControl.invalid && passwordControl.errors.required) {
+          <mat-error translate>MANDATORY_PASSWORD
+          </mat-error>
+          }
+          @if (passwordControl.invalid && (passwordControl.errors.minlength || passwordControl.errors.maxlength)) {
+          <mat-error translate [translateParams]="{length: '5-40'}">INVALID_PASSWORD_LENGTH
+          </mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" color="accent" subscriptSizing="dynamic">
+          <mat-label translate>LABEL_PASSWORD_REPEAT</mat-label>
+          <input #repeatPassword id="repeatPasswordControl" [formControl]="repeatPasswordControl"
+            (focus)="this.error=null" type="password" matInput aria-label="Field to confirm the password">
+          <mat-hint align="end">{{repeatPassword.value?.length || 0}}/40</mat-hint>
+          @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.required) {
+          <mat-error translate>
+            MANDATORY_PASSWORD_REPEAT
+          </mat-error>
+          }
+          @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame) {
+          <mat-error translate>
+            PASSWORDS_NOT_MATCHING
+          </mat-error>
+          }
+        </mat-form-field>
+
+        <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' |
+          translate}}</mat-slide-toggle>
+        <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
+        @if (passwordInfoToggle.checked) {
+        <app-password-strength-info [passwordComponent]="passwordStrength"
+          [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
+          [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
+          [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
+          [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
+          [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
+        </app-password-strength-info>
+        }
+
+        <div class="security-container">
+
+          <mat-form-field color="accent" appearance="outline">
+            <mat-label>
+              {{'LABEL_SECURITY_QUESTION' | translate}}
+            </mat-label>
+            <mat-select [formControl]="securityQuestionControl" placeholder="" [(value)]="selected"
+              (focus)="this.error=null" name="securityQuestion" aria-label="Selection list for the security question">
+              @for (question of securityQuestions; track question) {
+              <mat-option [value]="question.id" class="mat-body">
+                {{question.question}}
+              </mat-option>
+              }
+            </mat-select>
+            <mat-hint translate>
+              <i class="fas fa-exclamation-circle"></i>
+              <em class="hint-spacing" translate>CANNOT_BE_CHANGED_LATER</em>
+            </mat-hint>
+            @if (securityQuestionControl.invalid && securityQuestionControl.errors.required) {
+            <mat-error translate>
+              MANDATORY_SECURITY_QUESTION
+            </mat-error>
             }
           </mat-form-field>
 
           <mat-form-field appearance="outline" color="accent">
-            <mat-label translate>LABEL_PASSWORD</mat-label>
-            <input #password id="passwordControl" [formControl]="passwordControl" (focus)="this.error=null" type="password"
-              matInput aria-label="Field for the password">
-              <mat-hint translate>
-                <i class="fas fa-exclamation-circle"></i>
-                <em class="hint-spacing" translate>{{ 'INVALID_PASSWORD_LENGTH' | translate: {length: '5-40'} }}</em>
-              </mat-hint>
-              <mat-hint align="end">{{password.value?.length || 0}}/20</mat-hint>
-              @if (passwordControl.invalid && passwordControl.errors.required) {
-                <mat-error translate>MANDATORY_PASSWORD
-                </mat-error>
-              }
-              @if (passwordControl.invalid && (passwordControl.errors.minlength || passwordControl.errors.maxlength)) {
-                <mat-error
-                  translate [translateParams]="{length: '5-40'}">INVALID_PASSWORD_LENGTH
-                </mat-error>
-              }
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" color="accent">
-              <mat-label translate>LABEL_PASSWORD_REPEAT</mat-label>
-              <input #repeatPassword id="repeatPasswordControl" [formControl]="repeatPasswordControl"
-                (focus)="this.error=null" type="password" matInput aria-label="Field to confirm the password">
-                <mat-hint align="end">{{repeatPassword.value?.length || 0}}/40</mat-hint>
-                @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.required) {
-                  <mat-error translate>
-                    MANDATORY_PASSWORD_REPEAT
-                  </mat-error>
-                }
-                @if (repeatPasswordControl.invalid && repeatPasswordControl.errors.notSame) {
-                  <mat-error translate>
-                    PASSWORDS_NOT_MATCHING
-                  </mat-error>
-                }
-              </mat-form-field>
-
-              <mat-slide-toggle #passwordInfoToggle [color]="passwordStrength.color">{{'SHOW_PASSWORD_ADVICE' | translate}}</mat-slide-toggle>
-              <app-password-strength #passwordStrength [password]="password.value"></app-password-strength>
-              @if (passwordInfoToggle.checked) {
-                <app-password-strength-info [passwordComponent]="passwordStrength"
-                  [lowerCaseCriteriaMsg]="'LOWER_CASE_CRITERIA_MSG' | translate"
-                  [upperCaseCriteriaMsg]="'UPPER_CASE_CRITERIA_MSG'| translate"
-                  [digitsCriteriaMsg]="'DIGITS_CRITERIA_MSG'| translate"
-                  [specialCharsCriteriaMsg]="'SPECIAL_CHARS_CRITERIA_MSG' | translate"
-                  [minCharsCriteriaMsg]="'MIN_CHARS_CRITERIA_MSG' | translate:{value: 8}">
-                </app-password-strength-info>
-              }
-
-              <div class="security-container">
-
-                <mat-form-field color="accent" appearance="outline">
-                  <mat-label>
-                    {{'LABEL_SECURITY_QUESTION' | translate}}
-                  </mat-label>
-                  <mat-select [formControl]="securityQuestionControl" placeholder="" [(value)]="selected"
-                    (focus)="this.error=null" name="securityQuestion"
-                    aria-label="Selection list for the security question">
-                    @for (question of securityQuestions; track question) {
-                      <mat-option [value]="question.id" class="mat-body">
-                        {{question.question}}
-                      </mat-option>
-                    }
-                  </mat-select>
-                  <mat-hint translate>
-                    <i class="fas fa-exclamation-circle"></i>
-                    <em class="hint-spacing" translate>CANNOT_BE_CHANGED_LATER</em>
-                  </mat-hint>
-                  @if (securityQuestionControl.invalid && securityQuestionControl.errors.required) {
-                    <mat-error translate>
-                      MANDATORY_SECURITY_QUESTION
-                    </mat-error>
-                  }
-                </mat-form-field>
-
-                <mat-form-field appearance="outline" color="accent">
-                  <mat-label translate>SECURITY_ANSWER</mat-label>
-                  <input id="securityAnswerControl" [formControl]="securityAnswerControl" (focus)="this.error=null" type="text"
-                    matInput [placeholder]="'SECURITY_ANSWER_PLACEHOLDER' | translate"
-                    aria-label="Field for the answer to the security question">
-                    @if (securityAnswerControl.invalid && securityAnswerControl.errors.required) {
-                      <mat-error translate>
-                        MANDATORY_SECURITY_ANSWER
-                      </mat-error>
-                    }
-                  </mat-form-field>
-                </div>
-
-                <button type="submit"
-                  id="registerButton"
-                  mat-raised-button color="primary"
-                  [disabled]="emailControl.invalid || passwordControl.invalid || repeatPasswordControl.invalid || securityQuestionControl.invalid || securityAnswerControl.invalid"
-                  (click)="save()"
-                  aria-label="Button to complete the registration">
-                  <mat-icon>person_add</mat-icon>
-                  {{'BTN_REGISTER' | translate}}
-                </button>
-
-                <div id="alreadyACustomerLink">
-                  <a class="primary-link" routerLink="/login" translate>ALREADY_A_CUSTOMER</a>
-                </div>
-              </div>
-            </div>
-          </mat-card>
+            <mat-label translate>SECURITY_ANSWER</mat-label>
+            <input id="securityAnswerControl" [formControl]="securityAnswerControl" (focus)="this.error=null"
+              type="text" matInput [placeholder]="'SECURITY_ANSWER_PLACEHOLDER' | translate"
+              aria-label="Field for the answer to the security question">
+            @if (securityAnswerControl.invalid && securityAnswerControl.errors.required) {
+            <mat-error translate>
+              MANDATORY_SECURITY_ANSWER
+            </mat-error>
+            }
+          </mat-form-field>
         </div>
+
+        <button type="submit" id="registerButton" mat-raised-button color="primary"
+          [disabled]="emailControl.invalid || passwordControl.invalid || repeatPasswordControl.invalid || securityQuestionControl.invalid || securityAnswerControl.invalid"
+          (click)="save()" aria-label="Button to complete the registration">
+          <mat-icon>person_add</mat-icon>
+          {{'BTN_REGISTER' | translate}}
+        </button>
+
+        <div id="alreadyACustomerLink">
+          <a class="primary-link" routerLink="/login" translate>ALREADY_A_CUSTOMER</a>
+        </div>
+      </div>
+    </div>
+  </mat-card>
+</div>

--- a/frontend/src/app/register/register.component.scss
+++ b/frontend/src/app/register/register.component.scss
@@ -19,7 +19,7 @@ mat-form-field {
   display: flex;
   flex-direction: column;
   position: relative;
-
+  gap: 1rem;
 }
 
 #registerButton {


### PR DESCRIPTION
This is a clean re-submission for the text overlapping issue (#3086) following your feedback on PR #3088.

### The Problem
When the "Password must be 5-40 characters long" hint text wraps to a second line on narrower screens or in localized languages, it overflows its bounds and overlaps with the "Repeat Password" input field.

### The Fix
In my previous PR, I attempted to use a hardcoded margin which would break other responsive layouts. 

After digging deeper into how Angular Material handles these hints, I realized the issue is that the `<mat-form-field>` components natively default to `subscriptSizing="fixed"`, which reserves exactly one line of height. 

To fix this natively, I updated the `<mat-form-field>` wrappers for both password fields in frontend/src/app/register/register.component.html to leverage `subscriptSizing="dynamic"`, and applied a responsive `gap: 1rem` to the `.form-container` in frontend/src/app/register/register.component.scss. 

This natively instructs the Material fields to auto-expand their height whenever the hint text wraps, pushing the subsequent "Repeat Password" field down gracefully without requiring rigid magic margins.

### Verification
- [x] Successfully compiled frontend and verified dynamically via `npm start`.
- [x] Tested locally on narrow 400px viewports: the "Repeat Password" field dynamically shifts downward.
- [x] Tested against localized string alterations.
- [x] Fix applied cleanly against `develop`.

Let me know if this native Angular approach aligns better with your codebase responsive standards!
