### PR TITLE
fix: pin remaining GitHub Actions by commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           name: api-test-lcov
       - name: "Publish coverage to Coveralls"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           files: frontend-lcov.info server-lcov.info api-lcov.info

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
@@ -31,6 +31,6 @@ jobs:
           - exclude:
                id: js/missing-rate-limiting
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3

--- a/.github/workflows/image_actions.yml
+++ b/.github/workflows/image_actions.yml
@@ -27,10 +27,10 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@2a254d926beda392b8c36e1be95252aa3d534405 # main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           ignorePaths: '**/3d_keychain.jpg,**/favorite-hiking-place.png,**/5.png'
@@ -39,7 +39,7 @@ jobs:
         if: |
           github.event_name != 'pull_request' &&
           steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           title: Auto Compress Images
           delete-branch: true


### PR DESCRIPTION
### Description

Pins the seven remaining mutable GitHub Action references in the CI, CodeQL, and image-compression workflows to the exact commits currently selected by their tags or branch.

This preserves the selected action versions while preventing a later tag or branch move from changing executable workflow code without a repository diff. The existing human-readable version references remain as comments.

Validation performed:

- Parsed all three changed workflow files as YAML.
- Confirmed no mutable `@vN`, `@main`, or `@master` action reference remains in the changed workflows.
- Confirmed each pinned commit exists at the previously selected upstream tag or branch.
- Ran `git diff --check`.

Resolved or fixed issue: none

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `OpenAI Codex`
    - LLMs and versions: `GPT-5.6`
    - Prompts: `Import last week's GitHub security reports, validate every finding, fix accepted reportable findings, and open a separate pull request for each.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
