### PR TITLE
Added redos recycling challenge

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -1541,3 +1541,15 @@
     - 'The chatbot trusts whatever discount value it decides to pass to its tool. Make it decide on a very generous number.'
   mitigationUrl: 'https://genai.owasp.org/llmrisk/llm01-prompt-injection/'
   key: chatbotGreedyInjectionChallenge
+-
+  name: 'ReDoS your Recycling'
+  category: 'Broken Anti Automation'
+  description: 'Perform a <i>ReDoS</i> attack on the recycling order ID validation endpoint keeping the server busy for >2 seconds.'
+  difficulty: 4
+  hints:
+    - 'The recycling page has an order ID validation field. What happens if you craft a special input?'
+    - 'Try an order ID that starts with the correct format but ends with an unexpected character.'
+    - 'A vulnerable regex with nested quantifiers can be tricked into catastrophic backtracking.'
+    - 'Try fe01-aaaaaaaaaaaaaaaa! as your input and see what happens to the response time.'
+  mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.html'
+  key: redosChallenge

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -122,9 +122,7 @@ const CHALLENGE_KEYS = [
   'csafChallenge',
   'exposedCredentialsChallenge',
   'leakedApiKeyChallenge',
-  'passwordHashLeakChallenge',
-  'chatbotPromptInjectionChallenge',
-  'chatbotGreedyInjectionChallenge'
+  'redosChallenge'
 ] as const
 
 export type ChallengeKey = typeof CHALLENGE_KEYS[number]

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -122,6 +122,9 @@ const CHALLENGE_KEYS = [
   'csafChallenge',
   'exposedCredentialsChallenge',
   'leakedApiKeyChallenge',
+  'passwordHashLeakChallenge',
+  'chatbotPromptInjectionChallenge',
+  'chatbotGreedyInjectionChallenge',
   'redosChallenge'
 ] as const
 

--- a/routes/recycles.ts
+++ b/routes/recycles.ts
@@ -34,7 +34,7 @@ export const validateRecycleOrderId = () => (req: Request, res: Response) => {
     return res.status(400).json({ error: 'Order ID is required' })
   }
 
-  const orderIdFormat = /^([0-9a-f]+(-[0-9a-f]*)?)+$/ // lgtm[js/redos] - intentionally vulnerable regex for security training challenge
+  const orderIdFormat = /^([0-9a-f]+(-[0-9a-f]*)?)+$/
 
   const start = Date.now()
   const isValid = orderIdFormat.test(orderId)

--- a/routes/recycles.ts
+++ b/routes/recycles.ts
@@ -6,6 +6,8 @@
 import { type Request, type Response } from 'express'
 import { RecycleModel } from '../models/recycle'
 
+import * as challengeUtils from '../lib/challengeUtils'
+import { challenges } from '../data/datacache'
 import * as utils from '../lib/utils'
 
 export const getRecycleItem = () => (req: Request, res: Response) => {
@@ -23,4 +25,22 @@ export const getRecycleItem = () => (req: Request, res: Response) => {
 export const blockRecycleItems = () => (req: Request, res: Response) => {
   const errMsg = { err: 'Sorry, this endpoint is not supported.' }
   return res.send(utils.queryResultToJson(errMsg))
+}
+
+export const validateRecycleOrderId = () => (req: Request, res: Response) => {
+  const orderId = req.query.orderId as string
+
+  if (!orderId) {
+    return res.status(400).json({ error: 'Order ID is required' })
+  }
+
+  const orderIdFormat = /^([0-9a-f]+(-[0-9a-f]*)?)+$/
+
+  const start = Date.now()
+  const isValid = orderIdFormat.test(orderId)
+  const duration = Date.now() - start
+
+  challengeUtils.solveIf(challenges.redosChallenge, () => { return duration > 2000 })
+
+  return res.json({ valid: isValid })
 }

--- a/routes/recycles.ts
+++ b/routes/recycles.ts
@@ -34,7 +34,7 @@ export const validateRecycleOrderId = () => (req: Request, res: Response) => {
     return res.status(400).json({ error: 'Order ID is required' })
   }
 
-  const orderIdFormat = /^([0-9a-f]+(-[0-9a-f]*)?)+$/
+  const orderIdFormat = /^([0-9a-f]+(-[0-9a-f]*)?)+$/ // lgtm[js/redos] - intentionally vulnerable regex for security training challenge
 
   const start = Date.now()
   const isValid = orderIdFormat.test(orderId)

--- a/rsn/cache.json
+++ b/rsn/cache.json
@@ -41,26 +41,30 @@
 	},
 	"changeProductChallenge_1.ts": {
 		"added": [
-			48
+			34,
+			49
 		],
 		"removed": []
 	},
 	"changeProductChallenge_2.ts": {
 		"added": [
 			18,
-			48
+			34,
+			49
 		],
 		"removed": []
 	},
 	"changeProductChallenge_3_correct.ts": {
 		"added": [
-			48
+			34,
+			49
 		],
 		"removed": []
 	},
 	"changeProductChallenge_4.ts": {
 		"added": [
-			48
+			34,
+			49
 		],
 		"removed": []
 	},

--- a/server.ts
+++ b/server.ts
@@ -383,6 +383,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   /* Recycles: POST and GET allowed when logged in only */
   app.get('/api/Recycles', recycles.blockRecycleItems())
   app.post('/api/Recycles', security.isAuthorized())
+  app.get('/api/Recycles/validateOrderId', recycles.validateRecycleOrderId())
   /* Challenge evaluation before finale takes over */
   app.get('/api/Recycles/:id', recycles.getRecycleItem())
   app.put('/api/Recycles/:id', security.denyAll())

--- a/test/api/recycleApiSpec.ts
+++ b/test/api/recycleApiSpec.ts
@@ -71,3 +71,26 @@ describe('/api/Recycles', () => {
       .expect('status', 401)
   })
 })
+
+describe('/api/Recycles/validateOrderId', () => {
+  it('GET returns valid true for a correctly formatted order ID', () => {
+    return frisby.get(`${API_URL}/Recycles/validateOrderId?orderId=fe01-8febb86ca96798ca`)
+      .expect('status', 200)
+      .expect('header', 'content-type', /application\/json/)
+      .expect('json', { valid: true })
+  })
+
+  it('GET returns valid false for an order ID with invalid characters', () => {
+    return frisby.get(`${API_URL}/Recycles/validateOrderId?orderId=fe01-xyz`)
+      .expect('status', 200)
+      .expect('header', 'content-type', /application\/json/)
+      .expect('json', { valid: false })
+  })
+
+  it('GET returns 400 when orderId parameter is missing', () => {
+    return frisby.get(`${API_URL}/Recycles/validateOrderId`)
+      .expect('status', 400)
+      .expect('header', 'content-type', /application\/json/)
+      .expect('json', { error: 'Order ID is required' })
+  })
+})


### PR DESCRIPTION
### Description
Adds a ReDoS (Regular Expression Denial of Service) challenge on the recycling page as discussed in #3138.

A new GET /api/Recycles/validateOrderId endpoint validates recycling order IDs against a regex with nested quantifiers (`/^([0-9a-f]+(-[0-9a-f]*)?)+$/`). When a crafted input like `fe01-aaaaaa!` is submitted the engine hits catastrophic backtracking and the request takes ~7 seconds. The challenge is marked solved when the response takes longer than 2000ms consistent with other DoS challenges.

### Files changed:
- routes/recycles.ts — new validateRecycleOrderId function
- server.ts — registered the new endpoint
- models/challenge.ts — added redosChallenge key
- data/static/challenges.yml — added challenge metadata
- test/api/recycleApiSpec.ts — added API tests for the new endpoint

### AI Tool Disclosure

- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `GitHub Copilot, ChatGPT`
    - LLMs and versions: `GPT-4o`
    - Prompts: `Helped implement the ReDoS vulnerable regex endpoint and challenge metadata based on the approach discussed in the issue`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines

