### PR TITLE
Fix inconsistent afterLogin typings in login route

### DIFF
--- a/routes/login.ts
+++ b/routes/login.ts
@@ -16,7 +16,7 @@ import * as utils from '../lib/utils'
 
 // vuln-code-snippet start loginAdminChallenge loginBenderChallenge loginJimChallenge
 export function login () {
-  function afterLogin (user: { data: User, bid: number }, res: Response, next: NextFunction) {
+  function afterLogin (user: { data: User, bid?: number }, res: Response, next: NextFunction) {
     verifyPostLoginChallenges(user) // vuln-code-snippet hide-line
     BasketModel.findOrCreate({ where: { UserId: user.data.id } })
       .then(([basket]: [BasketModel, boolean]) => {
@@ -45,7 +45,6 @@ export function login () {
             }
           })
         } else if (user.data?.id) {
-          // @ts-expect-error FIXME some properties missing in user - vuln-code-snippet hide-line
           afterLogin(user, res, next)
         } else {
           res.status(401).send(res.__('Invalid email or password.'))


### PR DESCRIPTION
## Summary

Relax the `bid` parameter of `afterLogin` in `routes/login.ts` from a required `number` to an optional `number`, so the function's type signature matches the runtime behavior. Callers may invoke `afterLogin` before `bid` has been attached to the user object (see the `else if (user.data?.id)` branch), which today is masked by a `// @ts-expect-error FIXME` suppression. With the type aligned, the suppression is no longer required and is removed.

This matches the cleanup approach proposed in the issue:
> Change the function signature from `user: { data: User, bid: number }` to `user: { data: User, bid?: number }` — would align the type definition with actual runtime behavior and allow removal of the `// @ts-expect-error` directive entirely.

Closes #3399.

## Changes

- `routes/login.ts:19` — `bid: number` → `bid?: number` in the `afterLogin` parameter type.
- `routes/login.ts:48` — removed the `// @ts-expect-error FIXME some properties missing in user` line, which is no longer needed once the type accepts an optional `bid`.

## Verification

- TypeScript no longer needs the suppression at the call site.
- Runtime behavior is unchanged (`user.bid = basket.id` continues to assign the value once the basket is resolved; assigning to an optional property is valid).
- The `vuln-code-snippet` directives elsewhere in the file are untouched (only the comment carrying the suppression is removed).