### PR TITLE
Refactor isAuthorized and enhance authorize functions

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -51,9 +51,32 @@ export const cutOffPoisonNullByte = (str: string) => {
   return str
 }
 
-export const isAuthorized = () => expressJwt(({ secret: publicKey }) as any)
-export const denyAll = () => expressJwt({ secret: '' + Math.random() } as any)
-export const authorize = (user = {}) => jwt.sign(user, privateKey, { expiresIn: '6h', algorithm: 'RS256' })
+// Updated isAuthorized implementation
+export const isAuthorized = () => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const token = req.headers.authorization ? req.headers.authorization.split(' ')[1] : req.cookies.token
+    // Reject request if no JWT
+    if (!token) {
+      return res.status(401).json({ status: 'error', message: 'You need to be logged in to perform this action.' })
+    } 
+    const decodedJws = jws.decode(token)
+    if (decodedJws?.header.alg !== jws.ALGORITHMS[3]) {
+      return res.status(401).json({ status: 'error', message: 'Token signature error'})
+    } else {
+      // Verify signature using RSA 256, or HMAC 256
+      jwt.verify(token, publicKey, { audience: 'web', issuer: 'juice-shop', algorithms: ['HS256', 'RS256']  }, function (err, decoded) {
+        if (err) {
+          return res.status(401).json({ status: 'error', message: 'You need to be logged in to perform this action.' })
+        } else {
+          next()
+        }
+      })
+    }
+  }
+}
+// Add issuer, audience claims to our JWT creation
+export const authorize = (user = {}) => jwt.sign(user, privateKey, { expiresIn: '6h', algorithm: 'RS256', issuer: 'juice-shop', audience: 'web' })
+
 export const verify = (token: string) => token ? (jws.verify as ((token: string, secret: string) => boolean))(token, publicKey) : false
 export const decode = (token: string) => { return jws.decode(token)?.payload }
 


### PR DESCRIPTION
Updated the isAuthorized function to include JWT verification and error handling. Enhanced the authorize function to include issuer and audience claims.

<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-days or even
∞ ban from interacting with the project depending on reoccurrence and severity.
You can find more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [ ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
