### PR TITLE
fix: patch 5 SAST vulnerabilities

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -41,7 +41,8 @@ interface IAuthenticatedUsers {
 }
 
 export const hash = (data: string) => crypto.createHash('md5').update(data).digest('hex')
-export const hmac = (data: string) => crypto.createHmac('sha256', 'pa4qacea4VK9t9nGv7yZtwmj').update(data).digest('hex')
+const HMAC_SECRET = process.env.HMAC_SECRET || 'pa4qacea4VK9t9nGv7yZtwmj' // TODO: remove fallback in production
+export const hmac = (data: string) => crypto.createHmac('sha256', HMAC_SECRET).update(data).digest('hex')
 
 export const cutOffPoisonNullByte = (str: string) => {
   const nullByte = '%00'

--- a/routes/fileServer.ts
+++ b/routes/fileServer.ts
@@ -30,7 +30,12 @@ export function servePublicFiles () {
       challengeUtils.solveIf(challenges.directoryListingChallenge, () => { return file.toLowerCase() === 'acquisitions.md' })
       verifySuccessfulPoisonNullByteExploit(file)
 
-      res.sendFile(path.resolve('ftp/', file))
+      const resolvedPath = path.resolve('ftp/', file)
+      if (!resolvedPath.startsWith(path.resolve('ftp/'))) {
+        res.status(403)
+        return next(new Error('Access denied'))
+      }
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
       next(new Error('Only .md and .pdf files are allowed!'))

--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -80,7 +80,7 @@ function handleXmlUpload ({ file }: Request, res: Response, next: NextFunction) 
       try {
         const sandbox = { libxml, data }
         vm.createContext(sandbox)
-        const xmlDoc = vm.runInContext('libxml.parseXml(data, { noblanks: true, noent: true, nocdata: true })', sandbox, { timeout: 2000 })
+        const xmlDoc = vm.runInContext('libxml.parseXml(data, { noblanks: true, noent: false, nocdata: true })', sandbox, { timeout: 2000 })
         const xmlString = xmlDoc.toString(false)
         challengeUtils.solveIf(challenges.xxeFileDisclosureChallenge, () => { return (utils.matchesEtcPasswdFile(xmlString) || utils.matchesSystemIniFile(xmlString)) })
         res.status(410)

--- a/routes/login.ts
+++ b/routes/login.ts
@@ -31,7 +31,7 @@ export function login () {
 
   return (req: Request, res: Response, next: NextFunction) => {
     verifyPreLoginChallenges(req) // vuln-code-snippet hide-line
-    models.sequelize.query(`SELECT * FROM Users WHERE email = '${req.body.email || ''}' AND password = '${security.hash(req.body.password || '')}' AND deletedAt IS NULL`, { model: UserModel, plain: true }) // vuln-code-snippet vuln-line loginAdminChallenge loginBenderChallenge loginJimChallenge
+    models.sequelize.query(`SELECT * FROM Users WHERE email = :email AND password = :password AND deletedAt IS NULL`, { replacements: { email: req.body.email || '', password: security.hash(req.body.password || '') }, model: UserModel, plain: true }) // vuln-code-snippet vuln-line loginAdminChallenge loginBenderChallenge loginJimChallenge
       .then((authenticatedUser) => { // vuln-code-snippet neutral-line loginAdminChallenge loginBenderChallenge loginJimChallenge
         const user = utils.queryResultToJson(authenticatedUser)
         if (user.data?.id && user.data.totpSecret !== '') {

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -59,7 +59,7 @@ export function getUserProfile () {
         if (!code) {
           throw new Error('Username is null')
         }
-        username = eval(code) // eslint-disable-line no-eval
+        username = String(code).replace(/[^a-zA-Z0-9 _\-@.]/g, '') // sanitized instead of eval
       } catch (err) {
         username = '\\' + username
       }


### PR DESCRIPTION
## Исправление SAST-уязвимостей (Semgrep)

  В ходе статического анализа кодовой базы Juice Shop с помощью Semgrep было обнаружено 40 уязвимостей. Для исправления я выбрал 5 наиболее критичных, каждая из которых представляет отдельный класс угроз из OWASP Top 10.

  ### 1. SQL Injection - `routes/login.ts` (CWE-89)
  Форма логина подставляла пользовательский ввод напрямую в SQL-запрос через интерполяцию строки. Это позволяло войти под любым аккаунтом с помощью классической инъекции вроде `' OR 1=1 --`. Заменил на параметризованный запрос с использованием `replacements` в Sequelize - теперь ввод пользователя не попадает в тело запроса напрямую.

  ### 2. Path Traversal - `routes/fileServer.ts` (CWE-22)
  Маршрут для скачивания файлов из папки `ftp/` никак не проверял итоговый путь после `path.resolve()`. Через последовательности `../` можно было выйти за пределы директории и прочитать произвольные файлы на сервере. Добавил проверку, что resolved-путь начинается с `ftp/` - если нет, возвращается 403.

  ### 3. Hardcoded Secret - `lib/insecurity.ts` (CWE-798)
  HMAC-ключ для подписи данных был захардкожен прямо в исходном коде. Любой, кто имеет доступ к репозиторию, мог его увидеть и подделать подписи. Вынес секрет в переменную окружения `HMAC_SECRET` с фолбеком на старое значение для обратной совместимости при локальной разработке.

  ### 4. Code Injection через eval() - `routes/userProfile.ts` (CWE-94)
  В обработке имени пользователя использовался `eval()` для выполнения произвольного кода из пользовательского ввода. Это давало полный RCE (Remote Code Execution) на сервере. Заменил `eval()` на санитизацию строки - теперь из ввода удаляются все символы, кроме безопасных (буквы, цифры, пробел, `_`, `-`, `@`, `.`).

  ### 5. XXE (XML External Entities) - `routes/fileUpload.ts` (CWE-611)
  XML-парсер был настроен с флагом `noent: true`, что разрешало обработку внешних сущностей. Через специально сформированный XML-файл можно было читать файлы сервера (например, `/etc/passwd`). Изменил на `noent: false` - внешние сущности больше не раскрываются.