### PR TITLE
fix: prevent password length hint from overlapping in registration an…

### DIFF
--- a/frontend/src/app/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/forgot-password/forgot-password.component.html
@@ -55,7 +55,7 @@
               }
             </mat-form-field>
 
-            <mat-form-field appearance="outline" color="accent">
+            <mat-form-field appearance="outline" color="accent" subscriptSizing="dynamic">
               <mat-label translate>LABEL_NEW_PASSWORD</mat-label>
               <input #password id="newPassword" [formControl]="passwordControl" type="password" matInput placeholder=""
                 aria-label="Field for New Password">

--- a/frontend/src/app/register/register.component.html
+++ b/frontend/src/app/register/register.component.html
@@ -25,7 +25,7 @@
             }
           </mat-form-field>
 
-          <mat-form-field appearance="outline" color="accent">
+          <mat-form-field appearance="outline" color="accent" subscriptSizing="dynamic">
             <mat-label translate>LABEL_PASSWORD</mat-label>
             <input #password id="passwordControl" [formControl]="passwordControl" (focus)="this.error=null" type="password"
               matInput aria-label="Field for the password">


### PR DESCRIPTION
…d forgot password forms

<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-days or even
∞ ban from interacting with the project depending on reoccurrence and severity.
You can find more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

**Summary**

This PR fixes a UI layout issue in the registration form where the password hint text overlaps with the "Repeat Password" input field.

---

### Root Cause

The password hint may wrap into multiple lines, but the Angular Material form field uses a fixed subscript area size by default.  
As a result, the hint text expands vertically without pushing the next form field down, causing a visual overlap.

---

### Fix

- Enabled dynamic subscript sizing for the password form field.
- This allows the hint/error area to grow automatically when the hint wraps to multiple lines.
- Prevents overlap with the following form elements.

---

### Result

- Password hint text no longer overlaps the "Repeat Password" field.
- Layout spacing remains consistent across different screen widths and translations.
<img width="433" height="614" alt="image" src="https://github.com/user-attachments/assets/2ea6f74b-1f2d-402a-99aa-ebf34e085cc3" />
<img width="376" height="746" alt="image" src="https://github.com/user-attachments/assets/27834606-b55b-44ae-b226-865673f62319" />


---

### Testing

- Verified registration form layout manually.
- Confirmed no overlap occurs when the password hint wraps to multiple lines.

Resolved or fixed issue: #3086 

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
