### PR TITLE
Fix: Prevent challenge-solved notifications from pushing page content ✅

### DIFF
--- a/frontend/src/app/Services/snack-bar-helper.service.ts
+++ b/frontend/src/app/Services/snack-bar-helper.service.ts
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
- * SPDX-License-Identifier: MIT
- */
-
 import { Injectable, inject } from '@angular/core'
 import { MatSnackBar } from '@angular/material/snack-bar'
 import { TranslateService } from '@ngx-translate/core'
@@ -14,21 +9,33 @@ export class SnackBarHelperService {
   private readonly translateService = inject(TranslateService)
   private readonly snackBar = inject(MatSnackBar)
 
+  private isSnackbarOpen = false;
 
-  open (message: string, cssClass?: string) {
+  open(message: string, cssClass?: string) {
+    if (this.isSnackbarOpen) return;
+
     this.translateService.get(message).subscribe({
       next: (translatedMessage) => {
-        this.snackBar.open(translatedMessage, 'X', {
-          duration: 5000,
-          panelClass: [cssClass, 'mat-body']
-        })
+        this.showSnack(translatedMessage, cssClass);
       },
       error: () => {
-        this.snackBar.open(message, 'X', {
-          duration: 5000,
-          panelClass: [cssClass, 'mat-body']
-        })
+        this.showSnack(message, cssClass);
       }
-    })
+    });
+  }
+
+  private showSnack(message: string, cssClass?: string) {
+    this.isSnackbarOpen = true;
+
+    const snackRef = this.snackBar.open(message, 'X', {
+      duration: 5000,
+      verticalPosition: 'top',
+      horizontalPosition: 'right',
+      panelClass: [cssClass || '', 'mat-body', 'custom-snackbar']
+    });
+
+    snackRef.afterDismissed().subscribe(() => {
+      this.isSnackbarOpen = false;
+    });
   }
 }

--- a/frontend/src/app/Services/snack-bar-helper.service.ts
+++ b/frontend/src/app/Services/snack-bar-helper.service.ts
@@ -9,33 +9,33 @@ export class SnackBarHelperService {
   private readonly translateService = inject(TranslateService)
   private readonly snackBar = inject(MatSnackBar)
 
-  private isSnackbarOpen = false;
+  private isSnackbarOpen = false
 
   open(message: string, cssClass?: string) {
-    if (this.isSnackbarOpen) return;
+    if (this.isSnackbarOpen) return
 
     this.translateService.get(message).subscribe({
       next: (translatedMessage) => {
-        this.showSnack(translatedMessage, cssClass);
+        this.showSnack(translatedMessage, cssClass)
       },
       error: () => {
-        this.showSnack(message, cssClass);
+        this.showSnack(message, cssClass)
       }
-    });
+    })
   }
 
   private showSnack(message: string, cssClass?: string) {
-    this.isSnackbarOpen = true;
+    this.isSnackbarOpen = true
 
     const snackRef = this.snackBar.open(message, 'X', {
       duration: 5000,
       verticalPosition: 'top',
       horizontalPosition: 'right',
       panelClass: [cssClass || '', 'mat-body', 'custom-snackbar']
-    });
+    })
 
     snackRef.afterDismissed().subscribe(() => {
-      this.isSnackbarOpen = false;
-    });
+      this.isSnackbarOpen = false
+    })
   }
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -307,3 +307,12 @@ div.mdc-card {
 .mat-mdc-tooltip-surface {
   max-height: none !important;
 }
+/* Fix: Prevent snackbar stacking from affecting layout */
+.custom-snackbar {
+  position: fixed !important;
+  top: 70px !important; /* below navbar */
+  right: 20px !important;
+  z-index: 1000 !important;
+
+  max-width: 350px;
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -289,3 +289,12 @@ div.mdc-card {
 .mat-mdc-tooltip-surface {
   max-height: none !important;
 }
+/* Fix: Prevent snackbar stacking from affecting layout */
+.custom-snackbar {
+  position: fixed !important;
+  top: 70px !important; /* below navbar */
+  right: 20px !important;
+  z-index: 1000 !important;
+
+  max-width: 350px;
+}


### PR DESCRIPTION
## Fix: Prevent challenge-solved notifications from pushing page content

### Problem

When multiple challenge-solved notifications are displayed, they stack vertically and push page content downward, negatively impacting usability.

### Solution

* Restricted snackbar to a single instance at a time
* Positioned snackbar as a fixed overlay (top-right)
* Added custom styling to prevent layout shift

### Result

* Notifications no longer affect page layout
* Improved user experience

### Testing

* Triggered multiple notifications
* Verified only one snackbar is shown at a time
* Confirmed no layout shifting occurs

Closes #3211
