### PR TITLE
[Security Fix] SAST: Base64 High Entropy String

### DIFF
--- a/data/static/users.yml
+++ b/data/static/users.yml
@@ -85,7 +85,7 @@
 -
   email: bjoern.kimminich@gmail.com
   username: bkimminich
-  password: 'bW9jLmxpYW1nQGhjaW5pbW1pay5ucmVvamI='
+  password: 'bW9jLmxpYW1nQGhjaW5pbW1pay5ucmVvamI=' # checkov:skip=CKV_SECRET_6 Intentional vulnerable-by-design seed credential for OWASP Juice Shop 'Reset Bjoern's Password' challenge; not a real secret.
   customDomain: true
   key: bjoernGoogle
   role: 'admin'


### PR DESCRIPTION
## Security Fix

**Type:** SAST
**Generated by:** AI-Powered Fix Generator
**Finding:** Base64 High Entropy String
**Rule:** CKV_SECRET_6 (checkov)
**File:** `data/static/users.yml` (line 88)
**Severity:** HIGH

### Explanation
The flagged base64 string on line 88 (`bW9jLmxpYW1nQGhjaW5pbW1pay5ucmVvamI=`) is the email `bjoern.kimminich@gmail.com` reversed and base64-encoded. It is an intentional vulnerable-by-design seed credential used by OWASP Juice Shop's "Reset Bjoern's Password" hacking challenge — not a leaked production secret. The entire `data/static/users.yml` file is deliberate training data, and ~25 other plaintext passwords in it are equally "secrets" that simply didn't trigger this particular high-entropy/base64 rule.

Because any genuine remediation (rotating, removing, or relocating the credential) would break documented product functionality and challenge solutions, the minimal change emitted here is an inline `# checkov:skip=CKV_SECRET_6` suppression with a justification comment. This clears the SAST finding without altering runtime behavior. However, the user should explicitly choose between (A) suppression as done here, (B) replacing the literal with an equivalent non-base64 representation plus seeding-code changes, or (C) removing the field and accepting the broken challenge. I recommend reviewing this decision before merging rather than treating the suppression as a final answer.

### Changes
- `data/static/users.yml`: Add an inline Checkov suppression with justification for the intentional OWASP Juice Shop training credential. This is the least-invasive option that preserves the documented hacking challenge and all dependent tests, while explicitly acknowledging the finding as a known, accepted, vulnerable-by-design artifact. NOTE: This is a placeholder change pending user direction — see explanation. The user should confirm whether suppression (A), replacement (B), or removal (C) is desired before merging.

### Test Suggestions
- Run Checkov against data/static/users.yml and confirm CKV_SECRET_6 no longer reports on line 88.
- Run the OWASP Juice Shop challenge suite and confirm the 'Reset Bjoern's Password' challenge and Bjoern-Google admin login still pass.
- Confirm YAML parsing of users.yml is unaffected by the trailing comment (load the file with js-yaml or equivalent and assert the bjoernGoogle user's password value is unchanged).