### PR TITLE
Improve stability of contact page test by adding timeout

### DIFF
--- a/test/cypress/e2e/contact.spec.ts
+++ b/test/cypress/e2e/contact.spec.ts
@@ -9,7 +9,7 @@ describe('/#/contact', () => {
   describe('challenge "forgedFeedback"', () => {
     beforeEach(() => {
       cy.login({ email: 'admin', password: 'admin123' })
-      cy.visit('/#/contact')
+      cy.visit('/#/contact', { timeout: 10000})
       solveNextCaptcha()
     })
 
@@ -45,7 +45,7 @@ describe('/#/contact', () => {
   describe('challenge "persistedXssFeedback"', () => {
     beforeEach(() => {
       cy.login({ email: 'admin', password: 'admin123' })
-      cy.visit('/#/contact')
+      cy.visit('/#/contact', { timeout: 10000})
       solveNextCaptcha()
     })
 


### PR DESCRIPTION
This PR improves reliability of the Cypress contact page test by adding an explicit timeout to cy.visit() to reduce risky flaky test failures.
