### PR TITLE
Fix padding for mat-dialog-actions in code snippet component

### DIFF
--- a/frontend/src/app/code-snippet/code-snippet.component.scss
+++ b/frontend/src/app/code-snippet/code-snippet.component.scss
@@ -15,10 +15,10 @@
 }
 
 mat-dialog-actions {
-  --mat-dialog-actions-padding: $space-ml $space-l;
   display: grid;
   gap: $space-m;
   grid-template-columns: 1fr;
+  padding: $space-m $space-l 0 $space-l;
 }
 
 .button-row {


### PR DESCRIPTION
### Description
In the morning, I played with the LLM challenges and discovered a spacing issue in the code snippets component. This PR addresses that.

## Before

![fix-1](https://github.com/user-attachments/assets/2c7e30f5-d949-4300-9366-294ee59fcb2e)

## After

![fix-2](https://github.com/user-attachments/assets/c5158a32-ceaa-470e-a6f4-8272f2a0e79d)

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines