### PR TITLE
UI: improve photo wall layout spacing and responsiveness

### DIFF
--- a/frontend/src/app/photo-wall/photo-wall.component.scss
+++ b/frontend/src/app/photo-wall/photo-wall.component.scss
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 
+
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 mat-form-field {
   width: 100%;
 }
@@ -45,24 +52,32 @@ input {
 }
 
 .grid {
-  align-items: center;
+  align-items: stretch;
   display: grid;
   grid-gap: 20px;
   grid-template-columns: repeat(auto-fill, minmax(255px, 1fr));
+  grid-auto-rows: 250px;
 }
 
 .grid img {
-  border-radius: 4px;
-  box-shadow: 2px 2px 6px 0 rgba(0, 0, 0, 0.3);
+  border-radius: 0;
+  box-shadow: none;
   max-width: 100%;
 }
 
 .container {
   position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  box-shadow: 2px 2px 6px 0 rgba(0, 0, 0, 0.3);
 }
 
 .image {
   display: block;
+  width: 100%;                 
+  height: 100%;                
+  object-fit: cover;           /* crops to fill tile uniformly */
+  border-radius: 0;  
 }
 
 .overlay {


### PR DESCRIPTION
### Description

The Photo Wall (`/#/photo-wall`) grid displayed jagged edges and uneven whitespace gaps between image tiles because uploaded memories have varying aspect ratios. Each grid row was sizing itself to the tallest image in that row, causing inconsistent row heights across the wall.

This PR fixes the layout entirely within `photo-wall.component.scss` with no template changes:
- Added `grid-auto-rows: 250px` to enforce a uniform fixed height for every grid row
- Added `object-fit: cover` with `width: 100%` and `height: 100%` on `.image` so photos crop cleanly to fill their tile without distortion or empty whitespace
- Added `overflow: hidden` to `.container` to clip the cropped image overflow and correctly apply `border-radius` at the tile level
- Moved `border-radius` and `box-shadow` from `.grid img` to `.container` since the clipping context lives there

Resolved or fixed issue: #3102

Before:
- Uneven spacing between photo cards
- Inconsistent responsiveness on smaller screens

<img width="1897" height="914" alt="image" src="https://github.com/user-attachments/assets/5b622cea-edc6-402d-83de-af31bf2b4c67" />

After:
- Uniform spacing between cards
- Improved responsive image scaling

<img width="1910" height="911" alt="image" src="https://github.com/user-attachments/assets/0cda5a3e-6762-49b6-9550-5bf7b0742f6f" />



Tested locally on:
- Desktop viewport
- Mobile viewport (Chrome dev tools)


---

### AI Tool Disclosure
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude.ai`
    - LLMs and versions: `Claude Sonnet 4.6`
    - Prompts: `Asked Claude to analyze the photo-wall SCSS and HTML to identify the root cause of jagged grid rows and uneven whitespace gaps, and suggest a minimal CSS-only fix`

---

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines