### PR TITLE
Fix mobile scroll lock by disabling Angular Material tooltip touch ge…

### DIFF
--- a/frontend/src/app/product/product.component.html
+++ b/frontend/src/app/product/product.component.html
@@ -20,6 +20,7 @@
       </aside>
     }
     <section
+      matTooltipTouchGestures="off"
       tabindex="0"
       (keydown.enter)="showDetail(product)"
       role="button"

--- a/frontend/src/app/product/product.component.scss
+++ b/frontend/src/app/product/product.component.scss
@@ -12,6 +12,7 @@
 }
 
 .product {
+  touch-action: pan-y;
   overflow: hidden;
   position: relative;
   display: flex;


### PR DESCRIPTION
Fixes #3148

On mobile devices, swipe gestures starting on product images or titles prevented the page from scrolling. This happens because Angular Material’s tooltip registers touch gesture handlers that intercept the event and prevent the browser’s native scroll behavior.

This change resolves the issue by:

* disabling tooltip touch gesture interception with matTooltipTouchGestures="off"
* allowing native vertical scrolling on the product card with touch-action: pan-y

After these changes:
- vertical swipe scrolling works when starting on product images or titles
- tapping the product card still opens the product details modal

Tested on a physical Android device.