### PR TITLE
fix: make bid optional in afterLogin and remove ts-expect-error

### DIFF
--- a/routes/login.ts
+++ b/routes/login.ts
@@ -16,7 +16,7 @@ import * as utils from '../lib/utils'
 
 // vuln-code-snippet start loginAdminChallenge loginBenderChallenge loginJimChallenge
 export function login () {
-  function afterLogin (user: { data: User, bid: number }, res: Response, next: NextFunction) {
+  function afterLogin (user: { data: User, bid?: number }, res: Response, next: NextFunction) {
     verifyPostLoginChallenges(user) // vuln-code-snippet hide-line
     BasketModel.findOrCreate({ where: { UserId: user.data.id } })
       .then(([basket]: [BasketModel, boolean]) => {
@@ -45,8 +45,7 @@ export function login () {
             }
           })
         } else if (user.data?.id) {
-          // @ts-expect-error FIXME some properties missing in user - vuln-code-snippet hide-line
-          afterLogin(user, res, next)
+          afterLogin(user as { data: User, bid?: number }, res, next)
         } else {
           res.status(401).send(res.__('Invalid email or password.'))
         }


### PR DESCRIPTION
### Description

Made `bid` optional in the `afterLogin` function signature in `routes/login.ts` 
to fix a typing inconsistency where `bid` was typed as required but the function 
was called before `bid` was attached to the user object.

**Changes made:**
- Changed `user: { data: User, bid: number }` → `user: { data: User, bid?: number }` in the `afterLogin` signature
- Replaced `// @ts-expect-error FIXME some properties missing in user` suppression with an explicit type assertion `user as { data: User, bid?: number }` at the call site

This aligns the type definition with actual runtime behavior, where `bid` is 
assigned **inside** `afterLogin` via `user.bid = basket.id`, and allows removal 
of the `@ts-expect-error` directive entirely.

Resolved or fixed issue: #3399

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
