### PR TITLE
Add predictable admin reset token challenge

### DIFF
--- a/config/fbctf.yml
+++ b/config/fbctf.yml
@@ -350,3 +350,6 @@ ctf:
     aiDebuggingChallenge:
       name: Iceland
       code: IS
+    resetPasswordAdminChallenge:
+      name: Romania
+      code: RO

--- a/data/datacreator.ts
+++ b/data/datacreator.ts
@@ -34,6 +34,7 @@ import { ordersCollection, reviewsCollection } from './mongodb'
 import { AllHtmlEntities as Entities } from 'html-entities'
 import * as datacache from './datacache'
 import * as security from '../lib/insecurity'
+import { seedResetPasswordTokens } from '../lib/resetPasswordTokens'
 import { variableDependencies, domainDependencies, preconditionResults } from '../lib/startup/validatePreconditions'
 // @ts-expect-error FIXME due to non-existing type definitions for replace
 import replace from 'replace'
@@ -46,6 +47,7 @@ export default async () => {
     createUsers,
     createChallenges,
     createRandomFakeUsers,
+    createResetPasswordTokens,
     createProducts,
     createBaskets,
     createBasketItems,
@@ -205,6 +207,10 @@ async function createWallet () {
       })
     })
   )
+}
+
+async function createResetPasswordTokens () {
+  await seedResetPasswordTokens()
 }
 
 async function createDeliveryMethods () {

--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -997,6 +997,18 @@
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html'
   key: resetPasswordMortyChallenge
 -
+  name: 'Reset Admin''s Password'
+  category: 'Broken Authentication'
+  description: 'Reset the administrator''s password via the <a href="/#/forgot-password">Forgot Password</a> mechanism by reverse-engineering the predictable token format.'
+  difficulty: 4
+  hints:
+    - 'The administrator no longer answers a security question during password reset. A token is supposedly sent by email and only valid today.'
+    - 'Use SQL Injection to inspect the password reset token storage and look for recurring patterns in tokens belonging to the same user or date.'
+    - 'The beginning of a token stays stable for the same user while the end stays stable for the same date.'
+    - 'Juice Shop already uses a quirky encoding library for coupon-related values. That might be relevant here as well.'
+  mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html'
+  key: resetPasswordAdminChallenge
+-
   name: 'Retrieve Blueprint'
   category: 'Sensitive Data Exposure'
   description: 'Deprive the shop of earnings by downloading the blueprint for one of its products.'

--- a/frontend/src/app/Models/securityQuestion.model.ts
+++ b/frontend/src/app/Models/securityQuestion.model.ts
@@ -4,6 +4,7 @@
  */
 
 export interface SecurityQuestion {
-  id: number
-  question: string
+  id?: number
+  question?: string
+  mode?: 'question' | 'token'
 }

--- a/frontend/src/app/Services/security-question.service.ts
+++ b/frontend/src/app/Services/security-question.service.ts
@@ -23,7 +23,7 @@ export class SecurityQuestionService {
 
   findBy (email: string) {
     return this.http.get(this.hostServer + '/' + 'rest/user/security-question?email=' + email).pipe(
-      map((response: any) => response.question),
+      map((response: any) => response),
       catchError((error) => { throw error })
     )
   }

--- a/frontend/src/app/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/forgot-password/forgot-password.component.html
@@ -41,17 +41,15 @@
         <div class="form-container" id="forgot-form">
 
           <mat-form-field appearance="outline" color="accent">
-            <mat-label translate>LABEL_SECURITY_QUESTION</mat-label>
-            <input id="securityAnswer" [formControl]="securityQuestionControl" type="password" matInput
-              placeholder="{{ securityQuestion }}"
-              aria-label="Field for the answer to the security question">
-              <mat-icon matSuffix matTooltip="{{ 'MANDATORY_SECURITY_ANSWER' | translate  }}"
-                matTooltipPosition=right aria-label="Please answer your selected security question">help_outline
-              </mat-icon>
+            <mat-label>{{ resetMode === 'token' ? 'Reset token' : ('LABEL_SECURITY_QUESTION' | translate) }}</mat-label>
+            <input [id]="resetMode === 'token' ? 'resetToken' : 'securityAnswer'" [formControl]="securityQuestionControl" type="password" matInput
+              [placeholder]="resetMode === 'token' ? 'Enter the reset token' : securityQuestion"
+              [attr.aria-label]="resetMode === 'token' ? 'Field for the reset token' : 'Field for the answer to the security question'">
+              <mat-icon matSuffix [matTooltip]="resetMode === 'token' ? 'Please enter the reset token' : ('MANDATORY_SECURITY_ANSWER' | translate)"
+                matTooltipPosition=right [attr.aria-label]="resetMode === 'token' ? 'Please enter the reset token' : 'Please answer your selected security question'">help_outline
+            </mat-icon>
               @if (securityQuestionControl.invalid && securityQuestionControl.errors.required) {
-                <mat-error translate>
-                  MANDATORY_SECURITY_ANSWER
-                </mat-error>
+                <mat-error>{{ resetMode === 'token' ? 'Reset token is required' : ('MANDATORY_SECURITY_ANSWER' | translate) }}</mat-error>
               }
             </mat-form-field>
 

--- a/frontend/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/frontend/src/app/forgot-password/forgot-password.component.spec.ts
@@ -157,11 +157,21 @@ describe('ForgotPasswordComponent', () => {
   }))
 
   it('should find the security question of a user with a known email address', fakeAsync(() => {
-    securityQuestionService.findBy.and.returnValue(of({ question: 'What is your favorite test tool?' }))
+    securityQuestionService.findBy.and.returnValue(of({ question: 'What is your favorite test tool?', mode: 'question' }))
     component.emailControl.setValue('known@user.test')
     tick(component.timeoutDuration)
     component.findSecurityQuestion()
     expect(component.securityQuestion).toBe('What is your favorite test tool?')
+    flush()
+  }))
+
+  it('should switch to token mode for admin reset flow', fakeAsync(() => {
+    securityQuestionService.findBy.and.returnValue(of({ mode: 'token' }))
+    component.emailControl.setValue('admin@juice-sh.op')
+    tick(component.timeoutDuration)
+    component.findSecurityQuestion()
+    expect(component.resetMode).toBe('token')
+    expect(component.securityQuestionControl.enabled).toBe(true)
     flush()
   }))
 

--- a/frontend/src/app/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/forgot-password/forgot-password.component.ts
@@ -41,6 +41,7 @@ export class ForgotPasswordComponent {
   public passwordControl: UntypedFormControl = new UntypedFormControl({ disabled: true, value: '' }, [Validators.required, Validators.minLength(5)])
   public repeatPasswordControl: UntypedFormControl = new UntypedFormControl({ disabled: true, value: '' }, [Validators.required, matchValidator(this.passwordControl)])
   public securityQuestion?: string
+  public resetMode: 'question' | 'token' = 'question'
   public error?: string
   public confirmation?: string
   public timeoutDuration = 1000
@@ -53,12 +54,20 @@ export class ForgotPasswordComponent {
       if (this.emailControl.value) {
         this.securityQuestionService.findBy(this.emailControl.value).subscribe({
           next: (securityQuestion: SecurityQuestion) => {
-            if (securityQuestion) {
+            if (securityQuestion?.mode === 'token') {
+              this.resetMode = 'token'
+              this.securityQuestion = 'A reset token was sent via email and is only valid today.'
+              this.securityQuestionControl.enable()
+              this.passwordControl.enable()
+              this.repeatPasswordControl.enable()
+            } else if (securityQuestion?.question) {
+              this.resetMode = 'question'
               this.securityQuestion = securityQuestion.question
               this.securityQuestionControl.enable()
               this.passwordControl.enable()
               this.repeatPasswordControl.enable()
             } else {
+              this.resetMode = 'question'
               this.securityQuestionControl.disable()
               this.passwordControl.disable()
               this.repeatPasswordControl.disable()
@@ -68,6 +77,7 @@ export class ForgotPasswordComponent {
         }
         )
       } else {
+        this.resetMode = 'question'
         this.securityQuestionControl.disable()
         this.passwordControl.disable()
         this.repeatPasswordControl.disable()
@@ -78,7 +88,8 @@ export class ForgotPasswordComponent {
   resetPassword () {
     this.userService.resetPassword({
       email: this.emailControl.value,
-      answer: this.securityQuestionControl.value,
+      answer: this.resetMode === 'question' ? this.securityQuestionControl.value : undefined,
+      token: this.resetMode === 'token' ? this.securityQuestionControl.value : undefined,
       new: this.passwordControl.value,
       repeat: this.repeatPasswordControl.value
     }).subscribe({
@@ -103,6 +114,8 @@ export class ForgotPasswordComponent {
   }
 
   resetForm () {
+    this.resetMode = 'question'
+    this.securityQuestion = undefined
     this.emailControl.setValue('')
     this.emailControl.markAsPristine()
     this.emailControl.markAsUntouched()
@@ -118,6 +131,7 @@ export class ForgotPasswordComponent {
   }
 
   resetErrorForm () {
+    this.resetMode = 'question'
     this.emailControl.markAsPristine()
     this.emailControl.markAsUntouched()
     this.securityQuestionControl.setValue('')

--- a/lib/resetPasswordTokenUtils.ts
+++ b/lib/resetPasswordTokenUtils.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-expect-error FIXME no typescript definitions for z85 :(
+import * as z85 from 'z85'
+
+function padForZ85 (value: string): string {
+  const remainder = value.length % 4
+  return remainder === 0 ? value : value.padEnd(value.length + (4 - remainder), ' ')
+}
+
+export function formatResetPasswordTokenDate (date = new Date()): string {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function createResetPasswordToken (email: string, date = new Date()): string {
+  const encodedEmail = z85.encode(padForZ85(email))
+  const encodedDate = z85.encode(padForZ85(formatResetPasswordTokenDate(date)))
+  return `${encodedEmail}${encodedDate}`
+}
+
+export function getResetPasswordTokenExpiry (date = new Date()): Date {
+  const expiry = new Date(date)
+  expiry.setHours(23, 59, 59, 999)
+  return expiry
+}

--- a/lib/resetPasswordTokens.ts
+++ b/lib/resetPasswordTokens.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Op } from 'sequelize'
+import { users } from '../data/datacache'
+import { ResetPasswordTokenModel } from '../models/resetPasswordToken'
+import { type UserModel } from '../models/user'
+import { createResetPasswordToken, getResetPasswordTokenExpiry } from './resetPasswordTokenUtils'
+
+export async function issueResetPasswordToken (user: UserModel, date = new Date()): Promise<ResetPasswordTokenModel> {
+  const token = createResetPasswordToken(user.email, date)
+  const expiresAt = getResetPasswordTokenExpiry(date)
+  const [entry] = await ResetPasswordTokenModel.findOrCreate({
+    where: { token },
+    defaults: {
+      UserId: user.id,
+      token,
+      expiresAt
+    }
+  })
+  if (entry.expiresAt.getTime() !== expiresAt.getTime()) {
+    await entry.update({ expiresAt })
+  }
+  return entry
+}
+
+export async function isValidResetPasswordToken (user: UserModel, token: string): Promise<boolean> {
+  if (token !== createResetPasswordToken(user.email)) {
+    return false
+  }
+  const count = await ResetPasswordTokenModel.count({
+    where: {
+      UserId: user.id,
+      token,
+      expiresAt: {
+        [Op.gte]: new Date()
+      }
+    }
+  })
+  return count > 0
+}
+
+export async function seedResetPasswordTokens (): Promise<void> {
+  const seedPlan = [
+    { user: users.admin, dayOffsets: [-3, -2, -1] },
+    { user: users.jim, dayOffsets: [-3, -2, -1, 0] },
+    { user: users.bender, dayOffsets: [-3, -2, -1, 0] },
+    { user: users.bjoern, dayOffsets: [-3, -2, -1, 0] }
+  ]
+
+  for (const { user, dayOffsets } of seedPlan) {
+    if (!user) {
+      continue
+    }
+    for (const dayOffset of dayOffsets) {
+      const date = new Date()
+      date.setDate(date.getDate() + dayOffset)
+      await issueResetPasswordToken(user, date)
+    }
+  }
+}

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -83,6 +83,7 @@ const CHALLENGE_KEYS = [
   'resetPasswordBenderChallenge',
   'resetPasswordBjoernChallenge',
   'resetPasswordJimChallenge',
+  'resetPasswordAdminChallenge',
   'resetPasswordMortyChallenge',
   'retrieveBlueprintChallenge',
   'ssrfChallenge',

--- a/models/index.ts
+++ b/models/index.ts
@@ -20,6 +20,7 @@ import { PrivacyRequestModelInit } from './privacyRequests'
 import { ProductModelInit } from './product'
 import { QuantityModelInit } from './quantity'
 import { RecycleModelInit } from './recycle'
+import { ResetPasswordTokenModelInit } from './resetPasswordToken'
 import { relationsInit } from './relations'
 import { SecurityAnswerModelInit } from './securityAnswer'
 import { SecurityQuestionModelInit } from './securityQuestion'
@@ -56,6 +57,7 @@ PrivacyRequestModelInit(sequelize)
 ProductModelInit(sequelize)
 QuantityModelInit(sequelize)
 RecycleModelInit(sequelize)
+ResetPasswordTokenModelInit(sequelize)
 SecurityAnswerModelInit(sequelize)
 SecurityQuestionModelInit(sequelize)
 UserModelInit(sequelize)

--- a/models/relations.ts
+++ b/models/relations.ts
@@ -13,6 +13,7 @@ import { PrivacyRequestModel } from './privacyRequests'
 import { ProductModel } from './product'
 import { QuantityModel } from './quantity'
 import { RecycleModel } from './recycle'
+import { ResetPasswordTokenModel } from './resetPasswordToken'
 import { SecurityAnswerModel } from './securityAnswer'
 import { SecurityQuestionModel } from './securityQuestion'
 import { UserModel } from './user'
@@ -123,6 +124,13 @@ const relationsInit = (_sequelize: Sequelize) => {
   })
 
   SecurityAnswerModel.belongsTo(UserModel, {
+    foreignKey: {
+      name: 'UserId'
+    }
+  })
+  ResetPasswordTokenModel.belongsTo(UserModel, {
+    constraints: true,
+    foreignKeyConstraint: true,
     foreignKey: {
       name: 'UserId'
     }

--- a/models/resetPasswordToken.ts
+++ b/models/resetPasswordToken.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+/* jslint node: true */
+import {
+  Model,
+  type InferAttributes,
+  type InferCreationAttributes,
+  DataTypes,
+  type CreationOptional,
+  type Sequelize
+} from 'sequelize'
+
+class ResetPasswordToken extends Model<
+InferAttributes<ResetPasswordToken>,
+InferCreationAttributes<ResetPasswordToken>
+> {
+  declare UserId: number
+  declare id: CreationOptional<number>
+  declare token: string
+  declare expiresAt: Date
+}
+
+const ResetPasswordTokenModelInit = (sequelize: Sequelize) => {
+  ResetPasswordToken.init(
+    {
+      UserId: {
+        type: DataTypes.INTEGER
+      },
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      token: {
+        type: DataTypes.STRING,
+        unique: true
+      },
+      expiresAt: DataTypes.DATE
+    },
+    {
+      tableName: 'ResetPasswordTokens',
+      sequelize
+    }
+  )
+}
+
+export { ResetPasswordToken as ResetPasswordTokenModel, ResetPasswordTokenModelInit }

--- a/routes/resetPassword.ts
+++ b/routes/resetPassword.ts
@@ -12,14 +12,17 @@ import * as challengeUtils from '../lib/challengeUtils'
 import { challenges, users } from '../data/datacache'
 import * as security from '../lib/insecurity'
 import { UserModel } from '../models/user'
+import { isValidResetPasswordToken } from '../lib/resetPasswordTokens'
+import { createResetPasswordToken } from '../lib/resetPasswordTokenUtils'
 
 export function resetPassword () {
   return async ({ body, connection }: Request, res: Response, next: NextFunction) => {
     const email = body.email
     const answer = body.answer
+    const token = body.token
     const newPassword = body.new
     const repeatPassword = body.repeat
-    if (!email || !answer) {
+    if (!email || (!answer && !token)) {
       next(new Error('Blocked illegal activity by ' + connection.remoteAddress))
       return
     }
@@ -32,6 +35,17 @@ export function resetPassword () {
       return
     }
     try {
+      if (email === users.admin.email) {
+        const adminUser = await UserModel.findByPk(users.admin.id)
+        if (adminUser && token && await isValidResetPasswordToken(adminUser, token)) {
+          const updatedUser = await adminUser.update({ password: newPassword })
+          verifyResetTokenChallenges(updatedUser, token)
+          res.json({ user: updatedUser })
+        } else {
+          res.status(401).send(res.__('Wrong answer to security question.'))
+        }
+        return
+      }
       const data = await SecurityAnswerModel.findOne({
         include: [{
           model: UserModel,
@@ -52,6 +66,10 @@ export function resetPassword () {
       next(error)
     }
   }
+}
+
+function verifyResetTokenChallenges (user: UserModel, token: string) {
+  challengeUtils.solveIf(challenges.resetPasswordAdminChallenge, () => { return user.id === users.admin.id && token === createResetPasswordToken(user.email) })
 }
 
 function verifySecurityAnswerChallenges (user: UserModel, answer: string) {

--- a/routes/securityQuestion.ts
+++ b/routes/securityQuestion.ts
@@ -7,11 +7,18 @@ import { type Request, type Response, type NextFunction } from 'express'
 import { SecurityAnswerModel } from '../models/securityAnswer'
 import { UserModel } from '../models/user'
 import { SecurityQuestionModel } from '../models/securityQuestion'
+import { users } from '../data/datacache'
+import { issueResetPasswordToken } from '../lib/resetPasswordTokens'
 
 export function securityQuestion () {
   return async ({ query }: Request, res: Response, next: NextFunction) => {
     const email = query.email
     try {
+      if (email?.toString() === users.admin.email) {
+        await issueResetPasswordToken(users.admin)
+        res.json({ mode: 'token' })
+        return
+      }
       const answer = await SecurityAnswerModel.findOne({
         include: [{
           model: UserModel,
@@ -20,7 +27,7 @@ export function securityQuestion () {
       })
       if (answer != null) {
         const question = await SecurityQuestionModel.findByPk(answer.SecurityQuestionId)
-        res.json({ question })
+        res.json({ question, mode: 'question' })
       } else {
         res.json({})
       }

--- a/test/api/passwordApiSpec.ts
+++ b/test/api/passwordApiSpec.ts
@@ -5,6 +5,7 @@
 
 import * as frisby from 'frisby'
 import config from 'config'
+import { createResetPasswordToken } from '../../lib/resetPasswordTokenUtils'
 
 const API_URL = 'http://localhost:3000/api'
 const REST_URL = 'http://localhost:3000/rest'
@@ -167,6 +168,61 @@ describe('/rest/user/reset-password', () => {
       }
     })
       .expect('status', 200)
+  })
+
+  it('POST password reset for Admin with the predictable reset token', () => {
+    const appDomain = config.get<string>('application.domain')
+    const adminEmail = `admin@${appDomain}`
+    const newAdminPassword = ['Adm1n', 'Res3t!'].join('')
+    const originalAdminPassword = ['admin', '123'].join('')
+    const adminToken = createResetPasswordToken(adminEmail)
+
+    return frisby.get(`${REST_URL}/user/security-question?email=${adminEmail}`)
+      .expect('status', 200)
+      .then(() => {
+        return frisby.post(REST_URL + '/user/reset-password', {
+          headers: jsonHeader,
+          body: {
+            email: adminEmail,
+            token: adminToken,
+            new: newAdminPassword,
+            repeat: newAdminPassword
+          }
+        })
+          .expect('status', 200)
+      })
+      .then(() => {
+        return frisby.post(REST_URL + '/user/login', {
+          headers: jsonHeader,
+          body: {
+            email: adminEmail,
+            password: newAdminPassword
+          }
+        })
+          .expect('status', 200)
+      })
+      .then(() => {
+        return frisby.post(REST_URL + '/user/reset-password', {
+          headers: jsonHeader,
+          body: {
+            email: adminEmail,
+            token: adminToken,
+            new: originalAdminPassword,
+            repeat: originalAdminPassword
+          }
+        })
+          .expect('status', 200)
+      })
+      .then(() => {
+        return frisby.post(REST_URL + '/user/login', {
+          headers: jsonHeader,
+          body: {
+            email: adminEmail,
+            password: originalAdminPassword
+          }
+        })
+          .expect('status', 200)
+      })
   })
 
   it('POST password reset with wrong answer to security question', () => {

--- a/test/api/searchApiSpec.ts
+++ b/test/api/searchApiSpec.ts
@@ -8,6 +8,7 @@ import { expect } from '@jest/globals'
 import * as security from '../../lib/insecurity'
 import type { Product as ProductConfig } from '../../lib/config.types'
 import config from 'config'
+import { createResetPasswordToken } from '../../lib/resetPasswordTokenUtils'
 
 const christmasProduct = config.get<ProductConfig[]>('products').filter(({ useForChristmasSpecialChallenge }) => useForChristmasSpecialChallenge)[0]
 const pastebinLeakProduct = config.get<ProductConfig[]>('products').filter(({ keywordsForPastebinDataLeakChallenge }) => keywordsForPastebinDataLeakChallenge)[0]
@@ -127,6 +128,22 @@ describe('/rest/products/search', () => {
       })
       .expect('json', 'data.?', {
         id: 'CREATE TABLE sqlite_sequence(name,seq)'
+      })
+  })
+
+  it('GET product search can inspect reset password tokens via UNION SELECT', () => {
+    const appDomain = config.get<string>('application.domain')
+
+    return frisby.get(`${REST_URL}/products/search?q=')) union select UserId,'2','3',token,expiresAt,'6','7','8','9' from ResetPasswordTokens--`)
+      .expect('status', 200)
+      .expect('header', 'content-type', /application\/json/)
+      .expect('json', 'data.?', {
+        id: 2,
+        price: createResetPasswordToken(`jim@${appDomain}`)
+      })
+      .expect('json', 'data.?', {
+        id: 3,
+        price: createResetPasswordToken(`bender@${appDomain}`)
       })
   })
 

--- a/test/api/securityQuestionApiSpec.ts
+++ b/test/api/securityQuestionApiSpec.ts
@@ -61,8 +61,19 @@ describe('/rest/user/security-question', () => {
   it('GET security question for an existing user\'s email address', () => {
     return frisby.get(`${REST_URL}/user/security-question?email=jim@${config.get<string>('application.domain')}`)
       .expect('status', 200)
+      .expect('json', {
+        mode: 'question'
+      })
       .expect('json', 'question', {
         question: 'Your eldest siblings middle name?'
+      })
+  })
+
+  it('GET admin reset flow switches to token mode', () => {
+    return frisby.get(`${REST_URL}/user/security-question?email=admin@${config.get<string>('application.domain')}`)
+      .expect('status', 200)
+      .expect('json', {
+        mode: 'token'
       })
   })
 

--- a/test/cypress/e2e/forgotPassword.spec.ts
+++ b/test/cypress/e2e/forgotPassword.spec.ts
@@ -1,3 +1,5 @@
+import { createResetPasswordToken } from '../../../lib/resetPasswordTokenUtils'
+
 describe('/#/forgot-password', () => {
   beforeEach(() => {
     cy.get('body').then(($body) => {
@@ -118,6 +120,27 @@ describe('/#/forgot-password', () => {
 
       cy.get('.confirmation').should('not.be.hidden')
       cy.expectChallengeSolved({ challenge: "Reset Uvogin's Password" })
+    })
+  })
+
+  describe('as Admin', () => {
+    it('should switch to token mode and reset the password with a predictable token', () => {
+      cy.task<string>('GetFromConfig', 'application.domain').then(
+        (appDomain: string) => {
+          const adminEmail = `admin@${appDomain}`
+          const newPassword = ['Adm1n', 'Res3t!'].join('')
+
+          cy.get('#email').type(adminEmail)
+          cy.wait('@securityQuestion')
+          cy.get('#resetToken').should('not.be.disabled').focus().type(createResetPasswordToken(adminEmail))
+          cy.get('#newPassword').focus().type(newPassword)
+          cy.get('#newPasswordRepeat').focus().type(newPassword)
+          cy.get('#resetButton').click()
+
+          cy.get('.confirmation').should('not.be.hidden')
+          cy.expectChallengeSolved({ challenge: "Reset Admin's Password" })
+        }
+      )
     })
   })
 })

--- a/test/server/resetPasswordTokensSpec.ts
+++ b/test/server/resetPasswordTokensSpec.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { expect } from 'chai'
+import { createResetPasswordToken } from '../../lib/resetPasswordTokenUtils'
+
+describe('resetPasswordTokens', () => {
+  it('keeps the beginning of the token stable for the same user across different dates', () => {
+    const first = createResetPasswordToken('admin@juice-sh.op', new Date('2026-03-18T12:00:00.000Z'))
+    const second = createResetPasswordToken('admin@juice-sh.op', new Date('2026-03-19T12:00:00.000Z'))
+
+    expect(first.substring(0, 25)).to.equal(second.substring(0, 25))
+  })
+
+  it('keeps the end of the token stable for different users on the same date', () => {
+    const first = createResetPasswordToken('jim@juice-sh.op', new Date('2026-03-19T12:00:00.000Z'))
+    const second = createResetPasswordToken('bender@juice-sh.op', new Date('2026-03-19T12:00:00.000Z'))
+
+    expect(first.slice(-15)).to.equal(second.slice(-15))
+  })
+})


### PR DESCRIPTION
## Description

Adds a broken-authentication challenge where the administrator password can be reset via a predictable daily token.

The existing forgot-password flow is extended so the admin account switches to a token-based reset mode while regular users keep the normal security-question flow. Reset tokens are stored server-side, reveal stable user/date patterns, and can be inspected through SQL injection to reconstruct the administrator token for the current day.

Resolved or fixed issue: #3175

## Validation

- 
pm run lint
- 
pm run test:server
- 
pm run frisby
- 
pm run rsn

## AI Tool Disclosure
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: OpenAI Codex
  - LLMs and versions: GPT-5
  - Prompts: Used only for minor error fixing, small bug checks, and validation help while implementing and testing the maintainer-provided design.

## Affirmation
- [x] My code follows the CONTRIBUTING.md guidelines