### PR TITLE
Add setup dependent challenge tag

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -321,6 +321,8 @@
 -
   name: 'Email Leak'
   category: 'Sensitive Data Exposure'
+  tags:
+    - Setup Dependent
   description: 'Perform an unwanted information disclosure by accessing data cross-domain.'
   difficulty: 5
   hints:
@@ -1360,6 +1362,8 @@
 -
   name: 'CSRF' # FIXME No e2e test automation! No longer works in Chrome >=80 and Firefox >=100 or other latest browsers!
   category: 'Broken Access Control'
+  tags:
+    - Setup Dependent
   description: 'Change the name of a user by performing Cross-Site Request Forgery from <a href="http://htmledit.squarefree.com">another origin</a>.'
   difficulty: 3
   hints:

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -382,6 +382,8 @@
   "TAG_BRUTE_FORCE_DESCRIPTION": "Marks challenges where automation of some security tool or custom script is an option or even prerequisite.",
   "TAG_GOOD_PRACTICE": "Good Practice",
   "TAG_GOOD_PRACTICE_DESCRIPTION": "Highlights challenges which are less about vulnerabilities but promoting good (security) practices.",
+  "TAG_SETUP_DEPENDENT": "Setup Dependent",
+  "TAG_SETUP_DEPENDENT_DESCRIPTION": "Marks challenges whose exploitability depends on deployment-specific conditions outside the vulnerable application itself.",
   "TAG_CODE_ANALYSIS": "Code Analysis",
   "TAG_CODE_ANALYSIS_DESCRIPTION": "Marks challenges where it can be helpful to rummage through some source code of the application or a third party.",
   "TAG_WEB3": "Web3",


### PR DESCRIPTION
## Summary
- add a new Setup Dependent challenge tag
- tag the CSRF and Email Leak challenges as setup-dependent
- add English label and tooltip text for the new tag

Fixes #3434

## Testing
- node --import ./test/server/helpers/test-env.mjs --import tsx --test test/server/challengeTag.unit.test.ts