### PR TITLE
fix(frontend): stabilize last-login-ip component specs by isolating test state

### DIFF
--- a/frontend/src/app/last-login-ip/last-login-ip.component.spec.ts
+++ b/frontend/src/app/last-login-ip/last-login-ip.component.spec.ts
@@ -41,9 +41,14 @@ describe('LastLoginIpComponent', () => {
   }))
 
   beforeEach(() => {
+    localStorage.clear()
     fixture = TestBed.createComponent(LastLoginIpComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
   })
 
   it('should compile', () => {
@@ -57,13 +62,13 @@ describe('LastLoginIpComponent', () => {
     expect(console.log).toHaveBeenCalled()
   })
 
-  xit('should set Last-Login IP from JWT as trusted HTML', () => { // FIXME Expected state seems to leak over from previous test case occasionally
+  it('should set Last-Login IP from JWT as trusted HTML', () => {
     localStorage.setItem('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7Imxhc3RMb2dpbklwIjoiMS4yLjMuNCJ9fQ.RAkmdqwNypuOxv3SDjPO4xMKvd1CddKvDFYDBfUt3bg')
     component.ngOnInit()
     expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith('<small>1.2.3.4</small>')
   })
 
-  xit('should not set Last-Login IP if none is present in JWT', () => { // FIXME Expected state seems to leak over from previous test case occasionally
+  it('should not set Last-Login IP if none is present in JWT', () => {
     localStorage.setItem('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7fX0.bVBhvll6IaeR3aUdoOeyR8YZe2S2DfhGAxTGfd9enLw')
     component.ngOnInit()
     expect(sanitizer.bypassSecurityTrustHtml).not.toHaveBeenCalled()


### PR DESCRIPTION
### Description

Stabilizes the `last-login-ip` component unit tests by isolating test state.

The tests were showing inconsistent behavior due to shared state between test cases. This PR ensures each test runs independently with proper setup and teardown.

Changes:
- Isolated test state for each spec
- Removed shared dependencies across tests
- Improved reliability of frontend unit tests

Resolved or fixed issue: none

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: ChatGPT
    - LLMs and versions: GPT-5.3
    - Prompts: Guidance on stabilizing Angular test state and structuring commit/PR

### Affirmation

- [x] My code follows the CONTRIBUTING.md guidelines