### PR TITLE
Keep challenge notifications from pushing page content

### DIFF
--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.html
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: MIT
 -->
 @if (notifications.length > 0) {
-<div class="container challenge-solved-toast mat-elevation-z4">
+<div class="container challenge-solved-toast notification-panel mat-elevation-z4" role="region" aria-live="polite">
   @for (notification of notifications; track notification.key) {
     <mat-card appearance="outlined" class="accent-notification">
       <div class="mdc-card">

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.scss
@@ -10,6 +10,18 @@
   margin: $space-l;
 }
 
+.challenge-solved-toast {
+  box-sizing: border-box;
+  left: 0;
+  margin-top: 0;
+  max-height: calc(100vh - $navbar-height - (2 * #{$space-l}));
+  overflow-y: auto;
+  position: fixed;
+  right: 0;
+  top: calc($navbar-height + $space-l);
+  z-index: 20;
+}
+
 mat-card {
   margin-bottom: $space-s;
 

--- a/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
+++ b/frontend/src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts
@@ -124,6 +124,17 @@ describe('ChallengeSolvedNotificationComponent', () => {
     expect(component.notifications).toEqual([{ key: 'test', message: 'CHALLENGE_SOLVED', flag: '1234', copied: false, country: undefined, codingChallenge: false }])
   }))
 
+  it('should render solved notifications inside the notification panel', fakeAsync(() => {
+    translateService.get.and.returnValue(of('CHALLENGE_SOLVED'))
+    component.notifications = []
+    component.showNotification({ key: 'test', challenge: 'Test', flag: '1234' })
+    tick()
+    fixture.detectChanges()
+
+    const panel = fixture.nativeElement.querySelector('.notification-panel')
+    expect(panel).not.toBeNull()
+  }))
+
   it('should store retrieved continue code as cookie for 1 year', () => {
     challengeService.continueCode.and.returnValue(of('12345'))
 


### PR DESCRIPTION
### Description

Fixes the challenge-solved notification stack so a large number of notifications no longer push the page content downward.

The notification container is rendered as a fixed tray below the navbar and gets its own vertical scroll area once it exceeds the available viewport height.

Resolved or fixed issue: #3211

Validation run locally:
- `npm run lint`
- `cd frontend && npx ng test --watch=false --browsers=ChromeHeadless --include src/app/challenge-solved-notification/challenge-solved-notification.component.spec.ts`

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `OpenAI Codex`
    - LLMs and versions: `GPT-5`
    - Prompts: `Used for small implementation and validation help while fixing the notification layout bug.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines