### PR TITLE
Guest basket support for anonymous users with merge-on-login

### DIFF
--- a/frontend/src/app/Services/basket.service.spec.ts
+++ b/frontend/src/app/Services/basket.service.spec.ts
@@ -114,6 +114,7 @@ describe('BasketService', () => {
 
   it('should emit total number of items when updating number of cart items', inject([BasketService, HttpTestingController],
     fakeAsync((service: BasketService, httpMock: HttpTestingController) => {
+      localStorage.setItem('token', 'token')
       sessionStorage.setItem('bid', '42')
       const totals: number[] = []
       service.getItemTotal().subscribe((t) => totals.push(t))
@@ -132,12 +133,14 @@ describe('BasketService', () => {
 
       tick()
       expect(totals).toEqual([5])
+      localStorage.removeItem('token')
       httpMock.verify()
     })
   ))
 
   it('should log error when updating number of cart items fails', inject([BasketService, HttpTestingController],
     fakeAsync((service: BasketService, httpMock: HttpTestingController) => {
+      localStorage.setItem('token', 'token')
       sessionStorage.setItem('bid', '99')
       let consoleSpy: jasmine.Spy
       const anyJ = (jasmine as any)
@@ -154,6 +157,84 @@ describe('BasketService', () => {
       tick()
 
       expect(consoleSpy).toHaveBeenCalled()
+      localStorage.removeItem('token')
+      httpMock.verify()
+    })
+  ))
+
+  it('should emit total number of guest basket items when anonymous', inject([BasketService],
+    (service: BasketService) => {
+      localStorage.removeItem('token')
+      sessionStorage.setItem('guestBasket', JSON.stringify([
+        { ProductId: 1, quantity: 2 },
+        { ProductId: 2, quantity: 3 }
+      ]))
+
+      const totals: number[] = []
+      service.getItemTotal().subscribe((t) => totals.push(t))
+      service.updateNumberOfCartItems()
+
+      expect(totals).toEqual([5])
+      sessionStorage.removeItem('guestBasket')
+    }
+  ))
+
+  it('should silently drop malformed guest basket items', inject([BasketService],
+    (service: BasketService) => {
+      sessionStorage.setItem('guestBasket', JSON.stringify([
+        { ProductId: 1, quantity: 2 },
+        { ProductId: '2', quantity: '3' },
+        { ProductId: 0, quantity: 5 },
+        { ProductId: 5, quantity: -1 },
+        { ProductId: null, quantity: 4 },
+        { foo: 'bar' }
+      ]))
+
+      expect(service.getGuestBasketItems()).toEqual([
+        { ProductId: 1, quantity: 2 },
+        { ProductId: 2, quantity: 3 }
+      ])
+      sessionStorage.removeItem('guestBasket')
+    }
+  ))
+
+  it('should merge guest basket as best effort and continue on item errors', inject([BasketService, HttpTestingController],
+    fakeAsync((service: BasketService, httpMock: HttpTestingController) => {
+      localStorage.removeItem('token')
+      sessionStorage.setItem('guestBasket', JSON.stringify([
+        { ProductId: 1, quantity: 2 },
+        { ProductId: 1, quantity: 1 },
+        { ProductId: 2, quantity: 3 }
+      ]))
+
+      let completed = false
+      service.mergeGuestBasketIntoUserBasket(42).subscribe(() => {
+        completed = true
+      })
+
+      const findReq = httpMock.expectOne('http://localhost:3000/rest/basket/42')
+      findReq.flush({
+        data: {
+          Products: [
+            { id: 1, BasketItem: { id: 100, quantity: 4 } }
+          ]
+        }
+      })
+
+      const putReq = httpMock.expectOne('http://localhost:3000/api/BasketItems/100')
+      expect(putReq.request.method).toBe('PUT')
+      expect(putReq.request.body).toEqual({ quantity: 7 })
+      putReq.error(new ErrorEvent('Merge failed'), { status: 500, statusText: 'Internal Error' })
+
+      const postReq = httpMock.expectOne('http://localhost:3000/api/BasketItems/')
+      expect(postReq.request.method).toBe('POST')
+      expect(postReq.request.body).toEqual({ ProductId: 2, BasketId: 42, quantity: 3 })
+      postReq.flush({ data: {} })
+
+      tick()
+
+      expect(completed).toBeTrue()
+      expect(sessionStorage.getItem('guestBasket')).toBeNull()
       httpMock.verify()
     })
   ))

--- a/frontend/src/app/Services/basket.service.ts
+++ b/frontend/src/app/Services/basket.service.ts
@@ -7,12 +7,18 @@ import { environment } from '../../environments/environment'
 import { Injectable, inject } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { catchError, map } from 'rxjs/operators'
-import { type Observable, Subject } from 'rxjs'
+import { type Observable, Subject, forkJoin, of } from 'rxjs'
+import { switchMap, tap } from 'rxjs/operators'
 
 interface OrderDetail {
   paymentId: string
   addressId: string
   deliveryMethodId: string
+}
+
+interface GuestBasketItem {
+  ProductId: number
+  quantity: number
 }
 
 @Injectable({
@@ -24,6 +30,7 @@ export class BasketService {
   public hostServer = environment.hostServer
   public itemTotal = new Subject<any>()
   private readonly host = this.hostServer + '/api/BasketItems'
+  private readonly guestBasketKey = 'guestBasket'
 
   find (id?: number) {
     return this.http.get(`${this.hostServer}/rest/basket/${id}`).pipe(map((response: any) => response.data), catchError((error) => { throw error }))
@@ -54,16 +61,126 @@ export class BasketService {
   }
 
   updateNumberOfCartItems () {
-    this.find(parseInt(sessionStorage.getItem('bid'), 10)).subscribe({
-      next: (basket) => {
+    if (localStorage.getItem('token')) {
+      this.find(parseInt(sessionStorage.getItem('bid'), 10)).subscribe({
+        next: (basket) => {
+          this.itemTotal.next(basket.Products.reduce((itemTotal, product) => itemTotal + product.BasketItem.quantity, 0))
+        },
+        error: (err) => { console.log(err) }
+      })
+      return
+    }
 
-        this.itemTotal.next(basket.Products.reduce((itemTotal, product) => itemTotal + product.BasketItem.quantity, 0))
-      },
-      error: (err) => { console.log(err) }
-    })
+    const guestBasketItems = this.getGuestBasketItems()
+    this.itemTotal.next(guestBasketItems.reduce((itemTotal, item) => itemTotal + item.quantity, 0))
   }
 
   getItemTotal (): Observable<any> {
     return this.itemTotal.asObservable()
+  }
+
+  getGuestBasketItems (): GuestBasketItem[] {
+    const rawGuestBasket = sessionStorage.getItem(this.guestBasketKey)
+    if (rawGuestBasket == null) {
+      return []
+    }
+
+    try {
+      const parsedGuestBasket = JSON.parse(rawGuestBasket)
+      if (Array.isArray(parsedGuestBasket)) {
+        return parsedGuestBasket
+          .map((item: any) => {
+            const productId = Number(item?.ProductId)
+            const quantity = Number(item?.quantity)
+            if (!Number.isInteger(productId) || productId < 1 || !Number.isFinite(quantity) || quantity < 1) {
+              return null
+            }
+            return {
+              ProductId: productId,
+              quantity: Math.floor(quantity)
+            }
+          })
+          .filter((item): item is GuestBasketItem => item != null)
+      }
+      return []
+    } catch {
+      return []
+    }
+  }
+
+  addToGuestBasket (productId: number, quantity = 1): void {
+    const guestBasketItems = this.getGuestBasketItems()
+    const existingGuestItem = guestBasketItems.find(item => item.ProductId === productId)
+
+    if (existingGuestItem != null) {
+      existingGuestItem.quantity += quantity
+    } else {
+      guestBasketItems.push({ ProductId: productId, quantity })
+    }
+
+    sessionStorage.setItem(this.guestBasketKey, JSON.stringify(guestBasketItems))
+    this.updateNumberOfCartItems()
+  }
+
+  updateGuestBasketItemQuantity (productId: number, quantity: number): void {
+    const guestBasketItems = this.getGuestBasketItems()
+    const guestItemToUpdate = guestBasketItems.find(item => item.ProductId === productId)
+    if (guestItemToUpdate == null) {
+      return
+    }
+
+    guestItemToUpdate.quantity = Math.max(1, quantity)
+    sessionStorage.setItem(this.guestBasketKey, JSON.stringify(guestBasketItems))
+    this.updateNumberOfCartItems()
+  }
+
+  removeGuestBasketItem (productId: number): void {
+    const guestBasketItems = this.getGuestBasketItems().filter(item => item.ProductId !== productId)
+    sessionStorage.setItem(this.guestBasketKey, JSON.stringify(guestBasketItems))
+    this.updateNumberOfCartItems()
+  }
+
+  clearGuestBasket (): void {
+    sessionStorage.removeItem(this.guestBasketKey)
+    this.updateNumberOfCartItems()
+  }
+
+  mergeGuestBasketIntoUserBasket (targetBasketId: number): Observable<void> {
+    const mergedGuestBasketItems = this.getGuestBasketItems().reduce((basketMap, item) => {
+      basketMap.set(item.ProductId, (basketMap.get(item.ProductId) ?? 0) + item.quantity)
+      return basketMap
+    }, new Map<number, number>())
+
+    if (mergedGuestBasketItems.size === 0) {
+      return of(void 0)
+    }
+
+    return this.find(targetBasketId).pipe(
+      catchError(() => of({ Products: [] })),
+      switchMap((targetBasket: any) => {
+        const existingProducts = new Map<number, any>()
+        ;(targetBasket.Products ?? []).forEach((product: any) => {
+          existingProducts.set(product.id, product.BasketItem)
+        })
+
+        const mergeRequests = Array.from(mergedGuestBasketItems.entries()).map(([productId, quantity]) => {
+          const existingBasketItem = existingProducts.get(productId)
+          if (existingBasketItem != null) {
+            return this.put(existingBasketItem.id, { quantity: existingBasketItem.quantity + quantity }).pipe(catchError(() => of(null)))
+          }
+          return this.save({ ProductId: productId, BasketId: targetBasketId, quantity }).pipe(catchError(() => of(null)))
+        })
+
+        if (mergeRequests.length === 0) {
+          return of([])
+        }
+
+        return forkJoin(mergeRequests)
+      }),
+      tap(() => {
+        this.clearGuestBasket()
+      }),
+      map(() => void 0)
+    )
   }
 }

--- a/frontend/src/app/basket/basket.component.ts
+++ b/frontend/src/app/basket/basket.component.ts
@@ -28,6 +28,15 @@ export class BasketComponent {
   public bonus = 0
 
   checkout (): void {
+    if (localStorage.getItem('token') == null) {
+      this.ngZone.run(async () => await this.router.navigate(['/login'], {
+        queryParams: {
+          redirectUrl: '/basket'
+        }
+      }))
+      return
+    }
+
     this.ngZone.run(async () => await this.router.navigate(['/address/select']))
   }
 

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -5,7 +5,7 @@
 
 import { CookieService } from 'ngy-cookie'
 import { WindowRefService } from '../Services/window-ref.service'
-import { Router, RouterLink } from '@angular/router'
+import { ActivatedRoute, Router, RouterLink } from '@angular/router'
 import { Component, NgZone, type OnInit, inject } from '@angular/core'
 import { UntypedFormControl, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -22,6 +22,8 @@ import { MatIconButton, MatButtonModule } from '@angular/material/button'
 import { MatInputModule } from '@angular/material/input'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatFormFieldModule, MatLabel, MatError, MatSuffix } from '@angular/material/form-field'
+import { of } from 'rxjs'
+import { catchError } from 'rxjs/operators'
 
 import { MatCardModule } from '@angular/material/card'
 
@@ -42,6 +44,7 @@ export class LoginComponent implements OnInit {
   private readonly windowRefService = inject(WindowRefService)
   private readonly cookieService = inject(CookieService)
   private readonly router = inject(Router)
+  private readonly route = inject(ActivatedRoute)
   private readonly formSubmitService = inject(FormSubmitService)
   private readonly basketService = inject(BasketService)
   private readonly ngZone = inject(NgZone)
@@ -98,14 +101,23 @@ export class LoginComponent implements OnInit {
     this.user.password = this.passwordControl.value
     this.userService.login(this.user).subscribe({
       next: (authentication: any) => {
+        const redirectUrl = this.route.snapshot.queryParamMap.get('redirectUrl') ?? '/search'
         localStorage.setItem('token', authentication.token)
         const expires = new Date()
         expires.setHours(expires.getHours() + 8)
         this.cookieService.put('token', authentication.token, { expires })
         sessionStorage.setItem('bid', authentication.bid)
-        this.basketService.updateNumberOfCartItems()
-        this.userService.isLoggedIn.next(true)
-        this.ngZone.run(async () => await this.router.navigate(['/search']))
+
+        this.basketService.mergeGuestBasketIntoUserBasket(authentication.bid)
+          .pipe(
+            catchError((err) => {
+              console.log(err)
+              return of(void 0)
+            })
+          )
+          .subscribe(() => {
+            this.completeLogin(redirectUrl)
+          })
       },
       error: ({ error }) => {
         if (error.status && error.data && error.status === 'totp_token_required') {
@@ -128,6 +140,12 @@ export class LoginComponent implements OnInit {
     } else {
       localStorage.removeItem('email')
     }
+  }
+
+  private completeLogin (redirectUrl: string): void {
+    this.basketService.updateNumberOfCartItems()
+    this.userService.isLoggedIn.next(true)
+    this.ngZone.run(async () => await this.router.navigateByUrl(redirectUrl))
   }
 
   googleLogin () {

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -101,16 +101,14 @@
       }
     </mat-menu>
 
-    @if (isLoggedIn()) {
-      <button mat-button routerLink="/basket" class="buttons nav-button"
-        aria-label="Show the shopping cart">
-        <mat-icon>
-          shopping_cart
-        </mat-icon>
-        <span class="hide-lt-md basket-label"> {{"TITLE_BASKET" | translate}}</span>
-        <span class="fa-layers-counter fa-layers-top-right fa-3x warn-notification">{{itemTotal}}</span>
-      </button>
-    }
+    <button mat-button routerLink="/basket" class="buttons nav-button"
+      aria-label="Show the shopping cart">
+      <mat-icon>
+        shopping_cart
+      </mat-icon>
+      <span class="hide-lt-md basket-label"> {{"TITLE_BASKET" | translate}}</span>
+      <span class="fa-layers-counter fa-layers-top-right fa-3x warn-notification">{{itemTotal}}</span>
+    </button>
 
     <button id="navbarLanguageButton" [matMenuTriggerFor]="menu" mat-button class="buttons nav-square-button"
       aria-label="Language selection menu"

--- a/frontend/src/app/navbar/navbar.component.scss
+++ b/frontend/src/app/navbar/navbar.component.scss
@@ -52,8 +52,8 @@ mat-toolbar {
 }
 
 .warn-notification {
-  font-size: 47px;
   left: 15px;
+  text-overflow: clip;
   top: -15px;
 }
 

--- a/frontend/src/app/navbar/navbar.component.spec.ts
+++ b/frontend/src/app/navbar/navbar.component.spec.ts
@@ -256,6 +256,12 @@ describe('NavbarComponent', () => {
     expect(sessionStorage.removeItem).toHaveBeenCalledWith('itemTotal')
   })
 
+  it('should remove guest basket from session storage', () => {
+    spyOn(sessionStorage, 'removeItem')
+    component.logout()
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('guestBasket')
+  })
+
   it('should set the login status to be false via UserService', () => {
     component.logout()
     expect(userService.isLoggedIn.next).toHaveBeenCalledWith(false)

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -115,6 +115,7 @@ export class NavbarComponent implements OnInit {
   ngOnInit (): void {
     this.getLanguages()
     this.basketService.getItemTotal().subscribe(x => (this.itemTotal = x))
+    this.basketService.updateNumberOfCartItems()
     this.administrationService.getApplicationVersion().subscribe({
       next: (version: any) => {
         if (version) {
@@ -157,6 +158,7 @@ export class NavbarComponent implements OnInit {
         this.getUserDetails()
       } else {
         this.userEmail = ''
+        this.basketService.updateNumberOfCartItems()
       }
     })
 
@@ -239,6 +241,7 @@ export class NavbarComponent implements OnInit {
     this.cookieService.remove('token')
     sessionStorage.removeItem('bid')
     sessionStorage.removeItem('itemTotal')
+    sessionStorage.removeItem('guestBasket')
     this.userService.isLoggedIn.next(false)
     this.ngZone.run(async () => await this.router.navigate(['/']))
   }

--- a/frontend/src/app/order-summary/order-summary.component.spec.ts
+++ b/frontend/src/app/order-summary/order-summary.component.spec.ts
@@ -41,10 +41,11 @@ describe('OrderSummaryComponent', () => {
   beforeEach(waitForAsync(() => {
     addressService = jasmine.createSpyObj('AddressService', ['getById'])
     addressService.getById.and.returnValue(of([]))
-    basketService = jasmine.createSpyObj('BasketService', ['checkout', 'find', 'updateNumberOfCartItems'])
+    basketService = jasmine.createSpyObj('BasketService', ['checkout', 'find', 'updateNumberOfCartItems', 'getGuestBasketItems'])
     basketService.find.and.returnValue(of({ Products: [] }))
     basketService.checkout.and.returnValue(of({}))
     basketService.updateNumberOfCartItems.and.returnValue(of({}))
+    basketService.getGuestBasketItems.and.returnValue([])
     paymentService = jasmine.createSpyObj('PaymentService', ['getById'])
     paymentService.getById.and.returnValue(of([]))
     deliveryService = jasmine.createSpyObj('DeliveryService', ['getById'])

--- a/frontend/src/app/product/product.component.html
+++ b/frontend/src/app/product/product.component.html
@@ -56,19 +56,17 @@
             {{ product.deluxePrice }}&curren;
           }
         </div>
-      @if (isLoggedIn()) {
-        <button
-          (click)="addToBasket(product.id)"
-          aria-label="{{ 'ADD_BASKET' | translate }}"
-          class="btn-basket"
-          color="primary"
-          mat-button
-          mat-raised-button
-        >
-          <mat-icon class="icon-basket">add_shopping_cart</mat-icon>
-          {{ "ADD_BASKET" | translate }}
-        </button>
-      }
+      <button
+        (click)="addToBasket(product.id)"
+        aria-label="{{ 'ADD_BASKET' | translate }}"
+        class="btn-basket"
+        color="primary"
+        mat-button
+        mat-raised-button
+      >
+        <mat-icon class="icon-basket">add_shopping_cart</mat-icon>
+        {{ "ADD_BASKET" | translate }}
+      </button>
     </footer>
   </article>
 </mat-card>

--- a/frontend/src/app/product/product.component.ts
+++ b/frontend/src/app/product/product.component.ts
@@ -36,6 +36,38 @@ export class ProductComponent {
   isDeluxe = input.required<boolean>()
 
   addToBasket(id?: number) {
+    if (id == null) {
+      return
+    }
+
+    if (!this.isLoggedIn()) {
+      this.basketService.addToGuestBasket(id)
+      this.productService.get(id).subscribe({
+        next: (product) => {
+          this.translateService
+            .get('BASKET_ADD_PRODUCT', { product: product.name })
+            .subscribe({
+              next: (basketAddProduct) => {
+                this.snackBarHelperService.open(
+                  basketAddProduct,
+                  'confirmBar'
+                )
+              },
+              error: (translationId) => {
+                this.snackBarHelperService.open(
+                  translationId,
+                  'confirmBar'
+                )
+              }
+            })
+        },
+        error: (err) => {
+          console.log(err)
+        }
+      })
+      return
+    }
+
     this.basketService.find(Number(sessionStorage.getItem('bid'))).subscribe({
       next: (basket) => {
         const productsInBasket: any = basket.Products

--- a/frontend/src/app/purchase-basket/purchase-basket.component.spec.ts
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.spec.ts
@@ -17,6 +17,7 @@ import { throwError } from 'rxjs/internal/observable/throwError'
 import { MatButtonToggleModule } from '@angular/material/button-toggle'
 import { PurchaseBasketComponent } from '../purchase-basket/purchase-basket.component'
 import { UserService } from '../Services/user.service'
+import { ProductService } from '../Services/product.service'
 import { DeluxeGuard } from '../app.guard'
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar'
 import { EventEmitter } from '@angular/core'
@@ -27,19 +28,25 @@ describe('PurchaseBasketComponent', () => {
   let fixture: ComponentFixture<PurchaseBasketComponent>
   let basketService
   let userService
+  let productService
   let translateService: any
   let deluxeGuard
   let snackBar: any
 
   beforeEach(waitForAsync(() => {
-    basketService = jasmine.createSpyObj('BasketService', ['find', 'del', 'get', 'put', 'updateNumberOfCartItems'])
+    basketService = jasmine.createSpyObj('BasketService', ['find', 'del', 'get', 'put', 'updateNumberOfCartItems', 'getGuestBasketItems', 'removeGuestBasketItem', 'updateGuestBasketItemQuantity'])
     basketService.find.and.returnValue(of({ Products: [] }))
     basketService.del.and.returnValue(of({}))
     basketService.get.and.returnValue(of({}))
     basketService.put.and.returnValue(of({}))
     basketService.updateNumberOfCartItems.and.returnValue(of({}))
+    basketService.getGuestBasketItems.and.returnValue([])
+    basketService.removeGuestBasketItem.and.stub()
+    basketService.updateGuestBasketItemQuantity.and.stub()
     userService = jasmine.createSpyObj('UserService', ['whoAmI'])
     userService.whoAmI.and.returnValue(of({}))
+    productService = jasmine.createSpyObj('ProductService', ['get'])
+    productService.get.and.returnValue(of({ id: 1, name: 'Product', price: 1, deluxePrice: 1 }))
     translateService = jasmine.createSpyObj('TranslateService', ['get'])
     translateService.get.and.returnValue(of({}))
     translateService.onLangChange = new EventEmitter()
@@ -65,6 +72,7 @@ describe('PurchaseBasketComponent', () => {
         { provide: BasketService, useValue: basketService },
         { provide: MatSnackBar, useValue: snackBar },
         { provide: UserService, useValue: userService },
+        { provide: ProductService, useValue: productService },
         { provide: DeluxeGuard, useValue: deluxeGuard },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
@@ -74,6 +82,7 @@ describe('PurchaseBasketComponent', () => {
   }))
 
   beforeEach(() => {
+    localStorage.setItem('token', 'token')
     fixture = TestBed.createComponent(PurchaseBasketComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
@@ -89,12 +98,21 @@ describe('PurchaseBasketComponent', () => {
     expect(component.userEmail).toBe('(a@a)')
   })
 
-  it('should log an error if userService fails to fetch the user', fakeAsync(() => {
+  it('should default to anonymous user label if userService fails to fetch the user', fakeAsync(() => {
     userService.whoAmI.and.returnValue(throwError('Error'))
-    console.log = jasmine.createSpy('log')
     component.ngOnInit()
-    expect(console.log).toHaveBeenCalledWith('Error')
+    expect(component.userEmail).toBe('(anonymous)')
   }))
+
+  it('should skip userService call and use anonymous label for guests', () => {
+    userService.whoAmI.calls.reset()
+    localStorage.removeItem('token')
+
+    component.ngOnInit()
+
+    expect(userService.whoAmI).not.toHaveBeenCalled()
+    expect(component.userEmail).toBe('(anonymous)')
+  })
 
   it('should hold products returned by backend API', () => {
     basketService.find.and.returnValue(of({ Products: [{ name: 'Product1', price: 1, deluxePrice: 1, BasketItem: { quantity: 1 } }, { name: 'Product2', price: 2, deluxePrice: 2, BasketItem: { quantity: 2 } }] }))
@@ -136,6 +154,23 @@ describe('PurchaseBasketComponent', () => {
     basketService.find.and.returnValue(of({ Products: [] }))
     component.load()
     expect(component.dataSource).toEqual([])
+  })
+
+  it('should keep valid guest basket products when one guest product fetch fails', () => {
+    localStorage.removeItem('token')
+    basketService.getGuestBasketItems.and.returnValue([
+      { ProductId: 1, quantity: 2 },
+      { ProductId: 2, quantity: 3 }
+    ])
+    productService.get.withArgs(1).and.returnValue(of({ id: 1, name: 'P1', price: 2, deluxePrice: 2 }))
+    productService.get.withArgs(2).and.returnValue(throwError('Error'))
+
+    component.load()
+
+    expect(component.dataSource.length).toBe(1)
+    expect(component.dataSource[0].id).toBe(1)
+    expect(component.dataSource[0].BasketItem.quantity).toBe(2)
+    expect(component.itemTotal).toBe(4)
   })
 
   it('should log error while getting Products from backend API directly to browser console', fakeAsync(() => {

--- a/frontend/src/app/purchase-basket/purchase-basket.component.ts
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.ts
@@ -6,6 +6,7 @@
 import { Component, EventEmitter, Input, type OnInit, Output, inject } from '@angular/core'
 import { BasketService } from '../Services/basket.service'
 import { UserService } from '../Services/user.service'
+import { ProductService } from '../Services/product.service'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons/'
 import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons'
@@ -13,6 +14,8 @@ import { DeluxeGuard } from '../app.guard'
 import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatIconButton } from '@angular/material/button'
+import { forkJoin, of } from 'rxjs'
+import { catchError, map } from 'rxjs/operators'
 
 import { MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatFooterCellDef, MatFooterCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatFooterRowDef, MatFooterRow } from '@angular/material/table'
 
@@ -28,6 +31,7 @@ export class PurchaseBasketComponent implements OnInit {
   private readonly deluxeGuard = inject(DeluxeGuard)
   private readonly basketService = inject(BasketService)
   private readonly userService = inject(UserService)
+  private readonly productService = inject(ProductService)
   private readonly snackBarHelperService = inject(SnackBarHelperService)
 
   @Input() public allowEdit = false
@@ -46,16 +50,30 @@ export class PurchaseBasketComponent implements OnInit {
       this.tableColumns.push('remove')
     }
     this.load()
+
+    if (localStorage.getItem('token') == null) {
+      this.userEmail = '(anonymous)'
+      return
+    }
+
     this.userService.whoAmI(['email']).subscribe({
       next: (data) => {
         this.userEmail = data.email || 'anonymous'
         this.userEmail = '(' + this.userEmail + ')'
       },
-      error: (err) => { console.log(err) }
+      error: (err) => {
+        this.userEmail = '(anonymous)'
+        console.log(err)
+      }
     })
   }
 
   load () {
+    if (localStorage.getItem('token') == null) {
+      this.loadGuestBasket()
+      return
+    }
+
     this.basketService.find(parseInt(sessionStorage.getItem('bid'), 10)).subscribe({
       next: (basket) => {
         if (this.isDeluxe()) {
@@ -74,7 +92,54 @@ export class PurchaseBasketComponent implements OnInit {
     })
   }
 
+  private loadGuestBasket () {
+    const guestBasketItems = this.basketService.getGuestBasketItems()
+    if (guestBasketItems.length === 0) {
+      this.dataSource = []
+      this.itemTotal = 0
+      this.bonus = 0
+      this.sendToParent(this.dataSource.length)
+      return
+    }
+
+    const guestProductRequests = guestBasketItems.map(item => {
+      return this.productService.get(item.ProductId).pipe(
+        map(product => ({ product, quantity: item.quantity })),
+        catchError(() => of(null))
+      )
+    })
+
+    forkJoin(guestProductRequests).subscribe({
+      next: (productResults) => {
+        this.dataSource = productResults
+          .filter(result => result != null)
+          .map(result => {
+            const price = this.isDeluxe() ? result.product.deluxePrice : result.product.price
+            return {
+              ...result.product,
+              price,
+              BasketItem: {
+                id: result.product.id,
+                quantity: result.quantity
+              }
+            }
+          })
+
+        this.itemTotal = this.dataSource.reduce((itemTotal, product) => itemTotal + product.price * product.BasketItem.quantity, 0)
+        this.bonus = this.dataSource.reduce((bonusPoints, product) => bonusPoints + Math.round(product.price / 10) * product.BasketItem.quantity, 0)
+        this.sendToParent(this.dataSource.length)
+      },
+      error: (err) => { console.log(err) }
+    })
+  }
+
   delete (id) {
+    if (localStorage.getItem('token') == null) {
+      this.basketService.removeGuestBasketItem(id)
+      this.load()
+      return
+    }
+
     this.basketService.del(id).subscribe({
       next: () => {
         this.load()
@@ -93,6 +158,17 @@ export class PurchaseBasketComponent implements OnInit {
   }
 
   addToQuantity (id, value) {
+    if (localStorage.getItem('token') == null) {
+      const existingGuestItem = this.basketService.getGuestBasketItems().find(item => item.ProductId === id)
+      if (existingGuestItem == null) {
+        return
+      }
+
+      this.basketService.updateGuestBasketItemQuantity(id, existingGuestItem.quantity + value)
+      this.load()
+      return
+    }
+
     this.basketService.get(id).subscribe({
       next: (basketItem) => {
 

--- a/frontend/src/app/sidenav/sidenav.component.spec.ts
+++ b/frontend/src/app/sidenav/sidenav.component.spec.ts
@@ -155,6 +155,12 @@ describe('SidenavComponent', () => {
     expect(sessionStorage.removeItem).toHaveBeenCalledWith('itemTotal')
   })
 
+  it('should remove guest basket from session storage', () => {
+    spyOn(sessionStorage, 'removeItem')
+    component.logout()
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('guestBasket')
+  })
+
   it('should set the login status to be false via UserService', () => {
     component.logout()
     expect(userService.isLoggedIn.next).toHaveBeenCalledWith(false)

--- a/frontend/src/app/sidenav/sidenav.component.ts
+++ b/frontend/src/app/sidenav/sidenav.component.ts
@@ -96,6 +96,7 @@ export class SidenavComponent implements OnInit {
     this.cookieService.remove('token')
     sessionStorage.removeItem('bid')
     sessionStorage.removeItem('itemTotal')
+    sessionStorage.removeItem('guestBasket')
     this.userService.isLoggedIn.next(false)
     this.ngZone.run(async () => await this.router.navigate(['/']))
   }


### PR DESCRIPTION
### Description
This PR adds guest basket behavior for anonymous users and improves basket state handling across login/logout flows.
Users can now add products before authentication, see basket counts in the navbar, edit guest basket contents, and merge guest basket items into their account basket after login.

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `GitHub CoPilot`
    - LLMs and versions: `GPT-5.3-Codex`
    - Prompts: Prompts: I use multiple prompts for small, localized problems, such as: `create tests for changes`, `review changes and tell me where can i improve the code`.
    
    

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
