### PR TITLE
Add server coverage for AI Debugging challenge gating

### DIFF
--- a/routes/chat.ts
+++ b/routes/chat.ts
@@ -46,6 +46,13 @@ async function getUserNameFromToken (req: Request): Promise<string | undefined> 
   return user?.username ?? undefined
 }
 
+export function isAiDebuggingExploited (req: Request): boolean {
+  const token = utils.jwtFrom(req)
+  const decoded = token ? security.decode(token) as { data?: { role?: string } } : undefined
+  const role = decoded?.data?.role
+  return req.cookies.show_tool_calls === 'true' && role !== roles.admin
+}
+
 // vuln-code-snippet start chatbotGreedyInjectionChallenge
 function buildSystemPrompt (userName?: string) { // vuln-code-snippet neutral-line chatbotGreedyInjectionChallenge
   const userIdentifier = userName ? `\nThe customer you are currently chatting with is ${userName}.` : ''
@@ -149,12 +156,7 @@ export function chat () {
             res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: event.text } }] })}\n\n`)
             break
           case 'tool-call':
-            challengeUtils.solveIf(challenges.aiDebuggingChallenge, () => {
-              const token = utils.jwtFrom(req)
-              const decoded = token ? security.decode(token) as { data?: { role?: string } } : undefined
-              const role = decoded?.data?.role
-              return req.cookies.show_tool_calls === 'true' && role !== roles.admin
-            })
+            challengeUtils.solveIf(challenges.aiDebuggingChallenge, () => isAiDebuggingExploited(req))
             res.write(`data: ${JSON.stringify({
               choices: [{
                 delta: {

--- a/test/server/chatSpec.ts
+++ b/test/server/chatSpec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { expect } from 'chai'
+import { type Request } from 'express'
+import * as security from '../../lib/insecurity'
+import { roles } from '../../lib/insecurity'
+import { isAiDebuggingExploited } from '../../routes/chat'
+
+describe('chat', () => {
+  describe('isAiDebuggingExploited', () => {
+    it('returns true for non-admin users when show_tool_calls cookie is set', () => {
+      const req = {
+        cookies: { show_tool_calls: 'true' },
+        headers: {
+          authorization: `Bearer ${security.authorize({ data: { role: roles.customer } })}`
+        }
+      } as unknown as Request
+
+      expect(isAiDebuggingExploited(req)).to.equal(true)
+    })
+
+    it('returns false for admin users when show_tool_calls cookie is set', () => {
+      const req = {
+        cookies: { show_tool_calls: 'true' },
+        headers: {
+          authorization: `Bearer ${security.authorize({ data: { role: roles.admin } })}`
+        }
+      } as unknown as Request
+
+      expect(isAiDebuggingExploited(req)).to.equal(false)
+    })
+
+    it('returns false when show_tool_calls cookie is not set', () => {
+      const req = {
+        cookies: {},
+        headers: {
+          authorization: `Bearer ${security.authorize({ data: { role: roles.customer } })}`
+        }
+      } as unknown as Request
+
+      expect(isAiDebuggingExploited(req)).to.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
### Description

Adds focused server-side coverage for the AI Debugging challenge exploit condition.

This extracts the non-admin `show_tool_calls` check into a small helper in the chat route and adds server tests to verify that the condition is only considered exploitable for non-admin users with the cookie enabled.

Resolved or fixed issue: none

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
 
### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines