### PR TITLE
Add Setup Dependent tag to CSRF and Email Leak challenges

### DIFF
--- a/data/static/challenges.yml
+++ b/data/static/challenges.yml
@@ -328,6 +328,8 @@
   category: 'Sensitive Data Exposure'
   description: 'Perform an unwanted information disclosure by accessing data cross-domain.'
   difficulty: 5
+  tags:
+    - Setup Dependent
   hints:
     - 'Try to find and attack an endpoint that responds with user information. SQL Injection is not the solution here.'
     - 'What ways are there to access data from a web application cross-domain?'
@@ -1378,6 +1380,8 @@
   category: 'Broken Access Control'
   description: 'Change the name of a user by performing Cross-Site Request Forgery from <a href="http://htmledit.squarefree.com">another origin</a>.'
   difficulty: 3
+  tags:
+    - Setup Dependent
   hints:
     - 'Find a form which updates the username and then construct a malicious page in the online HTML editor. You probably need an older browser version for this.'
     - 'Take a look at what happens when you change the username within the profile page.'


### PR DESCRIPTION
Fixes #3434

This PR adds a "Setup Dependent" tag to the CSRF and Email Leak challenges.

- [x] Added tag to CSRF challenge
- [x] Added tag to Email Leak challenge
- [x] Tested locally

AI Tool Disclosure: I used AI assistance for code formatting and understanding the codebase structure.

Affirmation: I confirm that my code follows the CONTRIBUTING.md guidelines.