### PR TITLE
dbSchemaChallenge injection fixed

### DIFF
--- a/data/static/codefixes/dbSchemaChallenge_1.ts
+++ b/data/static/codefixes/dbSchemaChallenge_1.ts
@@ -1,17 +1,38 @@
-export function searchProducts () {
-  return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
-    criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
-    models.sequelize.query("SELECT * FROM Products WHERE ((name LIKE '%"+criteria+"%' OR description LIKE '%"+criteria+"%') AND deletedAt IS NULL) ORDER BY name")
-      .then(([products]: any) => {
-        const dataString = JSON.stringify(products)
-        for (let i = 0; i < products.length; i++) {
-          products[i].name = req.__(products[i].name)
-          products[i].description = req.__(products[i].description)
+import { Request, Response, NextFunction } from 'express'
+import { QueryTypes } from 'sequelize'
+
+export function searchProducts() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      let criteria = req.query.q === 'undefined' ? '' : String(req.query.q ?? '')
+      criteria = criteria.length <= 200 ? criteria : criteria.substring(0, 200)
+
+      const likeCriteria = `%${criteria}%`
+
+      const products = await models.sequelize.query(
+        `
+          SELECT *
+          FROM Products
+          WHERE (
+            (name LIKE :criteria OR description LIKE :criteria)
+            AND deletedAt IS NULL
+          )
+          ORDER BY name
+        `,
+        {
+          replacements: { criteria: likeCriteria },
+          type: QueryTypes.SELECT
         }
-        res.json(utils.queryResultToJson(products))
-      }).catch((error: ErrorWithParent) => {
-        next(error.parent)
-      })
+      )
+
+      for (let i = 0; i < products.length; i++) {
+        products[i].name = req.__(products[i].name)
+        products[i].description = req.__(products[i].description)
+      }
+
+      res.json(utils.queryResultToJson(products))
+    } catch (error: any) {
+      next(error.parent ?? error)
+    }
   }
 }


### PR DESCRIPTION
### Description

This PR fixes a potential SQL injection vulnerability in `searchProducts`.

The previous implementation concatenated the user-controlled `q` parameter directly into a raw SQL query:

- unsafe SQL string construction via concatenation
- attacker-controlled input reaching the query without parameterization

This PR replaces that logic with a parameterized query using Sequelize replacements. The search semantics remain the same (`LIKE` on `name` and `description`), but the query is now executed safely.

Also cleaned up a small unrelated issue by removing an unused local variable.

Resolved or fixed issue: none

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `ChatGPT`
    - LLMs and versions: `GPT-5.4 Thinking`
    - Prompts: `Analyze Express/Sequelize code for SQL injection, refactor raw query to use safe parameter binding, and help prepare a pull request description consistent with the repository template.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines