### PR TITLE
fix(utils): correct endsWith behavior for empty suffix and add regres…

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -36,7 +36,18 @@ export const isUrl = (url: string) => {
 
 export const startsWith = (str: string, prefix: string) => str ? str.indexOf(prefix) === 0 : false
 
-export const endsWith = (str?: string, suffix?: string) => (str && suffix) ? str.includes(suffix, str.length - suffix.length) : false
+export const endsWith = (str?: string, suffix?: string) => {
+  if (str === undefined || str === null) {
+    return false
+  }
+  if (suffix === undefined || suffix === null) {
+    return false
+  }
+  if (suffix === '') {
+    return true
+  }
+  return str.endsWith(suffix)
+}
 
 export const contains = (str: string, element: string) => str ? str.includes(element) : false
 

--- a/test/server/utils.unit.test.ts
+++ b/test/server/utils.unit.test.ts
@@ -172,6 +172,14 @@ void describe('utils', () => {
       assert.equal(utils.endsWith('Bla Blubb', 'Blubb'), true)
     })
 
+    void it('rejects string when the substring appears earlier but not at the end', () => {
+      assert.equal(utils.endsWith('Bla Blubb', 'Bl'), false)
+    })
+
+    void it('treats an empty suffix as matching any string', () => {
+      assert.equal(utils.endsWith('Bla Blubb', ''), true)
+    })
+
     void it('rejects string not ending with another string', () => {
       assert.equal(utils.endsWith('Bla Blubb', 'Lala'), false)
     })


### PR DESCRIPTION
Fixes #3546 
The previous implementation of endsWith in utils.ts relied on a truthiness check, which caused an empty suffix ('') to incorrectly return false.

According to standard string semantics, an empty suffix should match any string.

Changes
Return false for null / undefined inputs
Return true for empty suffix ('')
Preserve normal suffix matching behavior for valid inputs

Tests
Added regression test in utils.unit.test.ts

Verified with:

npm run test:server -- --test-name-pattern "endsWith"
npx eslint utils.ts test/server/utils.unit.test.ts