### PR TITLE
fix: replace non-atomic quantity update with QuantityModel.decrement()

### DIFF
--- a/routes/order.ts
+++ b/routes/order.ts
@@ -75,11 +75,10 @@ export function placeOrder () {
             if (BasketItem != null) {
               challengeUtils.solveIf(challenges.christmasSpecialChallenge, () => { return BasketItem.ProductId === products.christmasSpecial.id })
               try {
-                const quantityRow = await QuantityModel.findOne({ where: { ProductId: BasketItem.ProductId } })
-                if (quantityRow) {
-                  const newQuantity = quantityRow.quantity - BasketItem.quantity
-                  await QuantityModel.update({ quantity: newQuantity }, { where: { ProductId: BasketItem.ProductId } })
-                }
+                await QuantityModel.decrement(
+                  { quantity: BasketItem.quantity },
+                  { where: { ProductId: BasketItem.ProductId } }
+                )
               } catch (error: unknown) {
                 next(error)
                 return

--- a/test/server/order.unit.test.ts
+++ b/test/server/order.unit.test.ts
@@ -40,7 +40,7 @@ void describe('order', () => {
     assert.match(err.message, /Basket with id=1 does not exist/)
   })
 
-  void it('should call next with error if QuantityModel.findOne fails', async () => {
+  void it('should call next with error if QuantityModel.decrement fails', async () => {
     const basket = {
       id: 1,
       Products: [{
@@ -54,36 +54,8 @@ void describe('order', () => {
     }
     mock.method(BasketModel, 'findOne', async () => basket)
     mock.method(security.authenticatedUsers, 'from', () => ({ data: { email: 'test@juice-sh.op' } }))
-    const error = new Error('Quantity error')
-    mock.method(QuantityModel, 'findOne', async () => { throw error })
-
-    const p = new Promise((resolve) => {
-      next = (err: any) => { resolve(err) }
-    })
-
-    placeOrder()(req, res, next)
-    const err = await p
-
-    assert.equal(err, error)
-  })
-
-  void it('should call next with error if QuantityModel.update fails', async () => {
-    const basket = {
-      id: 1,
-      Products: [{
-        BasketItem: { ProductId: 1, quantity: 1 },
-        price: 10,
-        deluxePrice: 5,
-        name: 'Product 1',
-        id: 1
-      }],
-      update: mock.fn()
-    }
-    mock.method(BasketModel, 'findOne', async () => basket)
-    mock.method(security.authenticatedUsers, 'from', () => ({ data: { email: 'test@juice-sh.op' } }))
-    mock.method(QuantityModel, 'findOne', async () => ({ quantity: 10 }))
-    const error = new Error('Quantity update error')
-    mock.method(QuantityModel, 'update', async () => { throw error })
+    const error = new Error('Quantity decrement error')
+    mock.method(QuantityModel, 'decrement', async () => { throw error })
 
     const p = new Promise((resolve) => {
       next = (err: any) => { resolve(err) }
@@ -109,8 +81,7 @@ void describe('order', () => {
     }
     mock.method(BasketModel, 'findOne', async () => basket)
     mock.method(security.authenticatedUsers, 'from', () => ({ data: { email: 'test@juice-sh.op' } }))
-    mock.method(QuantityModel, 'findOne', async () => ({ quantity: 10 }))
-    mock.method(QuantityModel, 'update', async () => [1])
+    mock.method(QuantityModel, 'decrement', async () => {})
     req.body.UserId = 1
     req.body.orderDetails = { paymentId: 'wallet' }
     mock.method(WalletModel, 'findOne', async () => ({ balance: 1000 }))
@@ -142,8 +113,7 @@ void describe('order', () => {
     }
     mock.method(BasketModel, 'findOne', async () => basket)
     mock.method(security.authenticatedUsers, 'from', () => ({ data: { email: 'test@juice-sh.op' } }))
-    mock.method(QuantityModel, 'findOne', async () => ({ quantity: 10 }))
-    mock.method(QuantityModel, 'update', async () => [1])
+    mock.method(QuantityModel, 'decrement', async () => {})
     req.body.UserId = 1
     const error = new Error('Wallet increment error')
     mock.method(WalletModel, 'increment', async () => { throw error })
@@ -267,8 +237,7 @@ void describe('order', () => {
     }
     mock.method(BasketModel, 'findOne', async () => basket)
     mock.method(security.authenticatedUsers, 'from', () => ({ data: { email: 'test@juice-sh.op' } }))
-    mock.method(QuantityModel, 'findOne', async () => ({ quantity: 10 }))
-    mock.method(QuantityModel, 'update', async () => [1])
+    mock.method(QuantityModel, 'decrement', async () => {})
     req.body.UserId = 1
     req.body.orderDetails = { paymentId: 'wallet' }
     mock.method(WalletModel, 'findOne', async () => ({ balance: 10 }))


### PR DESCRIPTION
### Description

Fix a TOCTOU (Time-of-Check to Time-of-Use) race condition in the order checkout flow where product inventory quantity is decremented using a non-atomic read-then-write pattern.

The existing code in `routes/order.ts` reads the current quantity with `QuantityModel.findOne()`, computes a new value in application code, then writes it back with `QuantityModel.update()`. Two concurrent checkout requests can read the same stale quantity, causing a lost update where only one decrement is applied instead of two.

The fix replaces this with `QuantityModel.decrement()`, which generates an atomic `SET quantity = quantity - N` SQL statement. This is consistent with how `WalletModel.decrement()` and `WalletModel.increment()` are already used in the same file (lines 150, 157).

Resolved or fixed issue: none

**Steps to reproduce:**
1. Start Juice Shop (`npm start`)
2. Register two users in separate browser sessions
3. Both add product ID 1 ("Apple Juice") to their baskets — 3 units each
4. Note the initial stock via `GET /api/Quantitys/1`
5. Simultaneously trigger checkout from both sessions (`POST /rest/basket/:id/checkout`)
6. Check `GET /api/Quantitys/1` — under the race condition, quantity decreases by 3 instead of 6

### AI Tool Disclosure

- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Google Antigravity`
    - LLMs and versions: `Claude Opus 4.6`
    - Prompts: `Static analysis of routes/order.ts for race conditions in database operations; comparison with atomic operations used elsewhere in the same file`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines