### PR TITLE
feat(challenges): add "Setup Dependent" tag for CSRF and Email Leak (#3434)

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -334,6 +334,8 @@
     - 'This challenge uses an old way which is no longer recommended.'
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/XS_Leaks_Cheat_Sheet.html'
   key: emailLeakChallenge
+  tags:
+    - Setup Dependent
 -
   name: 'Empty User Registration'
   category: 'Improper Input Validation'
@@ -1385,6 +1387,8 @@
     - 'Write the code for the CSRF attack within http://htmledit.squarefree.com and verify that it changes your username.'
   mitigationUrl: 'https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html'
   key: csrfChallenge
+  tags:
+    - Setup Dependent
 -
   name: 'Bonus Payload'
   category: 'XSS'


### PR DESCRIPTION
### Description

The reporter at #3434 requested a new tag to mark challenges whose solvability depends on deployment setup (similar pattern to the existing **Danger Zone** tag). This PR adds the new tag value to the two challenges the reporter explicitly named:

- **CSRF** challenge (`data/static/challenges.yml:1377`) — solvability depends on either an older browser OR a samesite Web origin with XSS/subdomain-takeover vulnerability.
- **Email Leak** challenge (`data/static/challenges.yml:327`) — currently too easily solvable; would benefit from being marked as setup-dependent so trainers can configure the deployment for a more instructive variant.

**Tag-naming convention.** Existing tag values use Title Case + space-separated form (`Danger Zone`, `Good for Demos`, `OSINT`, `Web3`). The new tag follows the same convention as **`Setup Dependent`** (the issue body wrote "setup-dependent" with a hyphen, but the YAML data convention is space-separated). Happy to rename if the maintainers prefer a different form.

**No code change is needed.** The score-board's tag filter dynamically discovers tag values from the loaded challenge set (`frontend/src/app/score-board/components/filter-settings/filter-settings.component.ts:43-57`), so the new tag appears in the filter dropdown at runtime without any code registration.

**Diff:** +4 lines, 2 hunks, 1 file (`data/static/challenges.yml`).

**Out of scope for this PR (flagged for follow-up per reporter's explicit framing).** The reporter's issue body notes: *"the logic for the checking whether the CSRF challenge is solved could be relaxed to only check the forged request is authenticated, cross-origin, and issued by a browser (perhaps by checking the fetch-request metadata headers)"*. The reporter used "could be" — optional follow-up. This is a behavioral change in challenge-success-detection logic (separate file + security-test invariant touch) and is best as a separate PR. Happy to file it as a follow-up if the maintainers confirm the direction.

Resolved or fixed issue: #3434

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code (Anthropic CLI)`
    - LLMs and versions: `Claude Opus 4.7 (1M context)`
    - Prompts: `Read upstream issue #3434 and apply the minimal data-only change — add a "Setup Dependent" tag value to the two challenge entries the reporter named (CSRF + Email Leak). Match the existing tag-naming convention (Title Case + space-separated). Do not change the CSRF challenge logic — defer that to a follow-up PR per the reporter's framing.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
