### PR TITLE
Improve wording of Fix 1 for 'Allowlist Bypass' challenge

### DIFF
--- a/data/static/codefixes/redirectChallenge.info.yml
+++ b/data/static/codefixes/redirectChallenge.info.yml
@@ -6,7 +6,7 @@ fixes:
   - id: 3
     explanation: "HTML-escaping is completely wrong in this situation because the code is dealing with URLs and not HTML input."
   - id: 4
-    explanation: "Using indexOf allowed any URLs as long as they contained any allow-listed URL, even if it just would be as a parameter. Replacing this with an actual equality check mitigates this lapse and makes the redirect only work for allow-listed URLs."
+    explanation: "Using includes allowed any URLs as long as they contained any allow-listed URL, even if it just would be as a parameter. Replacing this with a strict equality check mitigates this lapse and makes the redirect only work for allow-listed URLs."
 hints:
   - "You should take a close look at how this code checks for allowed vs. forbidded URLs to redirect to."
   - "Try to play through how the logical operators and used standard functions work in this situation."


### PR DESCRIPTION
### Description

The text of Fix 1 for the 'Allowlist Bypass' coding challenge is outdated: it references the `indexOf` method, which the implementation of the allowlist no longer relies on since commit 338c131d4f5bd252bc46e06d96235c8a8ade7a45.

This commit improves the text of Fix 1 accordingly.

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
