### PR TITLE
fix: remediate SAST findings - hardcoded JWT key, path traversal, XSS…

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -20,7 +20,10 @@ import * as utils from './utils'
 import * as z85 from 'z85'
 
 export const publicKey = fs ? fs.readFileSync('encryptionkeys/jwt.pub', 'utf8') : 'placeholder-public-key'
-const privateKey = '-----BEGIN RSA PRIVATE KEY-----\r\nMIICXAIBAAKBgQDNwqLEe9wgTXCbC7+RPdDbBbeqjdbs4kOPOIGzqLpXvJXlxxW8iMz0EaM4BKUqYsIa+ndv3NAn2RxCd5ubVdJJcX43zO6Ko0TFEZx/65gY3BE0O6syCEmUP4qbSd6exou/F+WTISzbQ5FBVPVmhnYhG/kpwt/cIxK5iUn5hm+4tQIDAQABAoGBAI+8xiPoOrA+KMnG/T4jJsG6TsHQcDHvJi7o1IKC/hnIXha0atTX5AUkRRce95qSfvKFweXdJXSQ0JMGJyfuXgU6dI0TcseFRfewXAa/ssxAC+iUVR6KUMh1PE2wXLitfeI6JLvVtrBYswm2I7CtY0q8n5AGimHWVXJPLfGV7m0BAkEA+fqFt2LXbLtyg6wZyxMA/cnmt5Nt3U2dAu77MzFJvibANUNHE4HPLZxjGNXN+a6m0K6TD4kDdh5HfUYLWWRBYQJBANK3carmulBwqzcDBjsJ0YrIONBpCAsXxk8idXb8jL9aNIg15Wumm2enqqObahDHB5jnGOLmbasizvSVqypfM9UCQCQl8xIqy+YgURXzXCN+kwUgHinrutZms87Jyi+D8Br8NY0+Nlf+zHvXAomD2W5CsEK7C+8SLBr3k/TsnRWHJuECQHFE9RA2OP8WoaLPuGCyFXaxzICThSRZYluVnWkZtxsBhW2W8z1b8PvWUE7kMy7TnkzeJS2LSnaNHoyxi7IaPQUCQCwWU4U+v4lD7uYBw00Ga/xt+7+UqFPlPVdz1yyr4q24Zxaw0LgmuEvgU5dycq8N7JxjTubX0MIRR+G9fmDBBl8=\r\n-----END RSA PRIVATE KEY-----'
+const privateKey = process.env.JWT_PRIVATE_KEY
+if (!privateKey) {
+  throw new Error('JWT_PRIVATE_KEY environment variable is not set')
+}
 
 interface ResponseWithUser {
   status?: string

--- a/routes/chatbot.ts
+++ b/routes/chatbot.ts
@@ -202,7 +202,7 @@ export const status = function status () {
       bot.addUser(`${user.id}`, username)
       res.status(200).json({
         status: bot.training.state,
-        body: bot.training.state ? bot.greet(`${user.id}`) : `${config.get<string>('application.chatBot.name')} isn't ready at the moment, please wait while I set things up`
+        body: bot.training.state ? security.sanitizeHtml(bot.greet(`${user.id}`)) : `${config.get<string>('application.chatBot.name')} isn't ready at the moment, please wait while I set things up`
       })
     } catch (err) {
       next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))

--- a/routes/fileServer.ts
+++ b/routes/fileServer.ts
@@ -30,7 +30,14 @@ export function servePublicFiles () {
       challengeUtils.solveIf(challenges.directoryListingChallenge, () => { return file.toLowerCase() === 'acquisitions.md' })
       verifySuccessfulPoisonNullByteExploit(file)
 
-      res.sendFile(path.resolve('ftp/', file))
+      const resolvedPath = path.resolve('ftp/', file)
+      const ftpDir = path.resolve('ftp/')
+      if (!resolvedPath.startsWith(ftpDir + path.sep)) {
+        res.status(403)
+        next(new Error('Access denied'))
+        return
+      }
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
       next(new Error('Only .md and .pdf files are allowed!'))


### PR DESCRIPTION
## SAST Findings Remediation (Semgrep)

Fixed 3 security vulnerabilities found by Semgrep (p/javascript ruleset):

### 1. Hardcoded JWT Private Key - `lib/insecurity.ts`
- **Rule:** `hardcoded-jwt-secret`
- **Fix:** Replaced hardcoded RSA private key with `process.env.JWT_PRIVATE_KEY`

### 2. Path Traversal - `routes/fileServer.ts`
- **Rule:** `express-res-sendfile`
- **Fix:** Added path canonicalization check to ensure file access is restricted to the `ftp/` directory

### 3. XSS via raw HTML - `routes/chatbot.ts`
- **Rule:** `raw-html-format`
- **Fix:** Wrapped `bot.greet()` output with `security.sanitizeHtml()` to sanitize user-controlled data before rendering