### PR TITLE
Fix 401 Unauthorized when using forged JWT tokens for challenges

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -351,6 +351,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   /** Authorization **/
   /* Checks on JWT in Authorization header */ // vuln-code-snippet hide-line
   app.use(verify.jwtChallenges()) // vuln-code-snippet hide-line
+  app.use(security.updateAuthenticatedUsers()) // vuln-code-snippet hide-line
   /* Baskets: Unauthorized users are not allowed to access baskets */
   app.use('/rest/basket', security.isAuthorized(), security.appendUserId())
   /* BasketItems: API only accessible for authenticated users */

--- a/test/api/basketApiSpec.ts
+++ b/test/api/basketApiSpec.ts
@@ -54,8 +54,7 @@ describe('/rest/basket/:id', () => {
       })
   })
 
-  // todo: Endpoint should return a 200, but returns a 401 right now, even though the challenges are marked as solved...
-  it.skip('GET basket should accept forged JWTs', () => {
+  it('GET basket should accept forged JWTs', () => {
     const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
     const payload = Buffer.from(JSON.stringify({ data: { email: 'jim@juice-sh.op' }, iat: 1508639612, exp: 9999999999 })).toString('base64url')
     const unsignedToken = `${header}.${payload}.`


### PR DESCRIPTION
### Description

Forged JWT tokens (`alg:none` unsigned and fake HS256-signed) correctly triggered the JWT challenges as solved, but any API call made with those tokens returned `401 Unauthorized`. This made the challenges confusing — the scoreboard showed "solved" while every protected endpoint rejected the request.

**Root cause:** `security.appendUserId()` looks up the token in `authenticatedUsers.tokenMap`, but forged tokens were never registered there. `security.updateAuthenticatedUsers()` — which registers tokens via the intentionally vulnerable `jsonwebtoken@0.4.0` — was only mounted on `/rest/user/whoami` and `/profile`, not globally.

**Fix:** Mount `security.updateAuthenticatedUsers()` globally in `server.ts` immediately after `verify.jwtChallenges()`. Forged tokens that pass the vulnerable `jwt.verify()` are registered in `tokenMap`, so `appendUserId()` no longer throws and protected routes return the expected response.

Also activates the previously-skipped regression test in `test/api/basketApiSpec.ts` added by a maintainer in commit a69e4c7 to document this exact bug.

Resolved or fixed issue: #1788

### AI Tool Disclosure

- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code (Anthropic CLI)`
    - LLMs and versions: `Claude Sonnet 4.6`
    - Prompts: `Analyzed issue #1788, traced the JWT auth middleware pipeline (jwtChallenges → isAuthorized → appendUserId), identified that forged tokens were never registered in authenticatedUsers.tokenMap, and proposed mounting updateAuthenticatedUsers() globally as the minimal fix.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines