### PR TITLE
Fix profile username template evaluation

### DIFF
--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -53,18 +53,8 @@ export function getUserProfile () {
 
     if (username?.match(/#{(.*)}/) !== null && utils.isChallengeEnabled(challenges.usernameXssChallenge)) {
       req.app.locals.abused_ssti_bug = true
-      const code = username?.substring(2, username.length - 1)
-      try {
-        if (!code) {
-          throw new Error('Username is null')
-        }
-        username = eval(code) // eslint-disable-line no-eval
-      } catch (err) {
-        username = '\\' + username
-      }
-    } else {
-      username = '\\' + username
     }
+    username = '\\' + username
 
     const themeKey = config.get<string>('application.theme') as keyof typeof themes
     const theme = themes[themeKey] || themes['bluegrey-lightgreen']

--- a/test/api/user-profile.test.ts
+++ b/test/api/user-profile.test.ts
@@ -51,4 +51,25 @@ void describe('/profile', () => {
 
     assert.equal(res.status, 302)
   })
+
+  void it('GET user profile treats username template expressions as text', async () => {
+    const globalWithProfileFlag = globalThis as typeof globalThis & { __juiceProfileEvalExecuted?: boolean }
+    globalWithProfileFlag.__juiceProfileEvalExecuted = false
+
+    await request(app)
+      .post('/profile')
+      .set('Cookie', authHeader.Cookie)
+      .field('username', '#{globalThis.__juiceProfileEvalExecuted = true}')
+      .redirects(0)
+      .expect(302)
+
+    const res = await request(app)
+      .get('/profile')
+      .set(authHeader)
+
+    assert.equal(res.status, 200)
+    assert.equal(globalWithProfileFlag.__juiceProfileEvalExecuted, false)
+
+    delete globalWithProfileFlag.__juiceProfileEvalExecuted
+  })
 })


### PR DESCRIPTION
## Summary

Fixes the top-ranked report finding: stored profile usernames containing `#{...}` were executed server-side by direct `eval` when `/profile` rendered.

This removes the eval path and always treats the stored username as template text while preserving the existing challenge bookkeeping flag when the expression pattern is observed.

## Validation

- `PATH=/Users/eszuhany/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import ./test/api/helpers/test-env.mjs --import tsx --test --test-force-exit test/api/user-profile.test.ts`
  - All `/profile` assertions passed, including the new regression proving `#{globalThis.__juiceProfileEvalExecuted = true}` is not executed.
  - The runner exited nonzero after assertions because the app left async watcher activity that hit `EMFILE: too many open files, watch` in this local checkout.

## Breaking-change risk

| Area | Risk | Notes |
|---|---|---|
| Major version bumps | None | No dependency or runtime version changes. |
| API changes | Medium | Usernames containing Pug-style interpolation are now rendered as text instead of being evaluated. This intentionally disables the server-side execution behavior used by the `usernameXssChallenge` exploit path. |
| Transitive conflicts | None | No package changes. |

## Security invariant

Authenticated profile updates may store display text, but profile rendering must never execute code derived from the stored username.
