### PR TITLE
fix: handle quantity check errors during basket updates

### DIFF
--- a/routes/basketItems.ts
+++ b/routes/basketItems.ts
@@ -72,7 +72,9 @@ export function quantityCheckBeforeBasketItemUpdate () {
         if (item == null) {
           throw new Error('No such item found!')
         }
-        void quantityCheck(req, res, next, item.ProductId, req.body.quantity)
+        void quantityCheck(req, res, next, item.ProductId, req.body.quantity).catch((error: Error) => {
+  next(error)
+})
       } else {
         next()
       }


### PR DESCRIPTION
fixes: #3551 
### Description

Updated the error handling in `quantityCheckBeforeBasketItemUpdate()` in `routes/basketItems.ts`.

The `quantityCheck()` function is asynchronous and can reject when, for example, the requested product does not exist. Previously, the returned Promise was not handled, which could result in the rejection not being forwarded to Express error handling.

The change adds a `.catch()` handler so errors from `quantityCheck()` are passed to `next(error)`, matching the error-handling approach already used by `quantityCheckBeforeBasketItemAddition()`.

Resolved or fixed issue: #3551

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `ChatGPT`
    - LLMs and versions: `GPT-5.6 Luna`
    - Prompts: `Helped analyze issue #3551, understand the existing error-handling flow in basketItems.ts, and verify the appropriate Promise error handling change.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines