### PR TITLE
Add Ollama-powered LLM chatbot with Coupon Extraction challenge

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -82,6 +82,9 @@ export default defineConfig({
         },
         isWindows () {
           return utils.isWindows()
+        },
+        isOllama () {
+          return utils.isOllama()
         }
       })
     }

--- a/data/datacreator.ts
+++ b/data/datacreator.ts
@@ -91,7 +91,7 @@ async function createChallenges () {
           category,
           tags: (tags != null) ? tags.join(',') : undefined,
           // todo(@J12934) currently missing the 'not available' text. Needs changes to the model and utils functions
-          description: isChallengeEnabled ? description : (description + ' <em>(This challenge is <strong>potentially harmful</strong> on ' + disabledBecause + '!)</em>'),
+          description: isChallengeEnabled ? description : (disabledBecause === 'NoOllama' ? (description + ' <em>(This challenge requires <strong>Ollama</strong> to be running!)</em>') : (disabledBecause === 'Ollama' ? (description + ' <em>(This challenge only works without <strong>Ollama</strong> running!)</em>') : (description + ' <em>(This challenge is <strong>potentially harmful</strong> on ' + disabledBecause + '!)</em>'))),
           difficulty,
           solved: false,
           mitigationUrl: showMitigations ? mitigationUrl : null,

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -1482,6 +1482,8 @@
     - 'No seriously, just keep asking.'
   mitigationUrl: ~
   key: bullyChatbotChallenge
+  disabledEnv:
+    - Ollama
 -
   name: 'Local File Read'
   category: 'Vulnerable Components'
@@ -1544,3 +1546,17 @@
     - 'Find the place where the API call happens — as stated above, it is not in the web application — and then look for the API key itself.'
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html'
   key: leakedApiKeyChallenge
+-
+  name: 'Coupon Extraction'
+  category: 'Injection'
+  description: 'Extract the secret coupon code hidden in JuiceBot&apos;s system prompt using prompt injection techniques.'
+  difficulty: 3
+  hints:
+    - 'The bot has been told to keep something from customers. Maybe if it thought you were staff, or if it was asked to complete a sentence, it might slip up.'
+    - 'Try different forms of prompt injections techniques!'
+    - 'Maybe ask the bot what codes not to use?'
+    - 'LLMs are non-deterministic, maybe try to spray some prompt injection with a tool to extract the coupon code'
+  mitigationUrl: https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html
+  key: couponExtractionChallenge
+  disabledEnv:
+    - NoOllama

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  juice-shop:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - OLLAMA_URL=http://ollama:11434
+    depends_on:
+      ollama-init:
+        condition: service_completed_successfully
+
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+  ollama-init:
+    image: ollama/ollama
+    entrypoint: ["/bin/sh", "-c", "ollama pull llama3.2:3b"]
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+volumes:
+  ollama_data:

--- a/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.html
+++ b/frontend/src/app/score-board/components/challenges-unavailable-warning/challenges-unavailable-warning.component.html
@@ -3,12 +3,16 @@
     <ng-container warning-icon>
       @if (disabledBecauseOfEnv === 'Windows') {
         <i class="env-icon" [ngClass]="'fab fa-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
+      } @else if (disabledBecauseOfEnv === 'NoOllama') {
+        <i class="env-icon fas fa-robot"></i>
       } @else {
         <i class="env-icon" [ngClass]="'icon-' + disabledBecauseOfEnv.toString().toLowerCase()"></i>
       }
     </ng-container>
     @if (disabledBecauseOfEnv ==='Safety Mode') {
       <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges,env:'safety mode being turned on'}"></span>
+    } @else if (disabledBecauseOfEnv === 'NoOllama') {
+      <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES_OLLAMA' | translate: {num: numberOfDisabledChallenges}"></span>
     } @else {
       <span warning-text [innerHTML]="'INFO_DISABLED_CHALLENGES' | translate: {num: numberOfDisabledChallenges, env: disabledBecauseOfEnv}"></span>
     }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -195,6 +195,7 @@
   "BTN_SHOW_ALL": "Show all",
   "BTN_SHOW_UNAVAILABLE": "Show unavailable",
   "INFO_DISABLED_CHALLENGES": "{{num}} challenges are unavailable on {{env}} due to <a href='https://pwning.owasp-juice.shop/companion-guide/latest/part1/challenges.html#_potentially_dangerous_challenges'>security concerns</a> or technical incompatibility!",
+  "INFO_DISABLED_CHALLENGES_OLLAMA": "{{num}} challenges require <a href='https://ollama.com'>Ollama</a> running locally to work. Start Ollama and restart the Juice Shop to enable them!",
   "SHOW_DISABLED_CHALLENGES": "Show them anyways",
   "HIDE_DISABLED_CHALLENGES": "Hide disabled challenges",
   "BTN_HIDE_ALL": "Hide all",

--- a/lib/is-ollama.ts
+++ b/lib/is-ollama.ts
@@ -1,0 +1,16 @@
+let isOllamaCached = false
+
+export async function initOllamaCheck (): Promise<boolean> {
+  const url = process.env.OLLAMA_URL ?? 'http://localhost:11434'
+  try {
+    const res = await fetch(`${url}/api/tags`, { signal: AbortSignal.timeout(2000) })
+    isOllamaCached = res.ok
+  } catch {
+    isOllamaCached = false
+  }
+  return isOllamaCached
+}
+
+export default function isOllama (): boolean {
+  return isOllamaCached
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -17,8 +17,11 @@ import type { Challenge } from 'data/types'
 import isHeroku from './is-heroku'
 import isDocker from './is-docker'
 import isWindows from './is-windows'
+import isOllama from './is-ollama'
 export { default as isDocker } from './is-docker'
 export { default as isWindows } from './is-windows'
+export { default as isOllama } from './is-ollama'
+export { initOllamaCheck } from './is-ollama'
 // import isGitpod from 'is-gitpod') // FIXME Roll back to this when https://github.com/dword-design/is-gitpod/issues/94 is resolve
 const isGitpod = () => false
 
@@ -162,7 +165,8 @@ export function getChallengeEnablementStatus (challenge: Challenge,
     isHeroku: isEnvironmentFunction
     isWindows: isEnvironmentFunction
     isGitpod: isEnvironmentFunction
-  } = { isDocker, isHeroku, isWindows, isGitpod }): ChallengeEnablementStatus {
+    isOllama: isEnvironmentFunction
+  } = { isDocker, isHeroku, isWindows, isGitpod, isOllama }): ChallengeEnablementStatus {
   if (!challenge?.disabledEnv) {
     return { enabled: true, disabledBecause: null }
   }
@@ -182,6 +186,12 @@ export function getChallengeEnablementStatus (challenge: Challenge,
   }
   if (challenge.disabledEnv?.includes('Gitpod') && isEnvironmentFunctions.isGitpod()) {
     return { enabled: false, disabledBecause: 'Gitpod' }
+  }
+  if (challenge.disabledEnv?.includes('NoOllama') && !isEnvironmentFunctions.isOllama()) {
+    return { enabled: false, disabledBecause: 'NoOllama' }
+  }
+  if (challenge.disabledEnv?.includes('Ollama') && !challenge.disabledEnv?.includes('NoOllama') && isEnvironmentFunctions.isOllama()) {
+    return { enabled: false, disabledBecause: 'Ollama' }
   }
   if (challenge.disabledEnv && safetyModeSetting === 'enabled') {
     return { enabled: false, disabledBecause: 'Safety Mode' }

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -124,7 +124,8 @@ const CHALLENGE_KEYS = [
   'csafChallenge',
   'exposedCredentialsChallenge',
   'leakedApiKeyChallenge',
-  'passwordHashLeakChallenge'
+  'passwordHashLeakChallenge',
+  'couponExtractionChallenge'
 ] as const
 
 export type ChallengeKey = typeof CHALLENGE_KEYS[number]

--- a/server.ts
+++ b/server.ts
@@ -600,6 +600,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.get('/rest/products/search', searchProducts())
   app.get('/rest/basket/:id', retrieveBasket())
   app.post('/rest/basket/:id/checkout', placeOrder())
+  app.put('/rest/basket/:id/coupon/:coupon', chatbot.verifyLlmCouponChallenge())
   app.put('/rest/basket/:id/coupon/:coupon', applyCoupon())
   app.get('/rest/admin/application-version', retrieveAppVersion())
   app.get('/rest/admin/application-configuration', retrieveAppConfiguration())
@@ -719,6 +720,13 @@ app.get('/metrics', metrics.serveMetrics()) // vuln-code-snippet vuln-line expos
 errorhandler.title = `${config.get<string>('application.name')} (Express ${utils.version('express')})`
 
 export async function start (readyCallback?: () => void) {
+  const ollamaAvailable = await utils.initOllamaCheck()
+  const ollamaUrl = process.env.OLLAMA_URL ?? 'http://localhost:11434'
+  if (ollamaAvailable) {
+    logger.info(colors.cyan(`Ollama connected at ${colors.bold(ollamaUrl)} - LLM chatbot active (Coupon Extraction challenge available)`))
+  } else {
+    logger.info(colors.cyan('Ollama not available - falling back to built-in chatbot (Bully Chatbot challenge available)'))
+  }
   const datacreatorEnd = startupGauge.startTimer({ task: 'datacreator' })
   await sequelize.sync({ force: true })
   await datacreator()

--- a/test/server/utilsSpec.ts
+++ b/test/server/utilsSpec.ts
@@ -119,7 +119,8 @@ describe('utils', () => {
       isDocker: () => false,
       isHeroku: () => false,
       isWindows: () => false,
-      isGitpod: () => false
+      isGitpod: () => false,
+      isOllama: () => false
     }
 
     for (const safetyMode of ['enabled', 'disabled', 'auto'] as const) {


### PR DESCRIPTION
### Description

Integrate an optional [Ollama](https://ollama.com) LLM backend into the existing chatbot route to enable a new **Coupon Extraction** prompt injection CTF challenge. When Ollama is available, the chatbot uses an LLM with a system prompt containing a hidden coupon code that players must extract via prompt injection techniques. When Ollama is not running, the app falls back to the built-in `juicy-chat-bot`, preserving all existing challenges (Bully Chatbot, Kill Chatbot).

**Changes:**
- Add **Coupon Extraction** challenge (difficulty 3, Injection category) to `challenges.yml` and challenge model
- Integrate Ollama LLM into existing chatbot route (`routes/chatbot.ts`) with graceful fallback
- Add `lib/is-ollama.ts` for static Ollama availability detection at startup
- Add `disabledEnv` support for `Ollama`/`NoOllama` environments in `lib/utils.ts`, so challenges are conditionally shown/hidden on the scoreboard based on Ollama availability
- Add custom scoreboard warning message for `NoOllama` disabled challenges
- Add coupon verification middleware on the coupon redemption route
- Add `docker-compose.yml` for Ollama + Juice Shop deployment
- Add Cypress e2e test for the Coupon Extraction challenge

Resolved or fixed issue: `none`

### AI Tool Disclosure
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code (CLI)`
    - LLMs and versions: `Claude Opus 4.6`
    - Prompts: `Implement Ollama-powered LLM chatbot integration with prompt injection CTF challenge, add fallback to existing chatbot, add disabledEnv environment detection for Ollama, add e2e tests, clean up per CONTRIBUTING.md guidelines`
    - Comment: I did many iterations on myself and throughly testing of the application. The prompts listed above are just cumulated on the many iterations (or the key prompts if you could say so)

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
