### PR TITLE
fix: make bid optional in afterLogin to remove ts-expect-error suppression

### DIFF
--- a/routes/login.ts
+++ b/routes/login.ts
@@ -16,7 +16,7 @@ import * as utils from '../lib/utils'
 
 // vuln-code-snippet start loginAdminChallenge loginBenderChallenge loginJimChallenge
 export function login () {
-  function afterLogin (user: { data: User, bid: number }, res: Response, next: NextFunction) {
+  function afterLogin (user: { data: User, bid?: number }, res: Response, next: NextFunction) { 
     verifyPostLoginChallenges(user) // vuln-code-snippet hide-line
     BasketModel.findOrCreate({ where: { UserId: user.data.id } })
       .then(([basket]: [BasketModel, boolean]) => {
@@ -45,7 +45,6 @@ export function login () {
             }
           })
         } else if (user.data?.id) {
-          // @ts-expect-error FIXME some properties missing in user - vuln-code-snippet hide-line
           afterLogin(user, res, next)
         } else {
           res.status(401).send(res.__('Invalid email or password.'))


### PR DESCRIPTION
Makes `bid` optional in the `afterLogin` function user type so the unnecessary `@ts-expect-error` suppression can be removed.

This improves type consistency in the login route while preserving existing behavior.

Resolved or fixed issue: #3399

