### PR TITLE
Finish the nftUnlock web3 coding challenge options

### DIFF
--- a/data/static/codefixes/nftUnlockChallenge.info.yml
+++ b/data/static/codefixes/nftUnlockChallenge.info.yml
@@ -1,13 +1,13 @@
 fixes:
   - id: 1
-    explanation: 'Wrong!'
+    explanation: 'Removing the counter increment only guarantees that every mint attempt keeps reusing the same token id, so the contract breaks as soon as a second NFT is minted.'
   - id: 2
-    explanation: 'Correct!'
+    explanation: 'Incrementing the counter before reading it avoids minting the first NFT with token id 0 and keeps every future soulbound token on a unique, non-default identifier.'
   - id: 3
-    explanation: 'Wrong!'
+    explanation: 'Hardcoding the token id to 1 prevents token id 0, but it also makes every mint attempt collide on the exact same NFT identifier.'
   - id: 4
-    explanation: 'Wrong!'
+    explanation: 'Multiplying the current counter value still leaves the first mint on token id 0 and only changes the predictable numbering scheme for later mints.'
 hints:
-  - 'Hint1'
-  - 'Hint2'
-  - 'Hint3'
+  - 'Look closely at the very first token id that gets minted from a freshly deployed contract.'
+  - 'What value does a Solidity counter return before it has been incremented for the first time?'
+  - 'The best fix should preserve unique token ids without relying on a default zero identifier.'

--- a/data/static/codefixes/nftUnlockChallenge_1.sol
+++ b/data/static/codefixes/nftUnlockChallenge_1.sol
@@ -14,7 +14,6 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
 
     function safeMint(address to, string memory uri) public onlyOwner {
         uint256 tokenId = _tokenIdCounter.current();
-        _tokenIdCounter.increment();
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
     }

--- a/data/static/codefixes/nftUnlockChallenge_2_correct.sol
+++ b/data/static/codefixes/nftUnlockChallenge_2_correct.sol
@@ -13,8 +13,8 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
     constructor() ERC721("JuiceShopSBT", "JS") {}
 
     function safeMint(address to, string memory uri) public onlyOwner {
-        uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
+        uint256 tokenId = _tokenIdCounter.current();
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
     }

--- a/data/static/codefixes/nftUnlockChallenge_3.sol
+++ b/data/static/codefixes/nftUnlockChallenge_3.sol
@@ -13,7 +13,7 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
     constructor() ERC721("JuiceShopSBT", "JS") {}
 
     function safeMint(address to, string memory uri) public onlyOwner {
-        uint256 tokenId = _tokenIdCounter.current();
+        uint256 tokenId = 1;
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);

--- a/data/static/codefixes/nftUnlockChallenge_4.sol
+++ b/data/static/codefixes/nftUnlockChallenge_4.sol
@@ -13,7 +13,7 @@ contract JuiceShopSBT is ERC721, ERC721URIStorage, Ownable {
     constructor() ERC721("JuiceShopSBT", "JS") {}
 
     function safeMint(address to, string memory uri) public onlyOwner {
-        uint256 tokenId = _tokenIdCounter.current();
+        uint256 tokenId = _tokenIdCounter.current() * 2;
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);

--- a/rsn/cache.json
+++ b/rsn/cache.json
@@ -317,20 +317,38 @@
 		"removed": []
 	},
 	"nftUnlockChallenge_1.sol": {
-		"added": [],
-		"removed": []
+		"added": [
+			17,
+			43
+		],
+		"removed": [
+			43
+		]
 	},
 	"nftUnlockChallenge_2_correct.sol": {
-		"added": [],
-		"removed": []
+		"added": [
+			43
+		],
+		"removed": [
+			18,
+			43
+		]
 	},
 	"nftUnlockChallenge_3.sol": {
-		"added": [],
-		"removed": []
+		"added": [
+			43
+		],
+		"removed": [
+			43
+		]
 	},
 	"nftUnlockChallenge_4.sol": {
-		"added": [],
-		"removed": []
+		"added": [
+			43
+		],
+		"removed": [
+			43
+		]
 	},
 	"noSqlReviewsChallenge_1.ts": {
 		"added": [

--- a/test/api/vulnCodeFixesSpec.ts
+++ b/test/api/vulnCodeFixesSpec.ts
@@ -27,6 +27,18 @@ describe('/snippets/fixes/:key', () => {
         fixes: Joi.array().length(3)
       })
   })
+
+  it('GET fixes for nftUnlockChallenge returns distinct fix options', async () => {
+    const response = await frisby.get(URL + '/snippets/fixes/nftUnlockChallenge')
+      .expect('status', 200)
+      .expect('jsonTypes', {
+        fixes: Joi.array().items(Joi.string())
+      })
+      .promise()
+
+    expect(response.json.fixes).toHaveLength(4)
+    expect(new Set(response.json.fixes).size).toBe(4)
+  })
 })
 
 describe('/snippets/fixes', () => {
@@ -112,5 +124,19 @@ describe('/snippets/fixes', () => {
       .promise()
 
     await websocketReceivedPromise
+  })
+
+  it('POST correct fix for nftUnlockChallenge gives positive verdict and non-placeholder explanation', () => {
+    return frisby.post(URL + '/snippets/fixes', {
+      body: {
+        key: 'nftUnlockChallenge',
+        selectedFix: 1
+      }
+    })
+      .expect('status', 200)
+      .expect('json', {
+        verdict: true,
+        explanation: 'Incrementing the counter before reading it avoids minting the first NFT with token id 0 and keeps every future soulbound token on a unique, non-default identifier.'
+      })
   })
 })


### PR DESCRIPTION
Description
This finishes the still-placeholder coding challenge assets for `nftUnlockChallenge` under #2091.

Changes:
- replace the identical `JuiceShopSBT` fix files with four distinct Solidity fix options
- replace the placeholder explanations and hints in `nftUnlockChallenge.info.yml`
- add focused API coverage to keep the options distinct and verify the correct explanation
- update the RSN cache for this intentional coding-challenge content change

Resolved or fixed issue: #2091

AI Tool Disclosure
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
AI Tools: OpenAI Codex
LLMs and versions: GPT-5
Prompts: Analyze the unfinished nftUnlockChallenge coding challenge scaffold, replace placeholder fix options and hints with a complete implementation, add focused regression coverage, and validate the change for a focused PR against #2091.

Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines