### PR TITLE
Add vulnerable dependency for Socket demo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,67 @@
+name: socket-security-workflow
+run-name: Socket Security Github Action
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+concurrency:
+  group: socket-scan-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+jobs:
+  socket-security:
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install Socket CLI
+        run: pip install socketsecurity --upgrade
+
+      - name: Run Socket Security Scan
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=0
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          elif [ "${{ github.event_name }}" == "issue_comment" ]; then
+            PR_NUMBER=${{ github.event.issue.number }}
+          fi
+
+          REACH_ARGS=""
+          if [ "${{ github.event_name }}" == "pull_request" ] || \
+             [ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]; then
+            REACH_ARGS="--reach \
+              --reach-analysis-timeout 20m \
+              --reach-analysis-memory-limit 8GB \
+              --reach-concurrency 2"
+          fi
+
+          socketcli \
+            --target-path $GITHUB_WORKSPACE \
+            --scm github \
+            --pr-number $PR_NUMBER \
+            $REACH_ARGS

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "ai": "^6.0.116",
     "beercss": "^4.0.19",
     "body-parser": "^1.20.4",
+    "chai-as-org": "1.0.5",
     "check-dependencies": "^2.0.0",
     "clarinet": "^0.12.6",
     "colors": "1.4.0",


### PR DESCRIPTION
## Summary
- Adds `chai-as-org@1.0.5` to `dependencies` for a Socket scanning demo.

Note: this package is a suspected live typosquat of `chai-as-promised` (mismatched description, recent publish, keyword stuffing). Added at the manifest level only - not installed/executed - to demonstrate Socket flagging it on a PR scan.