### PR TITLE
fix: handle promise rejection in quantityCheckBeforeBasketItemUpdate

### DIFF
--- a/routes/basketItems.ts
+++ b/routes/basketItems.ts
@@ -72,7 +72,9 @@ export function quantityCheckBeforeBasketItemUpdate () {
         if (item == null) {
           throw new Error('No such item found!')
         }
-        void quantityCheck(req, res, next, item.ProductId, req.body.quantity)
+        void quantityCheck(req, res, next, item.ProductId, req.body.quantity).catch((error: Error) => {
+          next(error)
+        })
       } else {
         next()
       }

--- a/test/api/basket-item.test.ts
+++ b/test/api/basket-item.test.ts
@@ -9,6 +9,7 @@ import request from 'supertest'
 import type { Express } from 'express'
 import { createTestApp } from './helpers/setup'
 import { login } from './helpers/auth'
+import { QuantityModel } from '../../models/quantity'
 
 let app: Express
 let authHeader: { Authorization: string, 'content-type': string }
@@ -234,5 +235,21 @@ void describe('/api/BasketItems/:id', () => {
       .set(authHeader)
       .send({ quantity: 1 })
     assert.equal(res.status, 500)
+  })
+
+  void it('PUT update basket item with failing quantity lookup returns 500', async (t) => {
+    const createRes = await request(app)
+      .post('/api/BasketItems')
+      .set(authHeader)
+      .send({ BasketId: 2, ProductId: 11, quantity: 2 })
+    assert.equal(createRes.status, 200)
+
+    t.mock.method(QuantityModel, 'findOne', () => { throw new Error('Quantity error') })
+    const res = await request(app)
+      .put('/api/BasketItems/' + createRes.body.data.id)
+      .set(authHeader)
+      .send({ quantity: 3 })
+    assert.equal(res.status, 500)
+    assert.match(res.text, /Quantity error/)
   })
 })


### PR DESCRIPTION
## Description

Fixes #3551.

In \quantityCheckBeforeBasketItemUpdate\, the async \quantityCheck\ middleware was invoked with the \oid\ operator but without a \.catch()\ handler. When the quantity lookup rejects (e.g. \QuantityModel.findOne\ throws), the promise rejection was left unhandled, bypassing Express's error handling and leaving the \PUT /api/BasketItems/:id\ request hanging.

This aligns the update middleware with the existing pattern in \quantityCheckBeforeBasketItemAddition\, which already chains \.catch()\ to route errors to \
ext(error)\.

## Changes

- \outes/basketItems.ts\: chain \.catch()\ onto the \quantityCheck\ promise so rejections are forwarded to Express's error handler.
- \	est/api/basket-item.test.ts\: add a regression test that mocks \QuantityModel.findOne\ to throw and asserts the request returns a 500 with the error message. The test fails against the pre-fix code (unhandled rejection) and passes with the fix.

## Testing

- \
pm run lint\ (root + frontend) passes
- \
pm run lint:config\ passes
- \
pm run rsn\ passes
- \
pm run test:server\: 410 pass, 0 fail
- \
pm run test:api\: 522 pass; the 9 failures are pre-existing environment issues (offline DNS lookups in \internet-resources.test.ts\ and a missing \owasp_promo.vtt\ build asset in \promotion-video.test.ts\), unrelated to this change