### PR TITLE
Prevent privileged self-registration roles

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -406,6 +406,7 @@ function configureApp (app: ReturnType<typeof express>, seq: typeof sequelize) {
   app.post('/api/Feedbacks', verify.captchaBypassChallenge())
   /* User registration challenge verifications before finale takes over */
   app.post('/api/Users', (req: Request, res: Response, next: NextFunction) => {
+    delete req.body.role
     if (req.body.email !== undefined && req.body.password !== undefined && req.body.passwordRepeat !== undefined) {
       if (req.body.email.length !== 0 && req.body.password.length !== 0) {
         req.body.email = req.body.email.trim()

--- a/test/api/user.test.ts
+++ b/test/api/user.test.ts
@@ -59,7 +59,7 @@ void describe('/api/Users', () => {
     assert.equal(res.body.data.password, undefined)
   })
 
-  void it('POST new admin', async () => {
+  void it('POST new user ignores admin role', async () => {
     const res = await request(app)
       .post('/api/Users')
       .set(jsonHeader)
@@ -74,7 +74,7 @@ void describe('/api/Users', () => {
     assert.equal(typeof res.body.data.createdAt, 'string')
     assert.equal(typeof res.body.data.updatedAt, 'string')
     assert.equal(res.body.data.password, undefined)
-    assert.equal(res.body.data.role, 'admin')
+    assert.equal(res.body.data.role, 'customer')
   })
 
   void it('POST new blank user', async () => {
@@ -127,7 +127,7 @@ void describe('/api/Users', () => {
     assert.equal(res.body.data.password, undefined)
   })
 
-  void it('POST new deluxe user', async () => {
+  void it('POST new user ignores deluxe role', async () => {
     const res = await request(app)
       .post('/api/Users')
       .set(jsonHeader)
@@ -142,10 +142,10 @@ void describe('/api/Users', () => {
     assert.equal(typeof res.body.data.createdAt, 'string')
     assert.equal(typeof res.body.data.updatedAt, 'string')
     assert.equal(res.body.data.password, undefined)
-    assert.equal(res.body.data.role, 'deluxe')
+    assert.equal(res.body.data.role, 'customer')
   })
 
-  void it('POST new accounting user', async () => {
+  void it('POST new user ignores accounting role', async () => {
     const res = await request(app)
       .post('/api/Users')
       .set(jsonHeader)
@@ -160,10 +160,10 @@ void describe('/api/Users', () => {
     assert.equal(typeof res.body.data.createdAt, 'string')
     assert.equal(typeof res.body.data.updatedAt, 'string')
     assert.equal(res.body.data.password, undefined)
-    assert.equal(res.body.data.role, 'accounting')
+    assert.equal(res.body.data.role, 'customer')
   })
 
-  void it('POST user not belonging to customer, deluxe, accounting, admin is forbidden', async () => {
+  void it('POST new user ignores invalid role', async () => {
     const res = await request(app)
       .post('/api/Users')
       .set(jsonHeader)
@@ -172,11 +172,9 @@ void describe('/api/Users', () => {
         password: 'hooooorst',
         role: 'accountinguser'
       })
-    assert.equal(res.status, 400)
+    assert.equal(res.status, 201)
     assert.ok(res.headers['content-type']?.includes('application/json'))
-    assert.equal(res.body.message, 'Validation error: Validation isIn on role failed')
-    assert.equal(res.body.errors[0].field, 'role')
-    assert.equal(res.body.errors[0].message, 'Validation isIn on role failed')
+    assert.equal(res.body.data.role, 'customer')
   })
 
   if (utils.isChallengeEnabled(challenges.persistedXssUserChallenge)) {


### PR DESCRIPTION
## Summary

Fixes the second-ranked report finding: public `POST /api/Users` accepted caller-supplied privileged roles such as `admin`, `accounting`, and `deluxe`.

The registration middleware now strips `role` before the generated Finale user resource creates the account, forcing self-service registrations to the model default `customer` role.

## Validation

- `PATH=/Users/eszuhany/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import ./test/api/helpers/test-env.mjs --import tsx --test --test-force-exit test/api/user.test.ts`
  - All `/api/Users` assertions passed, including new/updated cases for `admin`, `accounting`, `deluxe`, and invalid roles being stored as `customer`.
  - The runner exited nonzero after assertions because the app left async watcher activity that hit `EMFILE: too many open files, watch` in this local checkout.

## Breaking-change risk

| Area | Risk | Notes |
|---|---|---|
| Major version bumps | None | No dependency or runtime version changes. |
| API changes | High | Public registration no longer honors the `role` field. Clients relying on self-registration into `admin`, `accounting`, or `deluxe` roles will now receive `customer`. This intentionally disables the `registerAdminChallenge` mass-assignment behavior. |
| Transitive conflicts | None | No package changes. |

## Security invariant

Anonymous self-service registration may create customer accounts only; privileged roles must not be assignable from the public request body.
