### PR TITLE
fix(frontend): substitute {{range}} placeholder in INVALID_MOBILE_NUMBER error (#3433)

### DIFF
--- a/frontend/src/app/address-create/address-create.component.html
+++ b/frontend/src/app/address-create/address-create.component.html
@@ -38,10 +38,8 @@
             </mat-error>
           }
           @if (numberControl.invalid && (numberControl.errors.min || numberControl.errors.max)) {
-            <mat-error
-              [translateParams]="{range: '1000000-9999999999'}"
-              >
-              {{ 'INVALID_MOBILE_NUMBER' | translate }}
+            <mat-error>
+              {{ 'INVALID_MOBILE_NUMBER' | translate:{range: '1000000-9999999999'} }}
             </mat-error>
           }
         </mat-form-field>

--- a/frontend/src/app/address-create/address-create.component.spec.ts
+++ b/frontend/src/app/address-create/address-create.component.spec.ts
@@ -235,3 +235,63 @@ describe('AddressCreateComponent', () => {
         expect(component.stateControl.value).toBe('NY')
     })
 })
+
+describe('AddressCreateComponent rendered error messages (issue #3433)', () => {
+    let component: AddressCreateComponent
+    let fixture: ComponentFixture<AddressCreateComponent>
+
+    beforeEach(async () => {
+        const addressServiceStub = {
+            getById: vi.fn().mockReturnValue(of({})),
+            put: vi.fn().mockReturnValue(of({})),
+            save: vi.fn().mockReturnValue(of({}))
+        }
+        const snackBarStub = { open: vi.fn().mockReturnValue(null) }
+
+        await TestBed.configureTestingModule({
+            imports: [
+                RouterTestingModule,
+                TranslateModule.forRoot(),
+                ReactiveFormsModule,
+                MatCardModule,
+                MatFormFieldModule,
+                MatInputModule,
+                MatGridListModule,
+                MatIconModule,
+                MatSnackBarModule,
+                AddressCreateComponent
+            ],
+            providers: [
+                { provide: AddressService, useValue: addressServiceStub },
+                { provide: MatSnackBar, useValue: snackBarStub },
+                provideHttpClient(withInterceptorsFromDi()),
+                provideHttpClientTesting()
+            ]
+        }).compileComponents()
+
+        const translate = TestBed.inject(TranslateService)
+        translate.setTranslation('en', {
+            INVALID_MOBILE_NUMBER: 'Mobile number must match {{range}} format.'
+        })
+        translate.use('en')
+
+        fixture = TestBed.createComponent(AddressCreateComponent)
+        component = fixture.componentInstance
+        fixture.detectChanges()
+    })
+
+    it('should substitute {{range}} in INVALID_MOBILE_NUMBER error', () => {
+        component.numberControl.setValue(1)
+        component.numberControl.markAsTouched()
+        fixture.detectChanges()
+
+        const matErrors = fixture.nativeElement.querySelectorAll('mat-error')
+        const mobileError = Array.from(matErrors).find((e: Element) =>
+            (e.textContent ?? '').toLowerCase().includes('mobile')
+        ) as HTMLElement | undefined
+
+        expect(mobileError).toBeDefined()
+        expect(mobileError!.textContent).not.toContain('{{range}}')
+        expect(mobileError!.textContent).toContain('1000000-9999999999')
+    })
+})


### PR DESCRIPTION
### Description

The mobile-number out-of-range validation error on the address-create form rendered the literal text `{{range}}` instead of substituting the parameter value — the bug reported at #3433. The template at `frontend/src/app/address-create/address-create.component.html:40-45` used the `translate` pipe without inline params, and the existing `[translateParams]` binding was on `<mat-error>` (which is not a translate-directive host), making it dead code.

**Fix (2-line template change, no i18n string changes):**
- Pass `{range: '1000000-9999999999'}` inline to the `translate` pipe so the placeholder is substituted at render.
- Remove the dead `[translateParams]` binding on `<mat-error>`.

**Regression test added** (`frontend/src/app/address-create/address-create.component.spec.ts`): a new `describe` block sets up TestBed with a real `TranslateService` + a fake translation containing `{{range}}`, triggers the min-validation error, and asserts the rendered `<mat-error>` text does NOT contain `{{range}}` AND DOES contain `1000000-9999999999`.

Before the fix: the new test fails with `expected ' Mobile number must match {{range}} f…' not to contain '{{range}}'`. After the fix: the new test passes; all 120 frontend test files pass.

**Out of scope, flagged for follow-up:** the validator is `Validators.min(1111111)` but the displayed range is `1000000-9999999999` — a pre-existing display/validator mismatch not mentioned in the issue. A similar `{{range}}` placeholder appears in `INVALID_QUANTITY` (basket-quantity error) — the reporter noted other messages may be similarly affected; separate component, separate PR.

Resolved or fixed issue: #3433

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code (Anthropic CLI)`
    - LLMs and versions: `Claude Opus 4.7 (1M context)`
    - Prompts: `Locate and fix the {{range}}-literal-rendering bug on the address-edit mobile-number error per upstream issue #3433. Apply the minimal template fix that wires ngx-translate parameter substitution through the pipe. Add a regression test asserting rendered DOM substitutes the placeholder.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
