### PR TITLE
fix: SQL injection in product search endpoint (GET /rest/products/search?q=)

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -20,7 +20,7 @@ export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
-    models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
+    models.sequelize.query('SELECT * FROM Products WHERE ((name LIKE $criteria OR description LIKE $criteria) AND deletedAt IS NULL) ORDER BY name', { bind: { criteria: `%${criteria}%` } }) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {
         const dataString = JSON.stringify(products)
         if (challengeUtils.notSolved(challenges.unionSqlInjectionChallenge)) { // vuln-code-snippet hide-start


### PR DESCRIPTION
## Summary

Fixes [CRITICAL] SQL Injection in Product Search Endpoint (`GET /rest/products/search?q=`)

### Problem
The `q` query parameter in the product search endpoint was concatenated directly into a SQL query via JavaScript template literals:

```typescript
models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`)
```

An external attacker could inject arbitrary SQL via UNION-based injection to extract the entire database contents including all user credentials, credit card data, addresses, and security answers.

### Fix
Replaced string interpolation with Sequelize parameterized bind variables:

```typescript
models.sequelize.query('SELECT * FROM Products WHERE ((name LIKE $criteria OR description LIKE $criteria) AND deletedAt IS NULL) ORDER BY name', { bind: { criteria: `%${criteria}%` } })
```

This sends user input as a bound parameter, preventing the database from interpreting it as SQL code.

### Files Changed
- `routes/search.ts`: 1 line changed (line 23)

### Verification
- The query now uses Sequelize's `bind` parameter system, which passes the criteria value as a parameter separate from the SQL statement
- No functional behavior change — product search works identically for legitimate queries
- SQL injection payloads are now treated as literal search strings rather than SQL code