### PR TITLE
refactor: remove redundant contains utility helper

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -45,7 +45,7 @@ export const hmac = (data: string) => crypto.createHmac('sha256', 'pa4qacea4VK9t
 
 export const cutOffPoisonNullByte = (str: string) => {
   const nullByte = '%00'
-  if (utils.contains(str, nullByte)) {
+  if (str?.includes(nullByte)) {
     return str.substring(0, str.indexOf(nullByte))
   }
   return str

--- a/lib/startup/registerWebsocketEvents.ts
+++ b/lib/startup/registerWebsocketEvents.ts
@@ -4,7 +4,6 @@
  */
 
 import config from 'config'
-import * as utils from '../utils'
 import { Server } from 'socket.io'
 import { notifications, challenges } from '../../data/datacache'
 import * as challengeUtils from '../challengeUtils'
@@ -39,8 +38,8 @@ const registerWebsocketEvents = (server: any) => {
     })
 
     socket.on('verifyLocalXssChallenge', (data: any) => {
-      challengeUtils.solveIf(challenges.localXssChallenge, () => { return utils.contains(data, '<iframe src="javascript:alert(`xss`)">') })
-      challengeUtils.solveIf(challenges.xssBonusChallenge, () => { return utils.contains(data, config.get('challenges.xssBonusPayload')) })
+      challengeUtils.solveIf(challenges.localXssChallenge, () => { return data?.includes('<iframe src="javascript:alert(`xss`)">') })
+      challengeUtils.solveIf(challenges.xssBonusChallenge, () => { return data?.includes(config.get('challenges.xssBonusPayload')) })
     })
 
     socket.on('verifySvgInjectionChallenge', (data: any) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -41,14 +41,12 @@ export const startsWith = (str: string, prefix: string) => str ? str.indexOf(pre
 
 export const endsWith = (str?: string, suffix?: string) => (str && suffix) ? str.includes(suffix, str.length - suffix.length) : false
 
-export const contains = (str: string, element: string) => str ? str.includes(element) : false // TODO Inline all usages as this function is not adding any functionality to String.includes
-
 export const containsEscaped = function (str: string, element: string) {
-  return contains(str, element.replace(/"/g, '\\"'))
+  return str ? str.includes(element.replace(/"/g, '\\"')) : false
 }
 
 export const containsOrEscaped = function (str: string, element: string) {
-  return contains(str, element) || containsEscaped(str, element)
+  return (str ? str.includes(element) : false) || containsEscaped(str, element)
 }
 
 export const unquote = function (str: string) {
@@ -108,7 +106,7 @@ export const toISO8601 = (date: Date) => {
 
 export const extractFilename = (url: string) => {
   let file = decodeURIComponent(url.substring(url.lastIndexOf('/') + 1))
-  if (contains(file, '?')) {
+  if (file.includes('?')) {
     file = file.substring(0, file.indexOf('?'))
   }
   return file

--- a/models/feedback.ts
+++ b/models/feedback.ts
@@ -44,8 +44,7 @@ const FeedbackModelInit = (sequelize: Sequelize) => {
           if (utils.isChallengeEnabled(challenges.persistedXssFeedbackChallenge)) {
             sanitizedComment = security.sanitizeHtml(comment)
             challengeUtils.solveIf(challenges.persistedXssFeedbackChallenge, () => {
-              return utils.contains(
-                sanitizedComment,
+              return sanitizedComment?.includes(
                 '<iframe src="javascript:alert(`xss`)">'
               )
             })

--- a/models/product.ts
+++ b/models/product.ts
@@ -45,8 +45,7 @@ const ProductModelInit = (sequelize: Sequelize) => {
         set (description: string) {
           if (utils.isChallengeEnabled(challenges.restfulXssChallenge)) {
             challengeUtils.solveIf(challenges.restfulXssChallenge, () => {
-              return utils.contains(
-                description,
+              return description?.includes(
                 '<iframe src="javascript:alert(`xss`)">'
               )
             })

--- a/models/user.ts
+++ b/models/user.ts
@@ -60,8 +60,7 @@ const UserModelInit = (sequelize: Sequelize) => { // vuln-code-snippet start wea
         set (email: string) {
           if (utils.isChallengeEnabled(challenges.persistedXssUserChallenge)) {
             challengeUtils.solveIf(challenges.persistedXssUserChallenge, () => {
-              return utils.contains(
-                email,
+              return email?.includes(
                 '<iframe src="javascript:alert(`xss`)">'
               )
             })

--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -87,7 +87,7 @@ function handleXmlUpload ({ file }: Request, res: Response, next: NextFunction) 
         next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + utils.trunc(xmlString, 400) + ' (' + file.originalname + ')'))
       } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : String(err)
-        if (utils.contains(errorMessage, 'Script execution timed out')) {
+        if (errorMessage.includes('Script execution timed out')) {
           if (challengeUtils.notSolved(challenges.xxeDosChallenge)) {
             challengeUtils.solve(challenges.xxeDosChallenge)
           }
@@ -119,7 +119,7 @@ function handleYamlUpload ({ file }: Request, res: Response, next: NextFunction)
         next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + utils.trunc(yamlString, 400) + ' (' + file.originalname + ')'))
       } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : String(err)
-        if (utils.contains(errorMessage, 'Invalid string length') || utils.contains(errorMessage, 'Script execution timed out')) {
+        if (errorMessage.includes('Invalid string length') || errorMessage.includes('Script execution timed out')) {
           if (challengeUtils.notSolved(challenges.yamlBombChallenge)) {
             challengeUtils.solve(challenges.yamlBombChallenge)
           }

--- a/routes/search.ts
+++ b/routes/search.ts
@@ -29,7 +29,7 @@ export function searchProducts () {
             const users = utils.queryResultToJson(data)
             if (users.data?.length) {
               for (let i = 0; i < users.data.length; i++) {
-                solved = solved && utils.containsOrEscaped(dataString, users.data[i].email) && utils.contains(dataString, users.data[i].password)
+                solved = solved && utils.containsOrEscaped(dataString, users.data[i].email) && dataString.includes(users.data[i].password)
                 if (!solved) {
                   break
                 }

--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -14,7 +14,7 @@ export function trackOrder () {
     // Truncate id to avoid unintentional RCE
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
-    challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
+    challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return id.includes('<iframe src="javascript:alert(`xss`)">') })
     db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -88,7 +88,7 @@ export function getUserProfile () {
       const CSP = `img-src 'self' ${user?.profileImage}; script-src 'self' 'unsafe-eval'`
 
       challengeUtils.solveIf(challenges.usernameXssChallenge, () => {
-        return username && user?.profileImage.match(/;[ ]*script-src(.)*'unsafe-inline'/g) !== null && utils.contains(username, '<script>alert(`xss`)</script>')
+        return username && user?.profileImage.match(/;[ ]*script-src(.)*'unsafe-inline'/g) !== null && username.includes('<script>alert(`xss`)</script>')
       })
 
       res.set({

--- a/routes/verify.ts
+++ b/routes/verify.ts
@@ -209,8 +209,8 @@ function changeProductChallenge (osaft: Product) {
       }
     }
     if (urlForProductTamperingChallenge) {
-      if (!utils.contains(osaft.description, `${urlForProductTamperingChallenge}`)) {
-        if (utils.contains(osaft.description, `<a href="${config.get<string>('challenges.overwriteUrlForProductTamperingChallenge')}" target="_blank">`)) {
+      if (!osaft.description.includes(`${urlForProductTamperingChallenge}`)) {
+        if (osaft.description.includes(`<a href="${config.get<string>('challenges.overwriteUrlForProductTamperingChallenge')}" target="_blank">`)) {
           challengeUtils.solve(challenges.changeProductChallenge)
         }
       }

--- a/routes/videoHandler.ts
+++ b/routes/videoHandler.ts
@@ -54,7 +54,7 @@ export const promotionVideo = () => {
       let template = buf.toString()
       const subs = getSubsFromFile()
 
-      challengeUtils.solveIf(challenges.videoXssChallenge, () => { return utils.contains(subs, '</script><script>alert(`xss`)</script>') })
+      challengeUtils.solveIf(challenges.videoXssChallenge, () => { return subs.includes('</script><script>alert(`xss`)</script>') })
 
       const themeKey = config.get<string>('application.theme') as keyof typeof themes
       const theme = themes[themeKey] || themes['bluegrey-lightgreen']

--- a/server.ts
+++ b/server.ts
@@ -521,7 +521,7 @@ function configureApp (app: ReturnType<typeof express>, seq: typeof sequelize) {
       resource.list.fetch.after((req: Request, res: Response, context: { instance: string | any[], continue: any }) => {
         for (let i = 0; i < context.instance.length; i++) {
           let description = context.instance[i].description
-          if (utils.contains(description, '<em>(This challenge is <strong>')) {
+          if (description.includes('<em>(This challenge is <strong>')) {
             const warning = description.substring(description.indexOf(' <em>(This challenge is <strong>'))
             description = description.substring(0, description.indexOf(' <em>(This challenge is <strong>'))
             context.instance[i].description = req.__(description) + req.__(warning)

--- a/test/server/utilsSpec.ts
+++ b/test/server/utilsSpec.ts
@@ -185,16 +185,6 @@ describe('utils', () => {
     })
   })
 
-  describe('contains', () => {
-    it('accepts string containing another string', () => {
-      expect(utils.contains('Bla Blubb', 'la Bl')).to.equal(true)
-    })
-
-    it('rejects string containing another string', () => {
-      expect(utils.contains('Bla Blubb', 'Lala')).to.equal(false)
-    })
-  })
-
   describe('toISO8601', () => {
     it('converts date to ISO 8601 representation', () => {
       expect(utils.toISO8601(new Date('2025-12-15T00:00:00Z'))).to.equal('2025-12-15')


### PR DESCRIPTION
### Description
This PR simplifies the codebase by removing the custom `utils.contains` utility function in favor of the native ES6 `String.prototype.includes()`.

The `utils.contains` method was a wrapper around standard string matching that didn't provide additional value. By migrating to the native `.includes()` method across models, routes, and server code, this change reduces overhead, modernizes the code, and improves overall readability.

Additionally, the corresponding unit tests for `utils.contains` in `test/server/utilsSpec.ts` have been removed.

Resolved or fixed issue: none

### AI Tool Disclosure
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:

- **AI Tools:** Gemini 3 Flash
- **LLMs and versions:** Gemini 3 Flash
- **Prompts:** Assisted in drafting this PR description and verifying codebase linting/safety checks locally.

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
