### PR TITLE
fix(metrics): initialize metrics route in app bootstrap

### DIFF
--- a/routes/metrics.ts
+++ b/routes/metrics.ts
@@ -142,70 +142,76 @@ export function observeMetrics () {
     labelNames: ['type']
   })
 
-  const updateLoop = () => setInterval(() => {
-    void (async () => {
-      try {
-        const version = utils.version()
-        const { major, minor, patch } = version.match(/(?<major>\d+).(?<minor>\d+).(?<patch>\d+)/).groups
-        versionMetrics.set({ version, major, minor, patch }, 1)
+  const updateMetrics = async () => {
+    try {
+      const version = utils.version()
+      const { major, minor, patch } = version.match(/(?<major>\d+).(?<minor>\d+).(?<patch>\d+)/).groups
+      versionMetrics.set({ version, major, minor, patch }, 1)
 
-        const challengeStatuses = new Map()
-        const challengeCount = new Map()
+      const challengeStatuses = new Map()
+      const challengeCount = new Map()
 
-        for (const { difficulty, category, solved } of Object.values<ChallengeModel>(challenges)) {
-          const key = `${difficulty}:${category}`
+      for (const { difficulty, category, solved } of Object.values<ChallengeModel>(challenges)) {
+        const key = `${difficulty}:${category}`
 
-          // Increment by one if solved, when not solved increment by 0. This ensures that even unsolved challenges are set to , instead of not being set at all
-          challengeStatuses.set(key, (challengeStatuses.get(key) || 0) + (solved ? 1 : 0))
-          challengeCount.set(key, (challengeCount.get(key) || 0) + 1)
-        }
-
-        for (const key of challengeStatuses.keys()) {
-          const [difficulty, category] = key.split(':', 2)
-
-          challengeSolvedMetrics.set({ difficulty, category }, challengeStatuses.get(key))
-          challengeTotalMetrics.set({ difficulty, category }, challengeCount.get(key))
-        }
-
-        const [codingChallenges, findItCount, fixItCount, solvedCount, orderCount, reviewCount, customerCount, deluxeCount, totalUserCount, totalBalance, feedbackCount, complaintCount] = await Promise.all([
-          retrieveChallengesWithCodeSnippet(),
-          ChallengeModel.count({ where: { codingChallengeStatus: { [Op.eq]: 1 } } }),
-          ChallengeModel.count({ where: { codingChallengeStatus: { [Op.eq]: 2 } } }),
-          ChallengeModel.count({ where: { codingChallengeStatus: { [Op.ne]: 0 } } }),
-          ordersCollection.count({}),
-          reviewsCollection.count({}),
-          UserModel.count({ where: { role: { [Op.eq]: 'customer' } } }),
-          UserModel.count({ where: { role: { [Op.eq]: 'deluxe' } } }),
-          UserModel.count(),
-          WalletModel.sum('balance'),
-          FeedbackModel.count(),
-          ComplaintModel.count()
-        ])
-
-        codingChallengesProgressMetrics.set({ phase: 'find it' }, findItCount)
-        codingChallengesProgressMetrics.set({ phase: 'fix it' }, fixItCount)
-        codingChallengesProgressMetrics.set({ phase: 'unsolved' }, codingChallenges.length - solvedCount)
-
-        cheatScoreMetrics.set(totalCheatScore())
-        accuracyMetrics.set({ phase: 'find it' }, accuracy.totalFindItAccuracy())
-        accuracyMetrics.set({ phase: 'fix it' }, accuracy.totalFixItAccuracy())
-
-        if (orderCount) orderMetrics.set(orderCount)
-        if (reviewCount) interactionsMetrics.set({ type: 'review' }, reviewCount)
-        if (customerCount) userMetrics.set({ type: 'standard' }, customerCount)
-        if (deluxeCount) userMetrics.set({ type: 'deluxe' }, deluxeCount)
-        if (totalUserCount) userTotalMetrics.set(totalUserCount)
-        if (totalBalance) walletMetrics.set(totalBalance)
-        if (feedbackCount) interactionsMetrics.set({ type: 'feedback' }, feedbackCount)
-        if (complaintCount) interactionsMetrics.set({ type: 'complaint' }, complaintCount)
-      } catch (e: unknown) {
-        logger.warn('Error during metrics update loop: + ' + utils.getErrorMessage(e))
+        // Increment by one if solved, when not solved increment by 0. This ensures that even unsolved challenges are set to , instead of not being set at all
+        challengeStatuses.set(key, (challengeStatuses.get(key) || 0) + (solved ? 1 : 0))
+        challengeCount.set(key, (challengeCount.get(key) || 0) + 1)
       }
-    })()
-  }, 5000)
+
+      for (const key of challengeStatuses.keys()) {
+        const [difficulty, category] = key.split(':', 2)
+
+        challengeSolvedMetrics.set({ difficulty, category }, challengeStatuses.get(key))
+        challengeTotalMetrics.set({ difficulty, category }, challengeCount.get(key))
+      }
+
+      const [codingChallenges, findItCount, fixItCount, solvedCount, orderCount, reviewCount, customerCount, deluxeCount, totalUserCount, totalBalance, feedbackCount, complaintCount] = await Promise.all([
+        retrieveChallengesWithCodeSnippet(),
+        ChallengeModel.count({ where: { codingChallengeStatus: { [Op.eq]: 1 } } }),
+        ChallengeModel.count({ where: { codingChallengeStatus: { [Op.eq]: 2 } } }),
+        ChallengeModel.count({ where: { codingChallengeStatus: { [Op.ne]: 0 } } }),
+        ordersCollection.count({}),
+        reviewsCollection.count({}),
+        UserModel.count({ where: { role: { [Op.eq]: 'customer' } } }),
+        UserModel.count({ where: { role: { [Op.eq]: 'deluxe' } } }),
+        UserModel.count(),
+        WalletModel.sum('balance'),
+        FeedbackModel.count(),
+        ComplaintModel.count()
+      ])
+
+      codingChallengesProgressMetrics.set({ phase: 'find it' }, findItCount)
+      codingChallengesProgressMetrics.set({ phase: 'fix it' }, fixItCount)
+      codingChallengesProgressMetrics.set({ phase: 'unsolved' }, codingChallenges.length - solvedCount)
+
+      cheatScoreMetrics.set(totalCheatScore())
+      accuracyMetrics.set({ phase: 'find it' }, accuracy.totalFindItAccuracy())
+      accuracyMetrics.set({ phase: 'fix it' }, accuracy.totalFixItAccuracy())
+
+      if (orderCount) orderMetrics.set(orderCount)
+      if (reviewCount) interactionsMetrics.set({ type: 'review' }, reviewCount)
+      if (customerCount) userMetrics.set({ type: 'standard' }, customerCount)
+      if (deluxeCount) userMetrics.set({ type: 'deluxe' }, deluxeCount)
+      if (totalUserCount) userTotalMetrics.set(totalUserCount)
+      if (totalBalance) walletMetrics.set(totalBalance)
+      if (feedbackCount) interactionsMetrics.set({ type: 'feedback' }, feedbackCount)
+      if (complaintCount) interactionsMetrics.set({ type: 'complaint' }, complaintCount)
+    } catch (e: unknown) {
+      logger.warn('Error during metrics update loop: + ' + utils.getErrorMessage(e))
+    }
+  }
+
+  const updateLoop = () => {
+    void updateMetrics()
+    return setInterval(() => {
+      void updateMetrics()
+    }, 5000)
+  }
 
   return {
     register,
+    updateMetrics,
     updateLoop
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -208,6 +208,9 @@ function configureApp (app: ReturnType<typeof express>, seq: typeof sequelize) {
   /* Increase request counter metric for every request */
   app.use(metrics.observeRequestMetricsMiddleware())
 
+  /* Serve metrics */
+  app.get('/metrics', utils.asyncHandler(metrics.serveMetrics())) // vuln-code-snippet vuln-line exposedMetricsChallenge
+
   /* Security Policy */
   const securityTxtExpiration = new Date()
   securityTxtExpiration.setFullYear(securityTxtExpiration.getFullYear() + 1)
@@ -719,10 +722,8 @@ while (!expectedModels.every(model => Object.keys(sequelize.models).includes(mod
 logger.info(`Entity models ${colors.bold(Object.keys(sequelize.models).length.toString())} of ${colors.bold(expectedModels.length.toString())} are initialized (${colors.green('SUCCESS')})`)
 
 // vuln-code-snippet start exposedMetricsChallenge
-/* Serve metrics */
 let metricsUpdateLoop: any
 const Metrics = metrics.observeMetrics() // vuln-code-snippet neutral-line exposedMetricsChallenge
-app.get('/metrics', utils.asyncHandler(metrics.serveMetrics())) // vuln-code-snippet vuln-line exposedMetricsChallenge
 errorhandler.title = `${config.get<string>('application.name')} (Express ${utils.version('express')})`
 
 export async function start (readyCallback?: () => void) {
@@ -734,6 +735,7 @@ export async function start (readyCallback?: () => void) {
   const port = process.env.PORT ?? config.get('server.port')
   process.env.BASE_PATH = process.env.BASE_PATH ?? config.get('server.basePath')
 
+  await Metrics.updateMetrics()
   metricsUpdateLoop = Metrics.updateLoop() // vuln-code-snippet neutral-line exposedMetricsChallenge
 
   server.listen(port, () => {
@@ -774,11 +776,13 @@ export async function createApp (options?: { inMemoryDb?: boolean }) {
     setSequelize(seq)
   }
   Prometheus.register.clear()
+  const TestMetrics = metrics.observeMetrics()
   const testApp = express()
   testApp.set('view engine', 'hbs')
   configureApp(testApp, seq)
   await seq.sync({ force: true })
   await datacreator()
+  await TestMetrics.updateMetrics()
   return { app: testApp, sequelize: seq }
 }
 


### PR DESCRIPTION
### Description

Initialize Prometheus metrics during app bootstrap and expose /metrics consistently in test/in-memory startup so metric families are available reliably.

Resolved or fixed issue: none

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: GitHub Copilot
    - LLMs and versions: GPT-5.3-Codex
    - Prompts: Diagnose missing metrics registration in in-memory/test startup, apply minimal fix, validate /metrics output, and prepare compliant PR metadata.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
