### PR TITLE
Replace Cypress force-clicks with deterministic assertions

### DIFF
--- a/test/cypress/e2e/changePassword.spec.ts
+++ b/test/cypress/e2e/changePassword.spec.ts
@@ -11,7 +11,7 @@ describe('/#/privacy-security/change-password', () => {
     it('should be able to change password', () => {
       cy.get('#currentPassword').type('focusOnScienceMorty!focusOnScience')
       cy.get('#newPassword').type('GonorrheaCantSeeUs!')
-      cy.get('#newPasswordRepeat').click().type('GonorrheaCantSeeUs!')
+      cy.get('#newPasswordRepeat').focus().type('GonorrheaCantSeeUs!')
       cy.get('#changeButton').click()
 
       cy.get('.confirmation').should('not.be.hidden')

--- a/test/cypress/e2e/changePassword.spec.ts
+++ b/test/cypress/e2e/changePassword.spec.ts
@@ -11,7 +11,7 @@ describe('/#/privacy-security/change-password', () => {
     it('should be able to change password', () => {
       cy.get('#currentPassword').type('focusOnScienceMorty!focusOnScience')
       cy.get('#newPassword').type('GonorrheaCantSeeUs!')
-      cy.get('#newPasswordRepeat').should('be.visible').type('GonorrheaCantSeeUs!')
+      cy.get('#newPasswordRepeat').click().type('GonorrheaCantSeeUs!')
       cy.get('#changeButton').click()
 
       cy.get('.confirmation').should('not.be.hidden')

--- a/test/cypress/e2e/changePassword.spec.ts
+++ b/test/cypress/e2e/changePassword.spec.ts
@@ -11,7 +11,7 @@ describe('/#/privacy-security/change-password', () => {
     it('should be able to change password', () => {
       cy.get('#currentPassword').type('focusOnScienceMorty!focusOnScience')
       cy.get('#newPassword').type('GonorrheaCantSeeUs!')
-      cy.get('#newPasswordRepeat').type('GonorrheaCantSeeUs!', { force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#newPasswordRepeat').should('be.visible').type('GonorrheaCantSeeUs!')
       cy.get('#changeButton').click()
 
       cy.get('.confirmation').should('not.be.hidden')

--- a/test/cypress/e2e/contact.spec.ts
+++ b/test/cypress/e2e/contact.spec.ts
@@ -22,7 +22,7 @@ describe('/#/contact', () => {
       cy.get('#userId').clear().type('2')
       cy.get('#rating').type('{rightarrow}{rightarrow}{rightarrow}')
       cy.get('#comment').type('Picard stinks!')
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
 
       cy.visit('/#/administration')
 
@@ -58,7 +58,7 @@ describe('/#/contact', () => {
           cy.get('#comment').type(
             '<<script>Foo</script>iframe src="javascript:alert(`xss`)">'
           )
-          cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+          cy.get('#submitButton').should('not.be.disabled').click()
 
           cy.visit('/#/about')
           cy.on('window:alert', (t) => {
@@ -81,7 +81,7 @@ describe('/#/contact', () => {
       cy.get('#comment').type('sanitize-html 1.4.2 is non-recursive.')
       cy.get('#comment').type('express-jwt 0.1.3 has broken crypto.')
 
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
       cy.expectChallengeSolved({ challenge: 'Vulnerable Library' })
     })
   })
@@ -92,7 +92,7 @@ describe('/#/contact', () => {
       cy.get('#comment').type(
         'The following libraries are bad for crypto: z85, base85, md5 and hashids'
       )
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
       cy.expectChallengeSolved({ challenge: 'Weird Crypto' })
     })
   })
@@ -103,7 +103,7 @@ describe('/#/contact', () => {
       cy.get('#comment').type(
         'You are a typosquatting victim of this NPM package: epilogue-js'
       )
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
       cy.expectChallengeSolved({ challenge: 'Legacy Typosquatting' })
     })
   })
@@ -114,7 +114,7 @@ describe('/#/contact', () => {
       cy.get('#comment').type(
         'You are a typosquatting victim of this NPM package: ngy-cookie'
       )
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
       cy.expectChallengeSolved({ challenge: 'Frontend Typosquatting' })
     })
   })
@@ -125,7 +125,7 @@ describe('/#/contact', () => {
       cy.get('#comment').type(
         'Pickle Rick is hiding behind one of the support team ladies'
       )
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
       cy.expectChallengeSolved({ challenge: 'Steganography' })
     })
   })
@@ -229,7 +229,7 @@ describe('/#/contact', () => {
       cy.get('#comment').type(
         'Turn on 2FA! Now!!! https://github.com/eslint/eslint-scope/issues/39'
       )
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
       cy.expectChallengeSolved({ challenge: 'Supply Chain Attack' })
     })
   })
@@ -242,7 +242,7 @@ describe('/#/contact', () => {
           pastebinLeakProduct.keywordsForPastebinDataLeakChallenge ? pastebinLeakProduct.keywordsForPastebinDataLeakChallenge.toString() : '?'
         )
       })
-      cy.get('#submitButton').click({ force: true }) // FIXME Analyze Cypress recordings to properly fix behavior during test
+      cy.get('#submitButton').should('not.be.disabled').click()
       cy.expectChallengeSolved({ challenge: 'Leaked Unsafe Product' })
     })
   })


### PR DESCRIPTION
Fixes #3099

This PR replaces forced Cypress interactions in the test suite with
deterministic assertions.

In `contact.spec.ts`, occurrences of `click({ force: true })` were
replaced with `.should('not.be.disabled').click()` so Cypress waits
for Angular reactive form validation instead of bypassing actionability
checks.

In `changePassword.spec.ts`, a forced `.type()` was replaced with a
visibility assertion before typing.

These changes remove forced interactions and allow the tests to rely
on Cypress’ built-in retry behavior, improving test determinism.