### PR TITLE
fix(basket): prevent unhandled rejection during quantity update

### DIFF
--- a/routes/basketItems.ts
+++ b/routes/basketItems.ts
@@ -72,7 +72,9 @@ export function quantityCheckBeforeBasketItemUpdate () {
         if (item == null) {
           throw new Error('No such item found!')
         }
-        void quantityCheck(req, res, next, item.ProductId, req.body.quantity)
+        void quantityCheck(req, res, next, item.ProductId, req.body.quantity).catch((error: Error) => {
+          next(error)
+        })
       } else {
         next()
       }

--- a/test/server/basketItems.unit.test.ts
+++ b/test/server/basketItems.unit.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2026 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { quantityCheckBeforeBasketItemUpdate } from '../../routes/basketItems'
+import { BasketItemModel } from '../../models/basketitem'
+import { QuantityModel } from '../../models/quantity'
+
+void describe('basketItems', () => {
+  let req: any
+  let res: any
+  let next: any
+
+  beforeEach(() => {
+    req = { params: { id: '1' }, body: { quantity: 5 }, headers: {}, __: mock.fn((s) => s) }
+    res = { json: mock.fn(), status: mock.fn(() => res) }
+    next = mock.fn()
+    mock.restoreAll()
+  })
+
+  void it('should call next with error if QuantityModel.findOne fails during update', async () => {
+    const error = new Error('Database connection failed')
+    mock.method(BasketItemModel, 'findOne', async () => ({ ProductId: 1 }))
+    mock.method(QuantityModel, 'findOne', async () => { throw error })
+
+    const p = new Promise((resolve) => {
+      next = (err: any) => { resolve(err) }
+    })
+
+    void quantityCheckBeforeBasketItemUpdate()(req, res, next)
+    const err = await p as Error
+
+    assert.equal(err, error)
+  })
+})


### PR DESCRIPTION
### Description

This PR adds a `.catch` handler to the asynchronous `quantityCheck` call inside the `quantityCheckBeforeBasketItemUpdate` middleware. Database query errors (such as connection failures or lock errors) during basket item updates will now be forwarded to Express's `next` handler instead of triggering an unhandled promise rejection. It also adds a unit test suite to verify this error propagation.

Resolved or fixed issue: #3551

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools:
    - LLMs and versions:
    - Prompts:

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
