### PR TITLE
Verify chatbot JWT identity

### DIFF
--- a/routes/chat.ts
+++ b/routes/chat.ts
@@ -20,6 +20,8 @@ import * as db from '../data/mongodb'
 import { type Review } from '../data/types'
 import logger from '../lib/logger'
 import { Counter } from 'prom-client'
+// @ts-expect-error FIXME no typescript definitions for jws
+import * as jws from 'jws'
 
 export function summarizeLlmError (error: unknown): string {
   if (!(error instanceof Error)) {
@@ -42,8 +44,13 @@ const appName = config.get<string>('application.name')
 export async function getUserId (req: Request): Promise<number | undefined> {
   const token = utils.jwtFrom(req)
   if (!token) return undefined
-  const decoded = security.decode(token) as { data?: { id?: number } } | undefined
-  return decoded?.data?.id
+  try {
+    const decoded = jws.decode(token) as { header?: { alg?: string }, payload?: { data?: { id?: number } } } | null
+    if (decoded?.header?.alg !== 'RS256' || !security.verify(token)) return undefined
+    return decoded.payload?.data?.id
+  } catch {
+    return undefined
+  }
 }
 
 export async function getUserNameFromToken (req: Request): Promise<string | undefined> {

--- a/test/server/chat.unit.test.ts
+++ b/test/server/chat.unit.test.ts
@@ -57,6 +57,24 @@ void describe('chat', () => {
       const userId = await chat.getUserId(req as any)
       assert.equal(userId, 42)
     })
+
+    void it('should reject a token with an invalid signature', async () => {
+      const token = security.authorize({ data: { id: 42 } })
+      const [header, payload, signature] = token.split('.')
+      const forgedSignature = (signature.startsWith('a') ? 'b' : 'a') + signature.slice(1)
+      const forgedToken = `${header}.${payload}.${forgedSignature}`
+      const req = { headers: { authorization: `Bearer ${forgedToken}` } }
+      const userId = await chat.getUserId(req as any)
+      assert.equal(userId, undefined)
+    })
+
+    void it('should reject an unsigned token', async () => {
+      const header = Buffer.from(JSON.stringify({ typ: 'JWT', alg: 'none' })).toString('base64url')
+      const payload = Buffer.from(JSON.stringify({ data: { id: 42 } })).toString('base64url')
+      const req = { headers: { authorization: `Bearer ${header}.${payload}.` } }
+      const userId = await chat.getUserId(req as any)
+      assert.equal(userId, undefined)
+    })
   })
 
   void describe('getUserNameFromToken', () => {


### PR DESCRIPTION
## Vulnerability

The public chatbot's private-order tool derived customer identity by decoding an unverified bearer-token payload. An unauthenticated attacker could supply a forged JWT containing another user's ID; that ID selected the user whose masked email was used for the order ownership check.

## Why this was prioritized

This finding crosses a customer confidentiality boundary through a directly Internet-reachable endpoint without requiring a valid session. Exploitation also requires a target order ID and successful model tool invocation, so the scan calibrated it as medium severity, but it has more direct application impact than the validated availability findings and supply-chain issues requiring upstream compromise.

## Root cause

`getUserId()` called `security.decode()` and trusted `data.id` without first validating the JWT signature or restricting the accepted signing algorithm.

## Security impact

A forged bearer-token payload could cause the chatbot to treat an unauthenticated caller as another customer and return that customer's private order record when the attacker supplied a matching order ID.

## Code changes

- Decode the JOSE header and require `RS256`.
- Verify the JWT signature before returning its user ID.
- Treat malformed, incorrectly signed, or unsigned tokens as unauthenticated.
- Add regression tests for invalid signatures and `alg: none` tokens while retaining positive coverage for valid signed tokens.

The change is intentionally limited to the chatbot identity boundary and does not alter the application's documented JWT training challenges elsewhere.

## Validation

- `node --import ./test/server/helpers/test-env.mjs --import tsx --test --test-force-exit test/server/chat.unit.test.ts` — passed, 12/12.
- `npm run test:server` — passed, 415 tests passed and 2 intentionally skipped.
- `npx eslint routes/chat.ts test/server/chat.unit.test.ts` — passed.
- Root ESLint and configuration lint phases of `npm run lint` passed. The full command could not run frontend lint because the shared checkout has no Angular CLI installation (`ng: command not found`).
- `test/api/chat.test.ts` could not start because the shared dependency installation lacks the native SQLite binding for Node 25.2.1.

The original invalid-signature and unsigned-token paths now return no user identity, while the existing valid RS256 token test continues to return the correct user ID.

## Remaining limitations and follow-up

- This patch does not address the separately reported unmetered chatbot resource-consumption finding.
- The repository's legacy JWT library and intentionally weak training key remain unchanged to avoid modifying challenge behavior.
- CI should provide the final frontend lint and chatbot API integration coverage in its supported dependency environment.
