### PR TITLE
Fix description of 'Extra Language' challenge

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -386,7 +386,7 @@
   category: 'Broken Anti Automation'
   tags:
     - Brute Force
-  description: 'First you should find out how the languages are technically changed in the user interface.'
+  description: 'Retrieve the language file that never made it into production.'
   difficulty: 5
   hints:
     - 'First you should find out how the languages are technically changed in the user interface.'


### PR DESCRIPTION
Commit b5efaae0536d69efcb766f5423d9a29b52c107c9 [updated the description of the 'Extra Language' by mistake](https://github.com/juice-shop/juice-shop/commit/b5efaae0536d69efcb766f5423d9a29b52c107c9#diff-13f2640767dc992693e5fd23d94e192f3bdc40cfb942fe44bd47728c4ad45806L405). This commit remedies that.

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
