### PR TITLE
feat(challenge): finish the missing 'Fix It' options for the SBT Web3 challenge (Fixes #2091)

### DIFF
--- a/data/static/codefixes/nftUnlockChallenge_1.sol
+++ b/data/static/codefixes/nftUnlockChallenge_1.sol
@@ -24,7 +24,8 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
     address to,
     uint256 tokenId
     ) internal override virtual {
-    require(from == address(0), "Err: token transfer is BLOCKED");
+    // Incorrect fix: Removing the require statement allows infinite token transfers,
+    // which fundamentally breaks the concept of a Soul Bound Token (SBT).
     super._beforeTokenTransfer(from, to, tokenId);
     }
 

--- a/data/static/codefixes/nftUnlockChallenge_2_correct.sol
+++ b/data/static/codefixes/nftUnlockChallenge_2_correct.sol
@@ -24,7 +24,9 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
     address to,
     uint256 tokenId
     ) internal override virtual {
-    require(from == address(0), "Err: token transfer is BLOCKED");
+    // Correct Fix: A Soul Bound Token (SBT) must allow minting (from == 0x0)
+    // AND burning (to == 0x0), but block all standard transfers between users.
+    require(from == address(0) || to == address(0), "Err: token transfer is BLOCKED");
     super._beforeTokenTransfer(from, to, tokenId);
     }
 

--- a/data/static/codefixes/nftUnlockChallenge_3.sol
+++ b/data/static/codefixes/nftUnlockChallenge_3.sol
@@ -24,7 +24,10 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
     address to,
     uint256 tokenId
     ) internal override virtual {
-    require(from == address(0), "Err: token transfer is BLOCKED");
+    // Incorrect fix: Only allowing transfers TO the zero address means the 
+    // token can be burned, but it can NEVER be minted in the first place, 
+    // rendering the contract useless.
+    require(to == address(0), "Err: token transfer is BLOCKED");
     super._beforeTokenTransfer(from, to, tokenId);
     }
 

--- a/data/static/codefixes/nftUnlockChallenge_4.sol
+++ b/data/static/codefixes/nftUnlockChallenge_4.sol
@@ -24,6 +24,9 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
     address to,
     uint256 tokenId
     ) internal override virtual {
+    // Incorrect fix: This is the original flawed logic. It allows minting 
+    // (from == address(0)) but completely blocks burning (to == address(0)) 
+    // because burning involves transferring TO the zero address.
     require(from == address(0), "Err: token transfer is BLOCKED");
     super._beforeTokenTransfer(from, to, tokenId);
     }


### PR DESCRIPTION
Hey everyone! Just popping in with another small contribution. 

I was looking at Issue #2091 and noticed it was still open because the `nftUnlockChallenge` (the JuiceShopSBT contract) was missing its "Fix It" options. Currently, all four options in the `codefixes` folder are just identical copies of the vulnerable code, which makes the Fix-It phase impossible to solve for that specific challenge.

I went ahead and wrote the actual Solidity fixes to complete this issue!

Here is what I added:
 Option 1 (Flawed): Removes the `require` statement, which breaks the Soul Bound Token (SBT) by allowing infinite transfers.
 Option 2 (Correct):Updates the logic to `require(from == address(0) || to == address(0))`. This is the secure fix because it allows minting (from zero) and burning (to zero) but successfully blocks normal P2P transfers.
 Option 3 (Flawed): Only allows burning, which means the token could never be minted in the first place.
 Option 4 (Flawed): The original vulnerable logic (only allows minting, but blocks burning).

I tested this locally against the API and the server correctly grades Option 2 as the winning answer! 

Hope this helps close out Issue #2091! Let me know if you need any adjustments.
