### PR TITLE
Fix i18n restore basename extraction for Windows paths

### DIFF
--- a/lib/startup/restoreOverwrittenFilesWithOriginals.ts
+++ b/lib/startup/restoreOverwrittenFilesWithOriginals.ts
@@ -25,7 +25,7 @@ const restoreOverwrittenFilesWithOriginals = async () => {
     const files = await glob(path.resolve('data/static/i18n/*.json'), { windowsPathsNoEscape: true })
     await Promise.all(
       files.map(async (filename: string) => {
-        await copyFile(filename, path.resolve('i18n/', filename.substring(filename.lastIndexOf('/') + 1)))
+        await copyFile(filename, path.resolve('i18n/', path.basename(filename)))
       })
     )
   } catch (err) {


### PR DESCRIPTION
### Description

`restoreOverwrittenFilesWithOriginals()` already handles Windows glob matching via `windowsPathsNoEscape: true`, but the subsequent basename extraction (`filename.substring(filename.lastIndexOf('/') + 1)`) still assumes forward-slash paths. On Windows, `lastIndexOf('/')` returns `-1`, so the "basename" is actually the full absolute source path. Since that's an absolute path, `path.resolve('i18n/', ...)` resolves back to the original source file — meaning `copyFile()` silently copies each file onto itself instead of into `i18n/`, so `i18n/` is never actually populated.

Fix: replace the manual forward-slash-only substring logic with `path.basename(filename)`, which is separator-aware on all platforms.

Verified on Windows: before the fix, running `restoreOverwrittenFilesWithOriginals()` left `i18n/` empty (files copied onto themselves in `data/static/i18n/`); after the fix, `i18n/` is correctly populated with all 43 translation JSON files under their proper basenames. `npx eslint` on the changed file passes clean.

Resolved or fixed issue: #3516

### AI Tool Disclosure

- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code (CLI agent)`
    - LLMs and versions: `Claude Sonnet 5`
    - Prompts: `Investigate and fix GitHub issue about restoreOverwrittenFilesWithOriginals() silently failing to restore i18n JSON files on Windows; verify the fix actually populates i18n/ and does not regress upstream's existing windowsPathsNoEscape fix.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines