### PR TITLE
fix(chatbot): improve fallback responses with randomized messages

### DIFF
--- a/routes/chatbot.ts
+++ b/routes/chatbot.ts
@@ -24,6 +24,13 @@ let trainingFile = config.get<string>('application.chatBot.trainingData')
 let testCommand: string
 export let bot: Bot | null = null
 let initializationPromise: Promise<any> | null = null
+const fallbackResponses = [
+  'I didn\'t quite get that. Can you rephrase?',
+  'Hmm, I\'m not sure. Try asking differently.',
+  'I\'m still learning. Can you clarify?'
+]
+
+const getFallbackResponse = () => fallbackResponses[Math.floor(Math.random() * fallbackResponses.length)]
 
 export async function initializeChatbot () {
   if (initializationPromise !== null) {
@@ -110,10 +117,13 @@ async function processQuery (user: User, req: Request, res: Response, next: Next
       } else {
         res.status(200).json({
           action: 'response',
-          body: config.get('application.chatBot.defaultResponse')
+          body: getFallbackResponse()
         })
       }
     } else {
+      if (response.action === 'response' && response.body === config.get('application.chatBot.defaultResponse')) {
+        response.body = getFallbackResponse()
+      }
       res.status(200).json(response)
     }
   } catch (err) {
@@ -121,7 +131,7 @@ async function processQuery (user: User, req: Request, res: Response, next: Next
       await bot.respond(testCommand, `${user.id}`)
       res.status(200).json({
         action: 'response',
-        body: config.get('application.chatBot.defaultResponse')
+        body: getFallbackResponse()
       })
     } catch (err) {
       challengeUtils.solveIf(challenges.killChatbotChallenge, () => { return true })


### PR DESCRIPTION
## Description
This PR improves chatbot fallback behavior by replacing the single static default response with randomized, user-friendly messages.

## Motivation and Context
Currently, the chatbot returns the same default response for unknown queries, which makes interactions repetitive and less engaging. This change introduces multiple fallback responses to improve user experience.

## How Has This Been Tested?
- Tested chatbot with unknown queries
- Verified that fallback responses are randomized
- Confirmed no impact on existing chatbot logic

## Screenshots
Before: Static fallback response  
<img width="1396" height="847" alt="Screenshot 2026-04-08 220754" src="https://github.com/user-attachments/assets/d33413f7-e2b4-4551-966a-531168f09a28" />

After: Randomized fallback responses
<img width="1416" height="818" alt="Screenshot 2026-04-08 223054" src="https://github.com/user-attachments/assets/74951771-14a4-49fa-9afd-b98babee01a6" />



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## AI Tool Disclosure
- [x] My contribution includes AI-assisted content
  - Tools used: ChatGPT
  - Purpose: Help with structuring fallback response logic and PR description

## Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines