### PR TITLE
Fix broken link to wrongsecrets.fly.io

### DIFF
--- a/data/static/codefixes/weakPasswordChallenge.info.yml
+++ b/data/static/codefixes/weakPasswordChallenge.info.yml
@@ -1,7 +1,7 @@
 fixes:
   - id: 1
     explanation: "According to NIST-800-63B, passwords (Memorized Secrets) should have at least eight characters to prevent 'online attacks'. Furthermore, NIST-800-63B requires that passwords don't appear in common dictionaries.
-If you want to have more fun with secrets, check out OWASP Wrong Secrets at https://wrongsecrets.fly.dev/, specially challenge 16 and 23."
+If you want to have more fun with secrets, check out OWASP Wrong Secrets at https://www.wrongsecrets.com, specially challenge 16 and 23."
   - id: 2
     explanation: "According to NIST-800-63B, passwords (Memorized Secrets) should have at least eight characters to prevent 'online attacks'. Usage of special character tests is not appropriate (anymore) because users tend to find known workarounds like notes with passwords or adding an exclamation mark at the end to add a special character."
   - id: 3


### PR DESCRIPTION

### Description

The "Password Strength" coding challenge links to https://wrongsecrets.fly.io, but that instance is no longer running. Evidence gathered from the Wayback Machine suggests that the instance in question was retired [some time around September 2023](https://web.archive.org/web/20230914073700/http://owasp.org/www-project-wrongsecrets/). [The official page for the OWASP WrongSecrets project](https://owasp.org/www-project-wrongsecrets/) now links to https://www.wrongsecrets.com.

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
