### PR TITLE
Add token-based admin password reset challenge

### DIFF
--- a/config/fbctf.yml
+++ b/config/fbctf.yml
@@ -146,6 +146,9 @@ ctf:
     resetPasswordBenderChallenge:
       name: Moldova
       code: MD
+    resetPasswordAdminChallenge:
+      name: Romania
+      code: RO
     resetPasswordMortyChallenge:
       name: Czech Republic
       code: CZ

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -982,6 +982,17 @@
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.html'
   key: resetPasswordJimChallenge
 -
+  name: 'Reset Admin''s Password'
+  category: 'Broken Authentication'
+  description: 'Reset the password of the administrator via the <a href="/#/forgot-password">Forgot Password</a> mechanism by leaking a token that should never have been exposed.'
+  difficulty: 3
+  hints:
+    - 'The forgot-password flow does not necessarily use the same recovery mechanism for every account type.'
+    - 'Try entering an administrator email address into the reset form and compare the UI with a normal customer account.'
+    - 'If a reset token gets generated server-side, see whether some internal support-related data exposes it.'
+  mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html'
+  key: resetPasswordAdminChallenge
+-
   name: 'Reset Morty''s Password'
   category: 'Broken Anti Automation'
   tags:

--- a/frontend/src/app/Models/securityQuestion.model.ts
+++ b/frontend/src/app/Models/securityQuestion.model.ts
@@ -4,6 +4,7 @@
  */
 
 export interface SecurityQuestion {
-  id: number
-  question: string
+  id?: number
+  mode?: 'question' | 'token'
+  question?: string
 }

--- a/frontend/src/app/Services/security-question.service.spec.ts
+++ b/frontend/src/app/Services/security-question.service.spec.ts
@@ -41,11 +41,12 @@ describe('SecurityQuestionService', () => {
       let res: any
       service.findBy('x@y.z').subscribe((data) => (res = data))
       const req = httpMock.expectOne('http://localhost:3000/rest/user/security-question?email=x@y.z')
-      req.flush({ question: 'apiResponse' })
+      req.flush({ question: 'apiResponse', mode: 'question' })
       tick()
 
       expect(req.request.method).toBe('GET')
-      expect(res).toBe('apiResponse')
+      expect(res.question).toBe('apiResponse')
+      expect(res.mode).toBe('question')
       httpMock.verify()
     })
   ))

--- a/frontend/src/app/Services/security-question.service.ts
+++ b/frontend/src/app/Services/security-question.service.ts
@@ -23,7 +23,7 @@ export class SecurityQuestionService {
 
   findBy (email: string) {
     return this.http.get(this.hostServer + '/' + 'rest/user/security-question?email=' + email).pipe(
-      map((response: any) => response.question),
+      map((response: any) => response),
       catchError((error) => { throw error })
     )
   }

--- a/frontend/src/app/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/forgot-password/forgot-password.component.html
@@ -41,17 +41,15 @@
         <div class="form-container" id="forgot-form">
 
           <mat-form-field appearance="outline" color="accent">
-            <mat-label translate>LABEL_SECURITY_QUESTION</mat-label>
+            <mat-label>{{ resetMode === 'token' ? 'Reset Token' : ('SECURITY_ANSWER' | translate) }}</mat-label>
             <input id="securityAnswer" [formControl]="securityQuestionControl" type="password" matInput
-              placeholder="{{ securityQuestion }}"
-              aria-label="Field for the answer to the security question">
-              <mat-icon matSuffix matTooltip="{{ 'MANDATORY_SECURITY_ANSWER' | translate  }}"
-                matTooltipPosition=right aria-label="Please answer your selected security question">help_outline
+              [placeholder]="resetMode === 'token' ? 'Enter your password reset token' : securityQuestion"
+              [attr.aria-label]="resetMode === 'token' ? 'Field for the password reset token' : 'Field for the answer to the security question'">
+              <mat-icon matSuffix [matTooltip]="resetMode === 'token' ? 'Please provide a password reset token.' : ('MANDATORY_SECURITY_ANSWER' | translate)"
+                matTooltipPosition=right [attr.aria-label]="resetMode === 'token' ? 'Please enter your password reset token' : 'Please answer your selected security question'">help_outline
               </mat-icon>
               @if (securityQuestionControl.invalid && securityQuestionControl.errors.required) {
-                <mat-error translate>
-                  MANDATORY_SECURITY_ANSWER
-                </mat-error>
+                <mat-error>{{ resetMode === 'token' ? 'Please provide a password reset token.' : ('MANDATORY_SECURITY_ANSWER' | translate) }}</mat-error>
               }
             </mat-form-field>
 

--- a/frontend/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/frontend/src/app/forgot-password/forgot-password.component.spec.ts
@@ -29,7 +29,7 @@ describe('ForgotPasswordComponent', () => {
 
   beforeEach(waitForAsync(() => {
     securityQuestionService = jasmine.createSpyObj('SecurityQuestionService', ['findBy'])
-    securityQuestionService.findBy.and.returnValue(of({}))
+    securityQuestionService.findBy.and.returnValue(of({ question: 'Your eldest siblings middle name?', mode: 'question' }))
     userService = jasmine.createSpyObj('UserService', ['resetPassword'])
     userService.resetPassword.and.returnValue(of({}))
 
@@ -157,11 +157,23 @@ describe('ForgotPasswordComponent', () => {
   }))
 
   it('should find the security question of a user with a known email address', fakeAsync(() => {
-    securityQuestionService.findBy.and.returnValue(of({ question: 'What is your favorite test tool?' }))
+    securityQuestionService.findBy.and.returnValue(of({ question: 'What is your favorite test tool?', mode: 'question' }))
     component.emailControl.setValue('known@user.test')
     tick(component.timeoutDuration)
     component.findSecurityQuestion()
     expect(component.securityQuestion).toBe('What is your favorite test tool?')
+    expect(component.resetMode).toBe('question')
+    flush()
+  }))
+
+  it('should switch to token reset mode for privileged accounts', fakeAsync(() => {
+    securityQuestionService.findBy.and.returnValue(of({ mode: 'token' }))
+    component.emailControl.setValue('admin@user.test')
+    tick(component.timeoutDuration)
+    component.findSecurityQuestion()
+    expect(component.resetMode).toBe('token')
+    expect(component.securityQuestion).toBeUndefined()
+    expect(component.securityQuestionControl.enabled).toBe(true)
     flush()
   }))
 

--- a/frontend/src/app/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/forgot-password/forgot-password.component.ts
@@ -41,6 +41,7 @@ export class ForgotPasswordComponent {
   public passwordControl: UntypedFormControl = new UntypedFormControl({ disabled: true, value: '' }, [Validators.required, Validators.minLength(5)])
   public repeatPasswordControl: UntypedFormControl = new UntypedFormControl({ disabled: true, value: '' }, [Validators.required, matchValidator(this.passwordControl)])
   public securityQuestion?: string
+  public resetMode: 'question' | 'token' = 'question'
   public error?: string
   public confirmation?: string
   public timeoutDuration = 1000
@@ -53,12 +54,21 @@ export class ForgotPasswordComponent {
       if (this.emailControl.value) {
         this.securityQuestionService.findBy(this.emailControl.value).subscribe({
           next: (securityQuestion: SecurityQuestion) => {
-            if (securityQuestion) {
+            if (securityQuestion?.mode === 'token') {
+              this.resetMode = 'token'
+              this.securityQuestion = undefined
+              this.securityQuestionControl.enable()
+              this.passwordControl.enable()
+              this.repeatPasswordControl.enable()
+            } else if (securityQuestion?.question) {
+              this.resetMode = 'question'
               this.securityQuestion = securityQuestion.question
               this.securityQuestionControl.enable()
               this.passwordControl.enable()
               this.repeatPasswordControl.enable()
             } else {
+              this.resetMode = 'question'
+              this.securityQuestion = undefined
               this.securityQuestionControl.disable()
               this.passwordControl.disable()
               this.repeatPasswordControl.disable()
@@ -68,6 +78,8 @@ export class ForgotPasswordComponent {
         }
         )
       } else {
+        this.resetMode = 'question'
+        this.securityQuestion = undefined
         this.securityQuestionControl.disable()
         this.passwordControl.disable()
         this.repeatPasswordControl.disable()
@@ -76,12 +88,19 @@ export class ForgotPasswordComponent {
   }
 
   resetPassword () {
-    this.userService.resetPassword({
+    const params: any = {
       email: this.emailControl.value,
-      answer: this.securityQuestionControl.value,
       new: this.passwordControl.value,
       repeat: this.repeatPasswordControl.value
-    }).subscribe({
+    }
+
+    if (this.resetMode === 'token') {
+      params.token = this.securityQuestionControl.value
+    } else {
+      params.answer = this.securityQuestionControl.value
+    }
+
+    this.userService.resetPassword(params).subscribe({
       next: () => {
         this.error = undefined
         this.translate.get('PASSWORD_SUCCESSFULLY_CHANGED').subscribe({

--- a/lib/resetPasswordTokens.ts
+++ b/lib/resetPasswordTokens.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import config from 'config'
+import { ComplaintModel } from '../models/complaint'
+import { UserModel } from '../models/user'
+import * as utils from './utils'
+
+const resetTokenComplaintPrefix = '[Support] Password reset token for '
+
+export const isTokenResetAccount = (email?: string) => {
+  return email?.toLowerCase() === `admin@${config.get<string>('application.domain')}`.toLowerCase()
+}
+
+export const issueResetPasswordToken = async (email: string) => {
+  const user = await UserModel.findOne({ where: { email } })
+  if (!user || !isTokenResetAccount(email)) {
+    return undefined
+  }
+
+  const token = utils.randomHexString(32)
+  const complaint = await findResetTokenComplaint(email)
+  const message = buildResetTokenComplaintMessage(email, token)
+
+  if (complaint) {
+    await complaint.update({ message })
+  } else {
+    await ComplaintModel.create({ UserId: user.id, message })
+  }
+
+  return token
+}
+
+export const verifyResetPasswordToken = async (email: string, token: string) => {
+  const complaint = await findResetTokenComplaint(email)
+  return extractResetPasswordToken(complaint?.message) === token
+}
+
+export const extractResetPasswordToken = (message?: string) => {
+  if (!message) {
+    return undefined
+  }
+
+  const match = message.match(/: ([a-f0-9]{32})$/i)
+  return match?.[1]
+}
+
+function buildResetTokenComplaintMessage (email: string, token: string) {
+  return `${resetTokenComplaintPrefix}${email}: ${token}`
+}
+
+async function findResetTokenComplaint (email: string) {
+  const user = await UserModel.findOne({ where: { email } })
+  if (!user) {
+    return null
+  }
+
+  const complaintPrefix = `${resetTokenComplaintPrefix}${email}: `
+  const complaints = await ComplaintModel.findAll({
+    where: { UserId: user.id },
+    order: [['updatedAt', 'DESC'], ['id', 'DESC']]
+  })
+
+  return complaints.find(({ message }) => message?.startsWith(complaintPrefix)) ?? null
+}

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -83,6 +83,7 @@ const CHALLENGE_KEYS = [
   'resetPasswordBenderChallenge',
   'resetPasswordBjoernChallenge',
   'resetPasswordJimChallenge',
+  'resetPasswordAdminChallenge',
   'resetPasswordMortyChallenge',
   'retrieveBlueprintChallenge',
   'ssrfChallenge',

--- a/routes/resetPassword.ts
+++ b/routes/resetPassword.ts
@@ -11,15 +11,17 @@ import { SecurityAnswerModel } from '../models/securityAnswer'
 import * as challengeUtils from '../lib/challengeUtils'
 import { challenges, users } from '../data/datacache'
 import * as security from '../lib/insecurity'
+import { isTokenResetAccount, verifyResetPasswordToken } from '../lib/resetPasswordTokens'
 import { UserModel } from '../models/user'
 
 export function resetPassword () {
   return async ({ body, connection }: Request, res: Response, next: NextFunction) => {
     const email = body.email
     const answer = body.answer
+    const token = body.token
     const newPassword = body.new
     const repeatPassword = body.repeat
-    if (!email || !answer) {
+    if (!email || (!answer && !token)) {
       next(new Error('Blocked illegal activity by ' + connection.remoteAddress))
       return
     }
@@ -32,6 +34,22 @@ export function resetPassword () {
       return
     }
     try {
+      const user = await UserModel.findOne({ where: { email } })
+      if (isTokenResetAccount(email)) {
+        if (user && token && await verifyResetPasswordToken(email, token)) {
+          const updatedUser = await user.update({ password: newPassword })
+          verifyResetTokenChallenges(updatedUser)
+          res.json({ user: updatedUser })
+        } else {
+          res.status(401).send(res.__('Wrong password reset token.'))
+        }
+        return
+      }
+      if (!answer) {
+        next(new Error('Blocked illegal activity by ' + connection.remoteAddress))
+        return
+      }
+
       const data = await SecurityAnswerModel.findOne({
         include: [{
           model: UserModel,
@@ -52,6 +70,12 @@ export function resetPassword () {
       next(error)
     }
   }
+}
+
+function verifyResetTokenChallenges (user: UserModel) {
+  challengeUtils.solveIf(challenges.resetPasswordAdminChallenge, () => {
+    return user.id === users.admin.id
+  })
 }
 
 function verifySecurityAnswerChallenges (user: UserModel, answer: string) {

--- a/routes/securityQuestion.ts
+++ b/routes/securityQuestion.ts
@@ -7,11 +7,18 @@ import { type Request, type Response, type NextFunction } from 'express'
 import { SecurityAnswerModel } from '../models/securityAnswer'
 import { UserModel } from '../models/user'
 import { SecurityQuestionModel } from '../models/securityQuestion'
+import { isTokenResetAccount, issueResetPasswordToken } from '../lib/resetPasswordTokens'
 
 export function securityQuestion () {
   return async ({ query }: Request, res: Response, next: NextFunction) => {
     const email = query.email
+    const emailAddress = email?.toString()
     try {
+      if (emailAddress && isTokenResetAccount(emailAddress)) {
+        await issueResetPasswordToken(emailAddress)
+        res.json({ mode: 'token' })
+        return
+      }
       const answer = await SecurityAnswerModel.findOne({
         include: [{
           model: UserModel,
@@ -20,7 +27,7 @@ export function securityQuestion () {
       })
       if (answer != null) {
         const question = await SecurityQuestionModel.findByPk(answer.SecurityQuestionId)
-        res.json({ question })
+        res.json({ mode: 'question', question })
       } else {
         res.json({})
       }

--- a/test/api/passwordApiSpec.ts
+++ b/test/api/passwordApiSpec.ts
@@ -5,11 +5,15 @@
 
 import * as frisby from 'frisby'
 import config from 'config'
+import * as security from '../../lib/insecurity'
+import { extractResetPasswordToken } from '../../lib/resetPasswordTokens'
 
 const API_URL = 'http://localhost:3000/api'
 const REST_URL = 'http://localhost:3000/rest'
+const unchangedAdminPassword = `admin${123}`
 
 const jsonHeader = { 'content-type': 'application/json' }
+const authHeader = { Authorization: `Bearer ${security.authorize()}`, 'content-type': 'application/json' }
 
 describe('/rest/user/change-password', () => {
   it('GET password change for newly created user with recognized token as Authorization header', () => {
@@ -104,6 +108,36 @@ describe('/rest/user/change-password', () => {
 })
 
 describe('/rest/user/reset-password', () => {
+  it('POST password reset for Admin with token leaked via complaints', () => {
+    const email = 'admin@' + config.get<string>('application.domain')
+    return frisby.get(`${REST_URL}/user/security-question?email=${email}`)
+      .expect('status', 200)
+      .expect('json', { mode: 'token' })
+      .then(() => frisby.get(`${API_URL}/Complaints`, { headers: authHeader })
+        .expect('status', 200)
+        .then(({ json }) => {
+          const complaint = [...json.data].reverse().find((entry: { message?: string }) => entry.message?.includes(email))
+          if (!complaint) {
+            throw new Error(`No leaked reset token complaint found for ${email}`)
+          }
+          const token = extractResetPasswordToken(complaint?.message)
+          if (!token?.match(/^[a-f0-9]{32}$/)) {
+            throw new Error('Leaked admin reset token is missing or malformed')
+          }
+
+          return frisby.post(REST_URL + '/user/reset-password', {
+            headers: jsonHeader,
+            body: {
+              email,
+              token,
+              new: unchangedAdminPassword,
+              repeat: unchangedAdminPassword
+            }
+          })
+            .expect('status', 200)
+        }))
+  })
+
   it('POST password reset for Jim with correct answer to his security question', () => {
     return frisby.post(REST_URL + '/user/reset-password', {
       headers: jsonHeader,
@@ -181,6 +215,23 @@ describe('/rest/user/reset-password', () => {
     })
       .expect('status', 401)
       .expect('bodyContains', 'Wrong answer to security question.')
+  })
+
+  it('POST password reset for Admin with wrong token', () => {
+    const email = 'admin@' + config.get<string>('application.domain')
+    return frisby.get(`${REST_URL}/user/security-question?email=${email}`)
+      .expect('status', 200)
+      .then(() => frisby.post(REST_URL + '/user/reset-password', {
+        headers: jsonHeader,
+        body: {
+          email,
+          token: 'definitely-wrong-token',
+          new: unchangedAdminPassword,
+          repeat: unchangedAdminPassword
+        }
+      })
+        .expect('status', 401)
+        .expect('bodyContains', 'Wrong password reset token.'))
   })
 
   it('POST password reset without any data is blocked', () => {

--- a/test/api/securityQuestionApiSpec.ts
+++ b/test/api/securityQuestionApiSpec.ts
@@ -61,8 +61,19 @@ describe('/rest/user/security-question', () => {
   it('GET security question for an existing user\'s email address', () => {
     return frisby.get(`${REST_URL}/user/security-question?email=jim@${config.get<string>('application.domain')}`)
       .expect('status', 200)
-      .expect('json', 'question', {
-        question: 'Your eldest siblings middle name?'
+      .expect('json', {
+        mode: 'question',
+        question: {
+          question: 'Your eldest siblings middle name?'
+        }
+      })
+  })
+
+  it('GET security question switches admin account lookup into token mode', () => {
+    return frisby.get(`${REST_URL}/user/security-question?email=admin@${config.get<string>('application.domain')}`)
+      .expect('status', 200)
+      .expect('json', {
+        mode: 'token'
       })
   })
 

--- a/test/cypress/e2e/forgotPassword.spec.ts
+++ b/test/cypress/e2e/forgotPassword.spec.ts
@@ -1,4 +1,6 @@
 describe('/#/forgot-password', () => {
+  const unchangedAdminPassword = `admin${123}`
+
   beforeEach(() => {
     cy.get('body').then(($body) => {
       if ($body.find('#logout').length) {
@@ -25,6 +27,44 @@ describe('/#/forgot-password', () => {
 
       cy.get('.confirmation').should('not.be.hidden')
       cy.expectChallengeSolved({ challenge: "Reset Jim's Password" })
+    })
+  })
+
+  describe('as Admin', () => {
+    it('should be able to reset password with a leaked reset token', () => {
+      cy.login({ email: 'jim', password: 'ncc-1701' })
+      cy.visit('/#/forgot-password')
+      cy.task<string>('GetFromConfig', 'application.domain').then(
+        (appDomain: string) => {
+          const email = `admin@${appDomain}`
+          cy.get('#email').type(email)
+          cy.wait('@securityQuestion')
+          cy.window().then((window) => {
+            cy.request({
+              method: 'GET',
+              url: '/api/Complaints/',
+              headers: {
+                Authorization: `Bearer ${window.localStorage.getItem('token')}`
+              }
+            }).then(({ body }) => {
+              const complaint = [...body.data].reverse().find((entry: { message?: string }) => entry.message?.includes(email))
+              if (!complaint) {
+                throw new Error(`No leaked reset token complaint found for ${email}`)
+              }
+              const token = complaint?.message?.match(/: ([a-f0-9]{32})$/i)?.[1]
+
+              expect(token).to.match(/^[a-f0-9]{32}$/)
+              cy.get('#securityAnswer').should('not.be.disabled').focus().type(token)
+            })
+          })
+        }
+      )
+      cy.get('#newPassword').focus().type(unchangedAdminPassword)
+      cy.get('#newPasswordRepeat').focus().type(unchangedAdminPassword)
+      cy.get('#resetButton').click()
+
+      cy.get('.confirmation').should('not.be.hidden')
+      cy.expectChallengeSolved({ challenge: "Reset Admin's Password" })
     })
   })
 


### PR DESCRIPTION
### Description

Adds a broken-authentication challenge where the administrator password can be reset via a leaked reset token.

The existing forgot-password flow is extended so the admin account uses a token-based reset path, while regular users continue using security questions. The generated token is unintentionally exposed through complaint data, creating the intended challenge chain.

Resolved or fixed issue: none

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `OpenAI Codex`
    - LLMs and versions: `GPT-5`
    - Prompts: `Analyze the existing password reset flow, implement an admin token-based reset challenge that fits Juice Shop conventions, add focused API/Cypress coverage, keep the diff minimal, and prepare the branch/PR for submission.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines