### PR TITLE
Remove embedded JWT signing key

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-import fs from 'node:fs'
 import crypto from 'node:crypto'
 import { type Request, type Response, type NextFunction } from 'express'
 import { type UserModel } from '@juice-shop/models/user'
@@ -19,8 +18,24 @@ import * as utils from './utils'
 // @ts-expect-error FIXME no typescript definitions for z85 :(
 import * as z85 from 'z85'
 
-export const publicKey = fs ? fs.readFileSync('encryptionkeys/jwt.pub', 'utf8') : 'placeholder-public-key'
-const privateKey = '-----BEGIN RSA PRIVATE KEY-----\r\nMIICXAIBAAKBgQDNwqLEe9wgTXCbC7+RPdDbBbeqjdbs4kOPOIGzqLpXvJXlxxW8iMz0EaM4BKUqYsIa+ndv3NAn2RxCd5ubVdJJcX43zO6Ko0TFEZx/65gY3BE0O6syCEmUP4qbSd6exou/F+WTISzbQ5FBVPVmhnYhG/kpwt/cIxK5iUn5hm+4tQIDAQABAoGBAI+8xiPoOrA+KMnG/T4jJsG6TsHQcDHvJi7o1IKC/hnIXha0atTX5AUkRRce95qSfvKFweXdJXSQ0JMGJyfuXgU6dI0TcseFRfewXAa/ssxAC+iUVR6KUMh1PE2wXLitfeI6JLvVtrBYswm2I7CtY0q8n5AGimHWVXJPLfGV7m0BAkEA+fqFt2LXbLtyg6wZyxMA/cnmt5Nt3U2dAu77MzFJvibANUNHE4HPLZxjGNXN+a6m0K6TD4kDdh5HfUYLWWRBYQJBANK3carmulBwqzcDBjsJ0YrIONBpCAsXxk8idXb8jL9aNIg15Wumm2enqqObahDHB5jnGOLmbasizvSVqypfM9UCQCQl8xIqy+YgURXzXCN+kwUgHinrutZms87Jyi+D8Br8NY0+Nlf+zHvXAomD2W5CsEK7C+8SLBr3k/TsnRWHJuECQHFE9RA2OP8WoaLPuGCyFXaxzICThSRZYluVnWkZtxsBhW2W8z1b8PvWUE7kMy7TnkzeJS2LSnaNHoyxi7IaPQUCQCwWU4U+v4lD7uYBw00Ga/xt+7+UqFPlPVdz1yyr4q24Zxaw0LgmuEvgU5dycq8N7JxjTubX0MIRR+G9fmDBBl8=\r\n-----END RSA PRIVATE KEY-----'
+function createJwtKeyPair () {
+  if (process.env.JWT_PRIVATE_KEY && process.env.JWT_PUBLIC_KEY) {
+    return {
+      privateKey: process.env.JWT_PRIVATE_KEY,
+      publicKey: process.env.JWT_PUBLIC_KEY
+    }
+  }
+
+  const keyPair = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+  return {
+    privateKey: keyPair.privateKey.export({ type: 'pkcs1', format: 'pem' }).toString(),
+    publicKey: keyPair.publicKey.export({ type: 'pkcs1', format: 'pem' }).toString()
+  }
+}
+
+const jwtKeyPair = createJwtKeyPair()
+export const publicKey = jwtKeyPair.publicKey
+const privateKey = jwtKeyPair.privateKey
 
 interface ResponseWithUser {
   status?: string

--- a/test/server/insecurity.unit.test.ts
+++ b/test/server/insecurity.unit.test.ts
@@ -7,6 +7,7 @@
 import z85 from 'z85'
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
 import * as security from '../../lib/insecurity'
 import type { UserModel } from '@juice-shop/models/user'
 import type { Request } from 'express'
@@ -201,6 +202,17 @@ void describe('insecurity', () => {
       assert.equal(security.hmac('admin123'), '6be13e2feeada221f29134db71c0ab0be0e27eccfc0fb436ba4096ba73aafb20')
       assert.equal(security.hmac('password'), 'da28fc4354f4a458508a461fbae364720c4249c27f10fccf68317fc4bf6531ed')
       assert.equal(security.hmac(''), 'f052179ec5894a2e79befa8060cfcb517f1e14f7f6222af854377b6481ae953e')
+    })
+  })
+
+  void describe('JWT signing keys', () => {
+    void it('verifies tokens signed by the application key pair', () => {
+      assert.equal(security.verify(security.authorize({ data: { email: 'user@juice-sh.op' } })), true)
+    })
+
+    void it('does not embed an RSA private key in the insecurity module', () => {
+      const source = fs.readFileSync('lib/insecurity.ts', 'utf8')
+      assert.equal(source.includes('BEGIN RSA PRIVATE KEY'), false)
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes the fourth-ranked report finding: `lib/insecurity.ts` embedded the RSA private key used to sign JWTs, allowing anyone with source access to forge role-bearing tokens.

The module now uses `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` when provided, otherwise it generates a per-process RSA key pair at startup. The checked-in private-key literal is removed.

## Validation

- `PATH=/Users/eszuhany/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import ./test/server/helpers/test-env.mjs --import tsx --test --test-force-exit test/server/insecurity.unit.test.ts` passed.
- `PATH=/Users/eszuhany/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build:server` passed.

## Breaking-change risk

| Area | Risk | Notes |
|---|---|---|
| Major version bumps | None | No dependency or runtime version changes. |
| API changes | High | JWTs are no longer signed by the old checked-in key. Without stable `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` environment variables, tokens become invalid across process restarts and forged/static challenge tokens tied to the old key will fail. |
| Transitive conflicts | None | Uses Node built-in `crypto`; no package changes. |

## Security invariant

JWT signing material must not be committed to source. Application-issued tokens should verify with the active runtime public key, but source readers must not be able to derive the private signing key.
