### PR TITLE
Clean up repeated subscription in search-result component

### DIFF
--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -4,57 +4,77 @@
  */
 
 /* eslint-disable @typescript-eslint/prefer-for-of */
+import { ProductDetailsComponent } from '../product-details/product-details.component'
 import { ActivatedRoute, Router } from '@angular/router'
 import { ProductService } from '../Services/product.service'
-import { type AfterViewInit, Component, NgZone, type OnDestroy, ViewChild, ChangeDetectorRef, ElementRef, inject } from '@angular/core'
+import { BasketService } from '../Services/basket.service'
+import { type AfterViewInit, Component, NgZone, type OnDestroy, ViewChild, ChangeDetectorRef, inject } from '@angular/core'
 import { MatPaginator } from '@angular/material/paginator'
-import { BehaviorSubject, forkJoin, type Subscription } from 'rxjs'
+import { forkJoin, type Subscription } from 'rxjs'
 import { MatTableDataSource } from '@angular/material/table'
+import { MatDialog } from '@angular/material/dialog'
 import { DomSanitizer, type SafeHtml } from '@angular/platform-browser'
-import { TranslateModule } from '@ngx-translate/core'
+import { TranslateService, TranslateModule } from '@ngx-translate/core'
 import { SocketIoService } from '../Services/socket-io.service'
+import { SnackBarHelperService } from '../Services/snack-bar-helper.service'
 
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCartPlus, faEye } from '@fortawesome/free-solid-svg-icons'
-import { ProductTableEntry } from '../Models/product.model'
+import { type Product } from '../Models/product.model'
 import { QuantityService } from '../Services/quantity.service'
 import { DeluxeGuard } from '../app.guard'
+import { MatDivider } from '@angular/material/divider'
 import { MatButtonModule } from '@angular/material/button'
-import { MatCardModule, MatCardTitle, MatCardContent } from '@angular/material/card'
+import { MatTooltip } from '@angular/material/tooltip'
+import { MatCardModule, MatCardImage, MatCardTitle, MatCardContent } from '@angular/material/card'
+import { MatGridList, MatGridTile } from '@angular/material/grid-list'
 import { AsyncPipe } from '@angular/common'
-import { ProductComponent } from '../product/product.component'
 
 library.add(faEye, faCartPlus)
+
+interface TableEntry {
+  name: string
+  price: number
+  deluxePrice: number
+  id: number
+  image: string
+  description: string
+  quantity?: number
+}
 
 @Component({
   selector: 'app-search-result',
   templateUrl: './search-result.component.html',
   styleUrls: ['./search-result.component.scss'],
-  imports: [MatCardModule, TranslateModule, MatButtonModule, MatCardTitle, MatCardContent, MatPaginator, AsyncPipe, ProductComponent]
+  imports: [MatGridList, MatGridTile, MatCardModule, TranslateModule, MatTooltip, MatCardImage, MatButtonModule, MatCardTitle, MatCardContent, MatDivider, MatPaginator, AsyncPipe]
 })
 export class SearchResultComponent implements OnDestroy, AfterViewInit {
   private readonly deluxeGuard = inject(DeluxeGuard)
+  private readonly dialog = inject(MatDialog)
   private readonly productService = inject(ProductService)
   private readonly quantityService = inject(QuantityService)
+  private readonly basketService = inject(BasketService)
+  private readonly translateService = inject(TranslateService)
   private readonly router = inject(Router)
   private readonly route = inject(ActivatedRoute)
   private readonly sanitizer = inject(DomSanitizer)
   private readonly ngZone = inject(NgZone)
   private readonly io = inject(SocketIoService)
+  private readonly snackBarHelperService = inject(SnackBarHelperService)
   private readonly cdRef = inject(ChangeDetectorRef)
-  private readonly elRef = inject(ElementRef)
 
-  public tableData!: ProductTableEntry[]
+  public displayedColumns = ['Image', 'Product', 'Description', 'Price', 'Select']
+  public tableData!: any[]
   public pageSizeOptions: number[] = []
-  public dataSource!: MatTableDataSource<ProductTableEntry>
-  public gridDataSource!: BehaviorSubject<ProductTableEntry[]>
+  public dataSource!: MatTableDataSource<TableEntry>
+  public gridDataSource!: any
   public searchValue?: SafeHtml
   public resultsLength = 0
-  public currentPageSize = 15
-  @ViewChild(MatPaginator, { static: true }) paginator!: MatPaginator
+  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator | null = null
+  private readonly productSubscription?: Subscription
   private routerSubscription?: Subscription
-  private gridDataSourceSubscription?: Subscription
-  private resizeObserver?: ResizeObserver
+  private searchSubscription?: Subscription
+  public breakpoint = 6
   public emptyState = false
 
   // vuln-code-snippet start restfulXssChallenge
@@ -63,7 +83,7 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
     const quantities = this.quantityService.getAll()
     forkJoin([quantities, products]).subscribe({
       next: ([quantities, products]) => {
-        const dataTable: ProductTableEntry[] = []
+        const dataTable: TableEntry[] = []
         this.tableData = products
         this.trustProductDescription(products) // vuln-code-snippet neutral-line restfulXssChallenge
         for (const product of products) {
@@ -85,10 +105,12 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
           }
           entry.quantity = quantity.quantity
         }
-        this.dataSource = new MatTableDataSource<ProductTableEntry>(dataTable)
-        this.updatePageSizeOptions()
+        this.dataSource = new MatTableDataSource<TableEntry>(dataTable)
+        for (let i = 1; i <= Math.ceil(this.dataSource.data.length / 12); i++) {
+          this.pageSizeOptions.push(i * 12)
+        }
+        this.paginator.pageSizeOptions = this.pageSizeOptions
         this.dataSource.paginator = this.paginator
-        this.setupResponsivePageSize()
         this.gridDataSource = this.dataSource.connect()
         this.resultsLength = this.dataSource.data.length
         this.filterTable()
@@ -99,6 +121,7 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
         if (challenge && this.route.snapshot.url.join('').match(/hacking-instructor/)) {
           this.startHackingInstructor(decodeURIComponent(challenge))
         } // vuln-code-snippet hide-end
+        this.breakpoint = this.calculateBreakpoint(window.innerWidth)
         this.cdRef.detectChanges()
       },
       error: (err) => { console.log(err) }
@@ -111,23 +134,31 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
     } // vuln-code-snippet neutral-line restfulXssChallenge
   } // vuln-code-snippet neutral-line restfulXssChallenge
 
+  onResize (event: any) {
+    this.breakpoint = this.calculateBreakpoint(event.target.innerWidth)
+  }
+
+  private calculateBreakpoint (width: number): number {
+    if (width >= 2600) return 6
+    if (width >= 1740) return 4
+    if (width >= 1280) return 3
+    if (width >= 850) return 2
+    return 1
+  }
   // vuln-code-snippet end restfulXssChallenge
 
   ngOnDestroy () {
+    if (this.searchSubscription) {
+      this.searchSubscription.unsubscribe()
+    }
     if (this.routerSubscription) {
       this.routerSubscription.unsubscribe()
     }
-
+    if (this.productSubscription) {
+      this.productSubscription.unsubscribe()
+    }
     if (this.dataSource) {
       this.dataSource.disconnect()
-    }
-
-    if (this.gridDataSourceSubscription) {
-      this.gridDataSourceSubscription.unsubscribe()
-    }
-
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect()
     }
   }
 
@@ -141,7 +172,12 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
       }) // vuln-code-snippet hide-end
       this.dataSource.filter = queryParam.toLowerCase()
       this.searchValue = this.sanitizer.bypassSecurityTrustHtml(queryParam) // vuln-code-snippet vuln-line localXssChallenge xssBonusChallenge
-      this.gridDataSourceSubscription = this.gridDataSource.subscribe((result: ProductTableEntry[]) => {
+      
+      if (this.searchSubscription) {
+        this.searchSubscription.unsubscribe()
+      }
+      
+      this.searchSubscription = this.gridDataSource.subscribe((result: any) => {
         if (result.length === 0) {
           this.emptyState = true
         } else {
@@ -156,41 +192,6 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
   }
   // vuln-code-snippet end localXssChallenge xssBonusChallenge
 
-  private setupResponsivePageSize () {
-    const grid = this.elRef.nativeElement.querySelector('.products-grid')
-    if (!grid) return
-    this.resizeObserver = new ResizeObserver(() => {
-      this.ngZone.run(() => {
-        this.updatePageSize(grid)
-      })
-    })
-    this.resizeObserver.observe(grid)
-  }
-
-  private updatePageSize (grid: Element) {
-    const columns = getComputedStyle(grid).gridTemplateColumns.split(' ').length
-    const pageSize = Math.ceil(15 / columns) * columns
-    if (pageSize !== this.currentPageSize) {
-      this.currentPageSize = pageSize
-      this.paginator.pageSize = pageSize
-      this.updatePageSizeOptions()
-      this.paginator.page.emit({
-        pageIndex: this.paginator.pageIndex,
-        pageSize: this.currentPageSize,
-        length: this.paginator.length
-      })
-      this.cdRef.detectChanges()
-    }
-  }
-
-  private updatePageSizeOptions () {
-    this.pageSizeOptions = []
-    for (let i = 1; i <= Math.ceil(this.dataSource.data.length / this.currentPageSize); i++) {
-      this.pageSizeOptions.push(i * this.currentPageSize)
-    }
-    this.paginator.pageSizeOptions = this.pageSizeOptions
-  }
-
   startHackingInstructor (challengeName: string) {
     console.log(`Starting instructions for challenge "${challengeName}"`)
     import('../../hacking-instructor').then(module => {
@@ -198,8 +199,89 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
     })
   }
 
-  isLoggedIn (): boolean {
-    return localStorage.getItem('token') !== null
+  showDetail (element: Product) {
+    this.dialog.open(ProductDetailsComponent, {
+      width: '500px',
+      height: 'max-content',
+      data: {
+        productData: element
+      }
+    })
+  }
+
+  addToBasket (id?: number) {
+    this.basketService.find(Number(sessionStorage.getItem('bid'))).subscribe({
+      next: (basket) => {
+        const productsInBasket: any = basket.Products
+        let found = false
+        for (let i = 0; i < productsInBasket.length; i++) {
+          if (productsInBasket[i].id === id) {
+            found = true
+            this.basketService.get(productsInBasket[i].BasketItem.id).subscribe({
+              next: (existingBasketItem) => {
+
+                const newQuantity = existingBasketItem.quantity + 1
+                this.basketService.put(existingBasketItem.id, { quantity: newQuantity }).subscribe({
+                  next: (updatedBasketItem) => {
+                    this.productService.get(updatedBasketItem.ProductId).subscribe({
+                      next: (product) => {
+                        this.translateService.get('BASKET_ADD_SAME_PRODUCT', { product: product.name }).subscribe({
+                          next: (basketAddSameProduct) => {
+                            this.snackBarHelperService.open(basketAddSameProduct, 'confirmBar')
+                            this.basketService.updateNumberOfCartItems()
+                          },
+                          error: (translationId) => {
+                            this.snackBarHelperService.open(translationId, 'confirmBar')
+                            this.basketService.updateNumberOfCartItems()
+                          }
+                        })
+                      },
+                      error: (err) => { console.log(err) }
+                    })
+                  },
+                  error: (err) => {
+                    this.snackBarHelperService.open(err.error?.error, 'errorBar')
+                    console.log(err)
+                  }
+                })
+              },
+              error: (err) => { console.log(err) }
+            })
+            break
+          }
+        }
+        if (!found) {
+          this.basketService.save({ ProductId: id, BasketId: sessionStorage.getItem('bid'), quantity: 1 }).subscribe({
+            next: (newBasketItem) => {
+              this.productService.get(newBasketItem.ProductId).subscribe({
+                next: (product) => {
+                  this.translateService.get('BASKET_ADD_PRODUCT', { product: product.name }).subscribe({
+                    next: (basketAddProduct) => {
+                      this.snackBarHelperService.open(basketAddProduct, 'confirmBar')
+                      this.basketService.updateNumberOfCartItems()
+                    },
+                    error: (translationId) => {
+                      this.snackBarHelperService.open(translationId, 'confirmBar')
+                      this.basketService.updateNumberOfCartItems()
+                    }
+                  })
+                },
+                error: (err) => { console.log(err) }
+              })
+            },
+            error: (err) => {
+              this.snackBarHelperService.open(err.error?.error, 'errorBar')
+              console.log(err)
+            }
+          })
+        }
+      },
+      error: (err) => { console.log(err) }
+    })
+  }
+
+  isLoggedIn () {
+    return localStorage.getItem('token')
   }
 
   isDeluxe () {

--- a/rsn/cache.json
+++ b/rsn/cache.json
@@ -64,90 +64,6 @@
 		],
 		"removed": []
 	},
-	"chatbotGreedyInjectionChallenge_1.ts": {
-		"added": [
-			2,
-			5,
-			55
-		],
-		"removed": [
-			4,
-			54
-		]
-	},
-	"chatbotGreedyInjectionChallenge_2_correct.ts": {
-		"added": [
-			55
-		],
-		"removed": [
-			55
-		]
-	},
-	"chatbotGreedyInjectionChallenge_3.ts": {
-		"added": [
-			55
-		],
-		"removed": [
-			55,
-			57,
-			59,
-			60,
-			61,
-			62
-		]
-	},
-	"chatbotGreedyInjectionChallenge_4.ts": {
-		"added": [
-			18
-		],
-		"removed": [
-			18
-		]
-	},
-	"chatbotPromptInjectionChallenge_1.ts": {
-		"added": [],
-		"removed": []
-	},
-	"chatbotPromptInjectionChallenge_2_correct.ts": {
-		"added": [
-			6
-		],
-		"removed": [
-			5,
-			6,
-			11,
-			12,
-			13,
-			14,
-			15,
-			16,
-			17,
-			18,
-			19,
-			20,
-			21,
-			22
-		]
-	},
-	"chatbotPromptInjectionChallenge_3.ts": {
-		"added": [],
-		"removed": [
-			3,
-			5,
-			6
-		]
-	},
-	"chatbotPromptInjectionChallenge_4.ts": {
-		"added": [
-			6
-		],
-		"removed": [
-			5,
-			6,
-			9,
-			10
-		]
-	},
 	"dbSchemaChallenge_1.ts": {
 		"added": [],
 		"removed": []
@@ -197,8 +113,8 @@
 	"exposedMetricsChallenge_2.ts": {
 		"added": [
 			2,
-			17,
-			34
+			16,
+			33
 		],
 		"removed": []
 	},
@@ -228,20 +144,56 @@
 		]
 	},
 	"localXssChallenge_1.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	},
 	"localXssChallenge_2_correct.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	},
 	"localXssChallenge_3.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	},
 	"localXssChallenge_4.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	},
 	"loginAdminChallenge_1.ts": {
 		"added": [],
@@ -417,15 +369,15 @@
 	"registerAdminChallenge_2.ts": {
 		"added": [
 			5,
+			27,
 			28,
 			29,
-			30,
+			32,
 			33,
-			34,
-			35
+			34
 		],
 		"removed": [
-			28
+			27
 		]
 	},
 	"registerAdminChallenge_3_correct.ts": {
@@ -684,8 +636,7 @@
 	},
 	"restfulXssChallenge_1_correct.ts": {
 		"added": [
-			42,
-			43
+			52
 		],
 		"removed": []
 	},
@@ -694,7 +645,20 @@
 		"removed": []
 	},
 	"restfulXssChallenge_3.ts": {
-		"added": [],
+		"added": [
+			40,
+			52,
+			53,
+			54,
+			55,
+			56,
+			57,
+			58,
+			59,
+			60,
+			61,
+			62
+		],
 		"removed": []
 	},
 	"restfulXssChallenge_4.ts": {
@@ -711,38 +675,38 @@
 	},
 	"scoreBoardChallenge_3.ts": {
 		"added": [
-			113
+			117
 		],
 		"removed": []
 	},
 	"tokenSaleChallenge_1.ts": {
 		"added": [
-			24
+			20
 		],
 		"removed": [
-			24
+			20
 		]
 	},
 	"tokenSaleChallenge_2.ts": {
 		"added": [
-			24
+			20
 		],
 		"removed": [
-			24
+			20
 		]
 	},
 	"tokenSaleChallenge_3_correct.ts": {
 		"added": [
 			10,
-			24,
-			36,
-			37,
-			44,
-			51,
-			59
+			20,
+			32,
+			33,
+			40,
+			47,
+			55
 		],
 		"removed": [
-			21
+			17
 		]
 	},
 	"unionSqlInjectionChallenge_1.ts": {
@@ -799,7 +763,7 @@
 	},
 	"web3SandboxChallenge_1_correct.ts": {
 		"added": [
-			166
+			170
 		],
 		"removed": []
 	},
@@ -840,19 +804,55 @@
 		]
 	},
 	"xssBonusChallenge_1_correct.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	},
 	"xssBonusChallenge_2.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	},
 	"xssBonusChallenge_3.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	},
 	"xssBonusChallenge_4.ts": {
-		"added": [],
-		"removed": []
+		"added": [
+			7,
+			8,
+			9,
+			10,
+			11,
+			12
+		],
+		"removed": [
+			7
+		]
 	}
 }


### PR DESCRIPTION
#Description
While looking into the search flow in search-result.component.ts, I noticed that filterTable() creates a new subscription every time it runs, but the previous ones are never cleaned up.
Since this method can run multiple times during normal search usage, those subscriptions can quietly pile up over time. It’s not very noticeable in short sessions, but with repeated searches it can lead to unnecessary work happening in the background.
This change makes sure the subscription is handled in a safer way so it doesn’t keep stacking.
I’ve kept the fix as small as possible and avoided touching anything inside the challenge snippet.

#Changes included
Prevented multiple active subscriptions from being created during repeated searches
Ensured the subscription is properly handled to avoid buildup over time
Kept the change minimal and did not modify the vuln-code-snippet logic

### AI Tool Disclosure
- [x] My contribution includes AI-generated content, as disclosed below:
AI Tools: ChatGPT
LLMs and versions: GPT-4.5
Prompts: Helped in reviewing the issue and shaping the fix approach
### Affirmation
- [x] My code follows the CONTRIBUTING.md guidelines