### PR TITLE
Fix inconsistent afterLogin typings in login route

### DIFF
--- a/routes/login.ts
+++ b/routes/login.ts
@@ -16,7 +16,7 @@ import * as utils from '../lib/utils'
 
 // vuln-code-snippet start loginAdminChallenge loginBenderChallenge loginJimChallenge
 export function login () {
-  function afterLogin (user: { data: User, bid: number }, res: Response, next: NextFunction) {
+  function afterLogin (user: { data: User, bid?: number }, res: Response, next: NextFunction) {
     verifyPostLoginChallenges(user) // vuln-code-snippet hide-line
     BasketModel.findOrCreate({ where: { UserId: user.data.id } })
       .then(([basket]: [BasketModel, boolean]) => {
@@ -45,7 +45,6 @@ export function login () {
             }
           })
         } else if (user.data?.id) {
-          // @ts-expect-error FIXME some properties missing in user - vuln-code-snippet hide-line
           afterLogin(user, res, next)
         } else {
           res.status(401).send(res.__('Invalid email or password.'))


### PR DESCRIPTION
### Description

This PR fixes the typing inconsistency in `routes/login.ts` reported in #3399.

The `afterLogin` function previously typed its `user` parameter with `bid` as a required `number`, while the actual call site (`else if (user.data?.id) { afterLogin(user, res, next) }`) invokes the function before `bid` has been attached to the user object. The mismatch was masked by a `// @ts-expect-error FIXME some properties missing in user` suppression directly above the call.

This PR aligns the type definition with runtime behavior by changing `bid: number` to `bid?: number` (optional) in the `afterLogin` parameter signature, and removes the now-unnecessary `// @ts-expect-error` suppression. The runtime behavior is unchanged: `user.bid = basket.id` continues to attach the value once `BasketModel.findOrCreate` resolves, and assigning to an optional property is valid in TypeScript.

This matches the cleanup approach proposed in the issue:

> Change the function signature from `user: { data: User, bid: number }` to `user: { data: User, bid?: number }` — would align the type definition with actual runtime behavior and allow removal of the `// @ts-expect-error` directive entirely.

The `vuln-code-snippet` markers elsewhere in the file are untouched.

Resolved or fixed issue: #3399

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: Anthropic Claude Code (CLI)
    - LLMs and versions: Claude Opus 4.7 (1M context)
    - Prompts: "Walk Juice Shop issue #3399 end-to-end: read the issue body and the referenced code in `routes/login.ts`, propose the minimal type-narrowing change implied by the issue (`bid: number` → `bid?: number`), remove the now-unnecessary `// @ts-expect-error` line, and prepare a PR against `develop` that complies with the project's contributing guidelines (AI Tool Disclosure + Affirmation + DCO sign-off)."

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
