### PR TITLE
feat: add Log Injection challenge (CWE-117)

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -1544,3 +1544,14 @@
     - 'Find the place where the API call happens — as stated above, it is not in the web application — and then look for the API key itself.'
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html'
   key: leakedApiKeyChallenge
+-
+  name: 'Log Injection'
+  category: 'Injection'
+  description: 'Forge an access log entry to frame another user for accessing a restricted endpoint.'
+  difficulty: 3
+  hints:
+    - 'The login form might not sanitize everything that ends up in the server log.'
+    - 'What happens if the email field contains characters that are meaningful in a log file format?'
+    - 'Newline characters can be very powerful when they end up in places they are not expected.'
+  mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html'
+  key: logInjectionChallenge

--- a/models/challenge.ts
+++ b/models/challenge.ts
@@ -124,7 +124,8 @@ const CHALLENGE_KEYS = [
   'csafChallenge',
   'exposedCredentialsChallenge',
   'leakedApiKeyChallenge',
-  'passwordHashLeakChallenge'
+  'passwordHashLeakChallenge',
+  'logInjectionChallenge'
 ] as const
 
 export type ChallengeKey = typeof CHALLENGE_KEYS[number]

--- a/routes/login.ts
+++ b/routes/login.ts
@@ -13,6 +13,7 @@ import { UserModel } from '../models/user'
 import * as models from '../models/index'
 import { type User } from '../data/types'
 import * as utils from '../lib/utils'
+import logger from '../lib/logger'
 
 // vuln-code-snippet start loginAdminChallenge loginBenderChallenge loginJimChallenge
 export function login () {
@@ -57,6 +58,13 @@ export function login () {
   // vuln-code-snippet end loginAdminChallenge loginBenderChallenge loginJimChallenge
 
   function verifyPreLoginChallenges (req: Request) {
+    // vuln-code-snippet start logInjectionChallenge
+    logger.info(`Login attempt for email: ${req.body.email}`) // vuln-code-snippet vuln-line logInjectionChallenge
+    challengeUtils.solveIf(challenges.logInjectionChallenge, () => {
+      const email = req.body.email || ''
+      return email.includes('\n') && /\d{3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.test(email) && /admin/i.test(email)
+    })
+    // vuln-code-snippet end logInjectionChallenge
     challengeUtils.solveIf(challenges.weakPasswordChallenge, () => { return req.body.email === 'admin@' + config.get<string>('application.domain') && req.body.password === 'admin123' })
     challengeUtils.solveIf(challenges.loginSupportChallenge, () => { return req.body.email === 'support@' + config.get<string>('application.domain') && req.body.password === 'J6aVjTgOpRs@?5l!Zkq2AYnCE@RF$P' })
     challengeUtils.solveIf(challenges.loginRapperChallenge, () => { return req.body.email === 'mc.safesearch@' + config.get<string>('application.domain') && req.body.password === 'Mr. N00dles' })

--- a/test/cypress/e2e/logInjection.spec.ts
+++ b/test/cypress/e2e/logInjection.spec.ts
@@ -1,0 +1,16 @@
+describe('/rest/user/login', () => {
+  describe('challenge "logInjection"', () => {
+    it('should be possible to forge a log entry by injecting a newline and fake log line into the email field', () => {
+      cy.request({
+        method: 'POST',
+        url: '/rest/user/login',
+        body: {
+          email: 'test@juice-sh.op\n192.168.1.1 - admin@juice-sh.op [forged] "GET /admin HTTP/1.1" 200',
+          password: 'anything'
+        },
+        failOnStatusCode: false
+      })
+      cy.expectChallengeSolved({ challenge: 'Log Injection' })
+    })
+  })
+})


### PR DESCRIPTION
### Description

Adds a new Log Injection challenge (CWE-117) where the player forges a server log entry to frame another user. The login endpoint logs the email through Winston without sanitizing newline characters, so a player can inject \n plus a fake log line into the email field.

Resolved or fixed issue: #3133

**Changes:**
- `models/challenge.ts` — added `logInjectionChallenge` to CHALLENGE_KEYS
- `data/static/challenges.yml` — challenge definition (Injection category, 3 stars)
- `routes/login.ts` — vulnerable log line with vuln-code-snippet annotations + solve detection
- `test/cypress/e2e/logInjection.spec.ts` — e2e test

**How it works:**
1. Login endpoint logs email unsanitized via Winston
2. Player sends login with email containing \n + forged log entry framing admin
3. Solve detection checks for newline, IP pattern, and "admin" in email

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code`
    - LLMs and versions: `Claude Opus 4.6`
    - Prompts: `Used to explore the codebase structure, understand existing challenge patterns, and review code. All implementation decisions and code were written by me.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines