### PR TITLE
fix: pin Heroku CLI installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,9 @@ jobs:
       - name: "Check out Git repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: "Install Heroku CLI"
-        run: curl https://cli-assets.heroku.com/install.sh | sh
+        run: |
+          npm install --global --ignore-scripts heroku@11.8.1
+          heroku --version
       - name: "Set Heroku app & branch for ${{ github.ref }}"
         run: |
           if [ "$GITHUB_REF" == "refs/heads/master" ]; then


### PR DESCRIPTION
### Description

Replaces the Heroku deployment job's remote `curl | sh` installer with an exact npm package version and disables install scripts.

The deployment still receives a global `heroku` executable, but the workflow no longer executes an unverified network response directly as shell code. The step also prints the installed version so a mismatch is visible in job logs.

Validation performed:

- Parsed the changed workflow as YAML.
- Confirmed no `curl` or `wget` pipe-to-shell pattern remains.
- Confirmed `heroku@11.8.1` is the current npm release, supports Node.js 20 and newer, and has registry integrity metadata.
- Ran the exact install command on a clean GitHub-hosted Ubuntu runner with Node.js 24, then successfully ran `heroku --version` and `heroku help git:remote`: https://github.com/htowata-oai/juice-shop/actions/runs/30261232648
- Ran `git diff --check`.

Resolved or fixed issue: none

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `OpenAI Codex`
    - LLMs and versions: `GPT-5.6`
    - Prompts: `Import last week's GitHub security reports, validate every finding, fix accepted reportable findings, and open a separate pull request for each.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
