### PR TITLE
feat: Add Log Injection challenge (CWE-117)

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -1544,3 +1544,14 @@
     - 'Find the place where the API call happens — as stated above, it is not in the web application — and then look for the API key itself.'
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html'
   key: leakedApiKeyChallenge
+-
+  name: 'Log Injection'
+  category: 'Injection'
+  description: 'Forge an access log entry to frame another user for accessing a restricted endpoint.'
+  difficulty: 3
+  hints:
+    - 'The login form might not sanitize everything that ends up in the server log.'
+    - 'What happens if the email field contains characters that are meaningful in a log file format?'
+    - 'Newline characters can be very powerful when they end up in places they are not expected.'
+  mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html'
+  key: logInjectionChallenge

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -124,7 +124,8 @@ const CHALLENGE_KEYS = [
   'csafChallenge',
   'exposedCredentialsChallenge',
   'leakedApiKeyChallenge',
-  'passwordHashLeakChallenge'
+  'passwordHashLeakChallenge',
+  'logInjectionChallenge'
 ] as const
 
 export type ChallengeKey = typeof CHALLENGE_KEYS[number]

--- a/routes/login.ts
+++ b/routes/login.ts
@@ -13,6 +13,7 @@ import { UserModel } from '../models/user'
 import * as models from '../models/index'
 import { type User } from '../data/types'
 import * as utils from '../lib/utils'
+import logger from '../lib/logger'
 
 // vuln-code-snippet start loginAdminChallenge loginBenderChallenge loginJimChallenge
 export function login () {
@@ -57,6 +58,13 @@ export function login () {
   // vuln-code-snippet end loginAdminChallenge loginBenderChallenge loginJimChallenge
 
   function verifyPreLoginChallenges (req: Request) {
+    // vuln-code-snippet start logInjectionChallenge
+    logger.info(`Login attempt for email: ${req.body.email}`) // vuln-code-snippet vuln-line logInjectionChallenge
+    challengeUtils.solveIf(challenges.logInjectionChallenge, () => {
+      const email = req.body.email || ''
+      return email.includes('\n') && /\d{3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.test(email) && /admin/i.test(email)
+    })
+    // vuln-code-snippet end logInjectionChallenge
     challengeUtils.solveIf(challenges.weakPasswordChallenge, () => { return req.body.email === 'admin@' + config.get<string>('application.domain') && req.body.password === 'admin123' })
     challengeUtils.solveIf(challenges.loginSupportChallenge, () => { return req.body.email === 'support@' + config.get<string>('application.domain') && req.body.password === 'J6aVjTgOpRs@?5l!Zkq2AYnCE@RF$P' })
     challengeUtils.solveIf(challenges.loginRapperChallenge, () => { return req.body.email === 'mc.safesearch@' + config.get<string>('application.domain') && req.body.password === 'Mr. N00dles' })

--- a/test/cypress/e2e/logInjection.spec.ts
+++ b/test/cypress/e2e/logInjection.spec.ts
@@ -1,0 +1,16 @@
+describe('/rest/user/login', () => {
+  describe('challenge "logInjection"', () => {
+    it('should be possible to forge a log entry by injecting a newline and fake log line into the email field', () => {
+      cy.request({
+        method: 'POST',
+        url: '/rest/user/login',
+        body: {
+          email: 'test@juice-sh.op\n192.168.1.1 - admin@juice-sh.op [forged] "GET /admin HTTP/1.1" 200',
+          password: 'anything'
+        },
+        failOnStatusCode: false
+      })
+      cy.expectChallengeSolved({ challenge: 'Log Injection' })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a new **Log Injection** challenge (difficulty 3, Injection category) where the player forges a server log entry to frame another user for accessing a restricted endpoint.

- The login endpoint (`routes/login.ts`) now logs the submitted email via Winston **without sanitizing newline characters** (the intentional vulnerability)
- A player injects `\n` plus a fake log line (containing an IP address and `admin`) into the email field
- Solve detection checks that the email contains a newline, an IP address pattern, and "admin" — proving the player forged a convincing log entry
- Challenge key: `logInjectionChallenge`
- OWASP reference: [CWE-117 — Improper Output Neutralization for Logs](https://cwe.mitre.org/data/definitions/117.html)

## Changes

| File | Change |
|------|--------|
| `data/static/challenges.yml` | New challenge definition |
| `models/challenge.ts` | Added `logInjectionChallenge` to `CHALLENGE_KEYS` |
| `routes/login.ts` | Vulnerable Winston log line + solve detection with `vuln-code-snippet` annotations |
| `test/cypress/e2e/logInjection.spec.ts` | E2E test that POSTs a forged log payload to the login API |

## Test plan

- [ ] `npm test` — unit tests pass
- [ ] `npm run cypress:run` — new `logInjection.spec.ts` passes
- [ ] `npm run rsn` — refactoring safety net passes (vuln-code-snippet annotations are consistent)
- [ ] Challenge appears on the score board under Injection category at difficulty 3
- [ ] Manually verify: POST to `/rest/user/login` with email containing `\n192.168.1.1 - admin@juice-sh.op [forged] "GET /admin HTTP/1.1" 200` solves the challenge

Closes #3133

## AI Tool Disclosure and Affirmation

This PR was developed with assistance from Claude (AI assistant). I have reviewed all changes, understand the code, and affirm that it meets the project's contribution guidelines.