### PR TITLE
fix(checkout): prevent invalid orders and race conditions in placeOrd…

### DIFF
--- a/routes/order.ts
+++ b/routes/order.ts
@@ -65,17 +65,19 @@ export function placeOrder () {
           let totalPrice = 0
           const basketProducts: Product[] = []
           let totalPoints = 0
-          basket.Products?.forEach(({ BasketItem, price, deluxePrice, name, id }) => {
+          for (const { BasketItem, price, deluxePrice, name, id } of basket.Products ?? []) {
             if (BasketItem != null) {
               challengeUtils.solveIf(challenges.christmasSpecialChallenge, () => { return BasketItem.ProductId === products.christmasSpecial.id })
-              QuantityModel.findOne({ where: { ProductId: BasketItem.ProductId } }).then((product: any) => {
-                const newQuantity = product.quantity - BasketItem.quantity
-                QuantityModel.update({ quantity: newQuantity }, { where: { ProductId: BasketItem?.ProductId } }).catch((error: unknown) => {
-                  next(error)
-                })
-              }).catch((error: unknown) => {
+              try {
+                const quantityRow = await QuantityModel.findOne({ where: { ProductId: BasketItem.ProductId } })
+                if (quantityRow) {
+                  const newQuantity = quantityRow.quantity - BasketItem.quantity
+                  await QuantityModel.update({ quantity: newQuantity }, { where: { ProductId: BasketItem.ProductId } })
+                }
+              } catch (error: unknown) {
                 next(error)
-              })
+                return
+              }
               let itemPrice: number
               if (security.isDeluxe(req)) {
                 itemPrice = deluxePrice
@@ -98,7 +100,7 @@ export function placeOrder () {
               totalPrice += itemTotal
               totalPoints += itemBonus
             }
-          })
+          }
           doc.moveDown()
           const discount = calculateApplicableDiscount(basket, req) ?? 0
           let discountAmount = '0'
@@ -139,16 +141,18 @@ export function placeOrder () {
             if (req.body.orderDetails && req.body.orderDetails.paymentId === 'wallet') {
               const wallet = await WalletModel.findOne({ where: { UserId: req.body.UserId } })
               if ((wallet != null) && wallet.balance >= totalPrice) {
-                WalletModel.decrement({ balance: totalPrice }, { where: { UserId: req.body.UserId } }).catch((error: unknown) => {
-                  next(error)
-                })
+                await WalletModel.decrement({ balance: totalPrice }, { where: { UserId: req.body.UserId } })
               } else {
                 next(new Error('Insufficient wallet balance.'))
+                return
               }
             }
-            WalletModel.increment({ balance: totalPoints }, { where: { UserId: req.body.UserId } }).catch((error: unknown) => {
+            try {
+              await WalletModel.increment({ balance: totalPoints }, { where: { UserId: req.body.UserId } })
+            } catch (error: unknown) {
               next(error)
-            })
+              return
+            }
           }
 
           db.ordersCollection.insert({
@@ -176,10 +180,9 @@ export function placeOrder () {
 }
 
 function calculateApplicableDiscount (basket: BasketModel, req: Request) {
-  if (security.discountFromCoupon(basket.coupon ?? undefined)) {
-    const discount = security.discountFromCoupon(basket.coupon ?? undefined)
+  const discount = security.discountFromCoupon(basket.coupon ?? undefined)
+  if (discount) {
     challengeUtils.solveIf(challenges.forgedCouponChallenge, () => { return (discount ?? 0) >= 80 })
-    console.log(discount)
     return discount
   } else if (req.body.couponData) {
     const couponData = Buffer.from(req.body.couponData, 'base64').toString().split('-')


### PR DESCRIPTION
### Description

The placeOrder() function in routes/order.tscontains five interrelated bugs in its checkout pipeline all in non-challenge infrastructure code (zero vuln-code-snippet markers, all four challenge solveIf() calls execute before the affected lines).

**Bugs fixed**

1. Fire-and-forget inventory updates in forEach loop — QuantityModel.findOne + updateran as unawaited promises inside a synchronous forEach, causing race conditions between concurrent orders and allowing totalPrice/totalPoints to accumulate before DB operations completed. Converted to for...of with await.

2. Missing return after next(error) on insufficient wallet balance — after calling next(new Error('Insufficient wallet balance.')), execution continued to credit bonus points, insert the MongoDB order, and generate the PDF. Added return.
 
3. Unawaited wallet operations WalletModel.decrement and WalletModel.increment were fire-and-forget with only .catch(next). Two concurrent checkouts could both pass the balance check before either decrement committed (TOCTOU race). Now properly awaited.

4. console.log(discount) in production — leaked applied discount percentage to stdout on every coupon-discounted order. Removed.

5. Redundant discountFromCoupon call — called twice with identical arguments (z85 decode + parse + date validation each time). Deduplicated to a single call with assign-then-check.

No challenges affected — christmasSpecialChallenge (line 70), negativeOrderChallenge (line 138), forgedCouponChallenge (line 185), and manipulateClockChallenge (line 194) are all solved before or orthogonal to the changed code paths.

Resolved or fixed issue: Fixes #3126 

### AI Tool Disclosure

- [ X ] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [ X ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
