### PR TITLE
fix(fileUpload): call next() for non-YAML files in handleYamlUpload

### DIFF
--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -126,8 +126,9 @@ function handleYamlUpload ({ file }: Request, res: Response, next: NextFunction)
       res.status(410)
       next(new Error('B2B customer complaints via file upload have been deprecated for security reasons (' + file?.originalname + ')'))
     }
+  } else {
+    next()
   }
-  res.status(204).end()
 }
 
 export {


### PR DESCRIPTION
## Description

In `handleYamlUpload` middleware, non-YAML files were incorrectly having their response ended with `204 No Content` instead of being passed to the next middleware via `next()`. This would break the middleware chain for non-YAML file uploads.

## Changes

- `routes/fileUpload.ts`: Added `else { next() }` branch for non-YAML files in `handleYamlUpload`

## Testing

- ESLint passes
- No functional change for YAML file handling
- Non-YAML files now correctly pass through the middleware chain