### PR TITLE
fix: handle promise rejection in quantityCheckBeforeBasketItemUpdate

### DIFF
--- a/routes/basketItems.ts
+++ b/routes/basketItems.ts
@@ -72,7 +72,9 @@ export function quantityCheckBeforeBasketItemUpdate () {
         if (item == null) {
           throw new Error('No such item found!')
         }
-        void quantityCheck(req, res, next, item.ProductId, req.body.quantity)
+        void quantityCheck(req, res, next, item.ProductId, req.body.quantity).catch((error: Error) => {
+          next(error)
+        })
       } else {
         next()
       }

--- a/test/api/basket-item.test.ts
+++ b/test/api/basket-item.test.ts
@@ -9,6 +9,7 @@ import request from 'supertest'
 import type { Express } from 'express'
 import { createTestApp } from './helpers/setup'
 import { login } from './helpers/auth'
+import { QuantityModel } from '../../models/quantity'
 
 let app: Express
 let authHeader: { Authorization: string, 'content-type': string }
@@ -234,5 +235,21 @@ void describe('/api/BasketItems/:id', () => {
       .set(authHeader)
       .send({ quantity: 1 })
     assert.equal(res.status, 500)
+  })
+
+  void it('PUT update basket item with failing quantity lookup returns 500', async (t) => {
+    const createRes = await request(app)
+      .post('/api/BasketItems')
+      .set(authHeader)
+      .send({ BasketId: 2, ProductId: 11, quantity: 2 })
+    assert.equal(createRes.status, 200)
+
+    t.mock.method(QuantityModel, 'findOne', () => { throw new Error('Quantity error') })
+    const res = await request(app)
+      .put('/api/BasketItems/' + createRes.body.data.id)
+      .set(authHeader)
+      .send({ quantity: 3 })
+    assert.equal(res.status, 500)
+    assert.match(res.text, /Quantity error/)
   })
 })


### PR DESCRIPTION
### Description

In `quantityCheckBeforeBasketItemUpdate`, the async `quantityCheck` middleware was invoked with the `void` operator but without a `.catch()` handler. When the quantity lookup rejects (e.g. `QuantityModel.findOne` throws), the promise rejection is left unhandled, bypassing Express's error handling and leaving the `PUT /api/BasketItems/:id` request hanging. This aligns the update middleware with the existing pattern in `quantityCheckBeforeBasketItemAddition`, which already chains `.catch()` to route errors to `next(error)`.

Resolved or fixed issue: #3551

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `opencode`
    - LLMs and versions: `deepseek-v4-flash-free`
    - Prompts: `The fix was produced with assistance from an AI coding agent; the root cause, fix and regression test were reviewed and verified locally.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines