### PR TITLE
fix: add missing return after next() in file upload handlers

### DIFF
--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -94,6 +94,7 @@ async function handleXmlUpload ({ file }: Request, res: Response, next: NextFunc
       res.status(410)
       next(new Error('B2B customer complaints via file upload have been deprecated for security reasons (' + file?.originalname + ')'))
     }
+    return
   }
   next()
 }
@@ -126,6 +127,7 @@ function handleYamlUpload ({ file }: Request, res: Response, next: NextFunction)
       res.status(410)
       next(new Error('B2B customer complaints via file upload have been deprecated for security reasons (' + file?.originalname + ')'))
     }
+    return
   }
   res.status(204).end()
 }


### PR DESCRIPTION
### Description

Fix missing early return in `handleXmlUpload` and `handleYamlUpload` middleware that causes `next()` or `res.end()` to be invoked twice when processing XML/YAML files.

**`handleXmlUpload`**: When an XML file is uploaded, `next(new Error(...))` is called inside the if-block to pass the error to the Express error handler. However, execution falls through to `next()` on the last line of the function, which invokes the next middleware (`handleYamlUpload`) as well. This causes both the error handler and the subsequent middleware to run simultaneously.

**`handleYamlUpload`**: Same pattern — when a YAML file is uploaded, `next(new Error(...))` is called, but execution falls through to `res.status(204).end()`, which attempts to send a second HTTP response after the error handler has already started processing. This can cause "Cannot set headers after they are sent" errors in production.

The fix adds `return` after the XML/YAML if-blocks so that fallthrough only occurs for non-XML/non-YAML files (the intended behavior for the middleware chain).

Resolved or fixed issue: none

**Steps to reproduce:**
1. Start Juice Shop (`npm start`)
2. Upload an XML file to `/file-upload`:
   ```bash
   curl -F 'file=@test.xml' http://localhost:3000/file-upload
   ```
3. Observe server logs — `handleYamlUpload` runs after `handleXmlUpload` already called `next(error)`, and `res.status(204).end()` attempts to send a response after the error handler
4. In Node.js debug mode, "Cannot set headers after they are sent" warnings appear

### AI Tool Disclosure

- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Google Antigravity`
    - LLMs and versions: `Claude Opus 4.6`
    - Prompts: `Static analysis of Express middleware chain in routes/fileUpload.ts for missing return statements after next() calls`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines