### PR TITLE
fix(basket): forward rejected quantityCheck promise during basket ite…

### DIFF
--- a/routes/basketItems.ts
+++ b/routes/basketItems.ts
@@ -72,7 +72,9 @@ export function quantityCheckBeforeBasketItemUpdate () {
         if (item == null) {
           throw new Error('No such item found!')
         }
-        void quantityCheck(req, res, next, item.ProductId, req.body.quantity)
+        void quantityCheck(req, res, next, item.ProductId, req.body.quantity).catch((error: Error) => {
+          next(error)
+        })
       } else {
         next()
       }

--- a/test/api/basket-item.test.ts
+++ b/test/api/basket-item.test.ts
@@ -9,6 +9,7 @@ import request from 'supertest'
 import type { Express } from 'express'
 import { createTestApp } from './helpers/setup'
 import { login } from './helpers/auth'
+import { QuantityModel } from '../../models/quantity'
 
 let app: Express
 let authHeader: { Authorization: string, 'content-type': string }
@@ -234,5 +235,22 @@ void describe('/api/BasketItems/:id', () => {
       .set(authHeader)
       .send({ quantity: 1 })
     assert.equal(res.status, 500)
+  })
+
+  void it('should handle error when QuantityModel.findOne fails during PUT update', async (t) => {
+    const createRes = await request(app)
+      .post('/api/BasketItems')
+      .set(authHeader)
+      .send({ BasketId: 2, ProductId: 13, quantity: 3 })
+    assert.equal(createRes.status, 200)
+
+    t.mock.method(QuantityModel, 'findOne', () => { throw new Error('Quantity findOne error') })
+
+    const res = await request(app)
+      .put('/api/BasketItems/' + createRes.body.data.id)
+      .set(authHeader)
+      .send({ quantity: 5 })
+    assert.equal(res.status, 500)
+    assert.match(res.text, /Quantity findOne error/)
   })
 })


### PR DESCRIPTION
### Description

This PR catches rejected Promises returned from `quantityCheck()` inside the `quantityCheckBeforeBasketItemUpdate` middleware and forwards them to Express's error handling via `next(error)`. This mirrors the error handling pattern already established in `quantityCheckBeforeBasketItemAddition`.

Resolved or fixed issue: none

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Antigravity IDE`
    - LLMs and versions: `Gemini 3.5 Flash`
    - Prompts: `Find, analyze, reproduce, and implement a minimal fix for unhandled promise rejections in routes/basketItems.ts.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
