### PR TITLE
Fix guest basket allowing over-limit product quantities

### DIFF
--- a/data/static/codefixes/restfulXssChallenge_1_correct.ts
+++ b/data/static/codefixes/restfulXssChallenge_1_correct.ts
@@ -23,6 +23,7 @@ ngAfterViewInit () {
             continue
           }
           entry.quantity = quantity.quantity
+          entry.limitPerUser = quantity.limitPerUser
         }
         this.dataSource = new MatTableDataSource<ProductTableEntry>(dataTable)
         this.updatePageSizeOptions()

--- a/data/static/codefixes/restfulXssChallenge_2.ts
+++ b/data/static/codefixes/restfulXssChallenge_2.ts
@@ -24,6 +24,7 @@ ngAfterViewInit () {
             continue
           }
           entry.quantity = quantity.quantity
+          entry.limitPerUser = quantity.limitPerUser
         }
         this.dataSource = new MatTableDataSource<ProductTableEntry>(dataTable)
         this.updatePageSizeOptions()

--- a/data/static/codefixes/restfulXssChallenge_3.ts
+++ b/data/static/codefixes/restfulXssChallenge_3.ts
@@ -24,6 +24,7 @@ ngAfterViewInit () {
             continue
           }
           entry.quantity = quantity.quantity
+          entry.limitPerUser = quantity.limitPerUser
         }
         this.dataSource = new MatTableDataSource<ProductTableEntry>(dataTable)
         this.updatePageSizeOptions()

--- a/data/static/codefixes/restfulXssChallenge_4.ts
+++ b/data/static/codefixes/restfulXssChallenge_4.ts
@@ -24,6 +24,7 @@ ngAfterViewInit () {
             continue
           }
           entry.quantity = quantity.quantity
+          entry.limitPerUser = quantity.limitPerUser
         }
         this.dataSource = new MatTableDataSource<ProductTableEntry>(dataTable)
         this.updatePageSizeOptions()

--- a/frontend/src/app/Models/product.model.ts
+++ b/frontend/src/app/Models/product.model.ts
@@ -13,4 +13,4 @@ export interface Product {
   deluxePrice: number
 }
 
-export type ProductTableEntry = Product & { quantity?: number }
+export type ProductTableEntry = Product & { quantity?: number, limitPerUser?: number | null }

--- a/frontend/src/app/Services/basket.service.spec.ts
+++ b/frontend/src/app/Services/basket.service.spec.ts
@@ -338,4 +338,41 @@ describe('BasketService', () => {
         expect(sessionStorage.getItem('guestBasket')).toBeNull()
         httpMock.verify()
     })
+
+    describe('getGuestBasketQuantityViolation', () => {
+        it('should return null when no quantity info is available', () => {
+            const service = TestBed.inject(BasketService)
+            expect(service.getGuestBasketQuantityViolation(2, undefined)).toBeNull()
+        })
+
+        it('should return a stock violation when the requested quantity exceeds the available stock', () => {
+            const service = TestBed.inject(BasketService)
+            expect(service.getGuestBasketQuantityViolation(3, { quantity: 2 })).toEqual({ type: 'stock' })
+        })
+
+        it('should return null when the requested quantity is within the available stock', () => {
+            const service = TestBed.inject(BasketService)
+            expect(service.getGuestBasketQuantityViolation(2, { quantity: 2 })).toBeNull()
+        })
+
+        it('should return a limit violation when the requested quantity exceeds the per-user limit', () => {
+            const service = TestBed.inject(BasketService)
+            expect(service.getGuestBasketQuantityViolation(2, { quantity: 10, limitPerUser: 1 })).toEqual({ type: 'limit', limitPerUser: 1 })
+        })
+
+        it('should return null when the requested quantity is within the per-user limit', () => {
+            const service = TestBed.inject(BasketService)
+            expect(service.getGuestBasketQuantityViolation(1, { quantity: 10, limitPerUser: 1 })).toBeNull()
+        })
+
+        it('should ignore the per-user limit for deluxe users', () => {
+            const service = TestBed.inject(BasketService)
+            expect(service.getGuestBasketQuantityViolation(2, { quantity: 10, limitPerUser: 1 }, true)).toBeNull()
+        })
+
+        it('should treat a zero per-user limit as unlimited', () => {
+            const service = TestBed.inject(BasketService)
+            expect(service.getGuestBasketQuantityViolation(2, { quantity: 10, limitPerUser: 0 })).toBeNull()
+        })
+    })
 })

--- a/frontend/src/app/Services/basket.service.ts
+++ b/frontend/src/app/Services/basket.service.ts
@@ -21,6 +21,15 @@ interface GuestBasketItem {
   quantity: number
 }
 
+export interface GuestBasketQuantityInfo {
+  limitPerUser?: number | null
+  quantity?: number
+}
+
+export type GuestBasketQuantityViolation =
+  | { type: 'limit', limitPerUser: number }
+  | { type: 'stock' }
+
 @Injectable({
   providedIn: 'root'
 })
@@ -132,6 +141,22 @@ export class BasketService {
     guestItemToUpdate.quantity = Math.max(1, quantity)
     sessionStorage.setItem(this.guestBasketKey, JSON.stringify(guestBasketItems))
     this.updateNumberOfCartItems()
+  }
+
+  getGuestBasketQuantityViolation (quantity: number, quantityInfo?: GuestBasketQuantityInfo, isDeluxe = false): GuestBasketQuantityViolation | null {
+    if (quantityInfo == null) {
+      return null
+    }
+
+    if (!isDeluxe && quantityInfo.limitPerUser != null && quantityInfo.limitPerUser > 0 && quantity > quantityInfo.limitPerUser) {
+      return { type: 'limit', limitPerUser: quantityInfo.limitPerUser }
+    }
+
+    if (quantityInfo.quantity != null && quantity > quantityInfo.quantity) {
+      return { type: 'stock' }
+    }
+
+    return null
   }
 
   removeGuestBasketItem (productId: number): void {

--- a/frontend/src/app/Services/snack-bar-helper.service.spec.ts
+++ b/frontend/src/app/Services/snack-bar-helper.service.spec.ts
@@ -27,4 +27,23 @@ describe('SnackBarHelperService', () => {
         const service: SnackBarHelperService = TestBed.inject(SnackBarHelperService)
         expect(service).toBeTruthy()
     })
+
+    it('should translate the per-user limit message with the quantity for limit violations', () => {
+        const service: SnackBarHelperService = TestBed.inject(SnackBarHelperService)
+        const translateService = TestBed.inject(TranslateService)
+        const getSpy = vi.spyOn(translateService, 'get')
+
+        service.openBasketQuantityViolation({ type: 'limit', limitPerUser: 3 })
+
+        expect(getSpy).toHaveBeenCalledWith('BASKET_ADD_PRODUCT_LIMIT', { quantity: 3 })
+    })
+
+    it('should show the out-of-stock message for stock violations', () => {
+        const service: SnackBarHelperService = TestBed.inject(SnackBarHelperService)
+        const openSpy = vi.spyOn(service, 'open')
+
+        service.openBasketQuantityViolation({ type: 'stock' })
+
+        expect(openSpy).toHaveBeenCalledWith('BASKET_ADD_PRODUCT_OUT_OF_STOCK', 'errorBar')
+    })
 })

--- a/frontend/src/app/Services/snack-bar-helper.service.ts
+++ b/frontend/src/app/Services/snack-bar-helper.service.ts
@@ -6,6 +6,7 @@
 import { Injectable, inject } from '@angular/core'
 import { MatSnackBar } from '@angular/material/snack-bar'
 import { TranslateService } from '@ngx-translate/core'
+import { type GuestBasketQuantityViolation } from './basket.service'
 
 @Injectable({
   providedIn: 'root'
@@ -18,17 +19,33 @@ export class SnackBarHelperService {
   open (message: string, cssClass?: string) {
     this.translateService.get(message).subscribe({
       next: (translatedMessage) => {
-        this.snackBar.open(translatedMessage, 'X', {
-          duration: 5000,
-          panelClass: [cssClass, 'mat-body']
-        })
+        this.show(translatedMessage, cssClass)
       },
       error: () => {
-        this.snackBar.open(message, 'X', {
-          duration: 5000,
-          panelClass: [cssClass, 'mat-body']
-        })
+        this.show(message, cssClass)
       }
+    })
+  }
+
+  openBasketQuantityViolation (violation: GuestBasketQuantityViolation) {
+    if (violation.type === 'limit') {
+      this.translateService.get('BASKET_ADD_PRODUCT_LIMIT', { quantity: violation.limitPerUser }).subscribe({
+        next: (translatedMessage) => {
+          this.show(translatedMessage, 'errorBar')
+        },
+        error: () => {
+          this.show('BASKET_ADD_PRODUCT_LIMIT', 'errorBar')
+        }
+      })
+    } else {
+      this.open('BASKET_ADD_PRODUCT_OUT_OF_STOCK', 'errorBar')
+    }
+  }
+
+  private show (message: string, cssClass?: string) {
+    this.snackBar.open(message, 'X', {
+      duration: 5000,
+      panelClass: [cssClass, 'mat-body']
     })
   }
 }

--- a/frontend/src/app/product/product.component.spec.ts
+++ b/frontend/src/app/product/product.component.spec.ts
@@ -51,14 +51,19 @@ describe('ProductComponent', () => {
             get: vi.fn().mockName("BasketService.get"),
             put: vi.fn().mockName("BasketService.put"),
             save: vi.fn().mockName("BasketService.save"),
-            updateNumberOfCartItems: vi.fn().mockName("BasketService.updateNumberOfCartItems")
+            updateNumberOfCartItems: vi.fn().mockName("BasketService.updateNumberOfCartItems"),
+            getGuestBasketItems: vi.fn().mockName("BasketService.getGuestBasketItems"),
+            getGuestBasketQuantityViolation: vi.fn().mockName("BasketService.getGuestBasketQuantityViolation")
         }
         basketService.find.mockReturnValue(of({ Products: [] } as any))
         basketService.get.mockReturnValue(of({ id: 1, quantity: 1 } as any))
         basketService.put.mockReturnValue(of({ ProductId: 1 } as any))
         basketService.save.mockReturnValue(of({ ProductId: 1 } as any))
+        basketService.getGuestBasketItems.mockReturnValue([])
+        basketService.getGuestBasketQuantityViolation.mockReturnValue(null)
         snackBarHelper = {
-            open: vi.fn().mockName("SnackBarHelperService.open")
+            open: vi.fn().mockName("SnackBarHelperService.open"),
+            openBasketQuantityViolation: vi.fn().mockName("SnackBarHelperService.openBasketQuantityViolation")
         }
 
         await TestBed.configureTestingModule({
@@ -280,6 +285,39 @@ describe('ProductComponent', () => {
             component.addToBasket(undefined)
             expect(basketService.addToGuestBasket).not.toHaveBeenCalled()
             expect(basketService.find).not.toHaveBeenCalled()
+        })
+
+        it('should not add more of a product to the guest basket than the per-user limit', () => {
+            fixture.componentRef.setInput('item', { ...testProduct, quantity: 5, limitPerUser: 1 })
+            basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 1, quantity: 1 }])
+            basketService.getGuestBasketQuantityViolation.mockReturnValue({ type: 'limit', limitPerUser: 1 })
+            component.addToBasket(1)
+            expect(snackBarHelper.openBasketQuantityViolation).toHaveBeenCalledWith({ type: 'limit', limitPerUser: 1 })
+            expect(basketService.addToGuestBasket).not.toHaveBeenCalled()
+        })
+
+        it('should not add a product to the guest basket when it is out of stock', () => {
+            fixture.componentRef.setInput('item', { ...testProduct, quantity: 1 })
+            basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 1, quantity: 1 }])
+            basketService.getGuestBasketQuantityViolation.mockReturnValue({ type: 'stock' })
+            component.addToBasket(1)
+            expect(snackBarHelper.openBasketQuantityViolation).toHaveBeenCalledWith({ type: 'stock' })
+            expect(basketService.addToGuestBasket).not.toHaveBeenCalled()
+        })
+
+        it('should add a product beyond its per-user limit to the guest basket for deluxe users', () => {
+            fixture.componentRef.setInput('isDeluxe', true)
+            fixture.componentRef.setInput('item', { ...testProduct, quantity: 5, limitPerUser: 1 })
+            basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 1, quantity: 1 }])
+            component.addToBasket(1)
+            expect(basketService.addToGuestBasket).toHaveBeenCalledWith(1)
+        })
+
+        it('should not restrict guest basket additions when the per-user limit is zero', () => {
+            fixture.componentRef.setInput('item', { ...testProduct, quantity: 10, limitPerUser: 0 })
+            basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 1, quantity: 4 }])
+            component.addToBasket(1)
+            expect(basketService.addToGuestBasket).toHaveBeenCalledWith(1)
         })
     })
 

--- a/frontend/src/app/product/product.component.ts
+++ b/frontend/src/app/product/product.component.ts
@@ -42,6 +42,17 @@ export class ProductComponent {
     }
 
     if (!this.isLoggedIn()) {
+      const guestBasketQuantity = this.basketService.getGuestBasketItems()
+        .filter(item => item.ProductId === id)
+        .reduce((sum, item) => sum + item.quantity, 0)
+      const newQuantity = guestBasketQuantity + 1
+      const violation = this.basketService.getGuestBasketQuantityViolation(newQuantity, this.item(), this.isDeluxe())
+
+      if (violation != null) {
+        this.snackBarHelperService.openBasketQuantityViolation(violation)
+        return
+      }
+
       this.basketService.addToGuestBasket(id)
       this.productService.get(id).subscribe({
         next: (product) => {

--- a/frontend/src/app/purchase-basket/purchase-basket.component.spec.ts
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.spec.ts
@@ -18,6 +18,7 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle'
 import { PurchaseBasketComponent } from '../purchase-basket/purchase-basket.component'
 import { UserService } from '../Services/user.service'
 import { ProductService } from '../Services/product.service'
+import { QuantityService } from '../Services/quantity.service'
 import { DeluxeGuard } from '../app.guard'
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar'
 import { EventEmitter } from '@angular/core'
@@ -29,6 +30,7 @@ describe('PurchaseBasketComponent', () => {
     let basketService
     let userService
     let productService
+    let quantityService
     let translateService: any
     let deluxeGuard
     let snackBar: any
@@ -42,7 +44,8 @@ describe('PurchaseBasketComponent', () => {
             updateNumberOfCartItems: vi.fn().mockName("BasketService.updateNumberOfCartItems"),
             getGuestBasketItems: vi.fn().mockName("BasketService.getGuestBasketItems"),
             removeGuestBasketItem: vi.fn().mockName("BasketService.removeGuestBasketItem"),
-            updateGuestBasketItemQuantity: vi.fn().mockName("BasketService.updateGuestBasketItemQuantity")
+            updateGuestBasketItemQuantity: vi.fn().mockName("BasketService.updateGuestBasketItemQuantity"),
+            getGuestBasketQuantityViolation: vi.fn().mockName("BasketService.getGuestBasketQuantityViolation")
         }
         basketService.find.mockReturnValue(of({ Products: [] }))
         basketService.del.mockReturnValue(of({}))
@@ -54,6 +57,7 @@ describe('PurchaseBasketComponent', () => {
         })
         basketService.updateGuestBasketItemQuantity.mockImplementation(() => {
         })
+        basketService.getGuestBasketQuantityViolation.mockReturnValue(null)
         userService = {
             whoAmI: vi.fn().mockName("UserService.whoAmI")
         }
@@ -62,6 +66,10 @@ describe('PurchaseBasketComponent', () => {
             get: vi.fn().mockName("ProductService.get")
         }
         productService.get.mockReturnValue(of({ id: 1, name: 'Product', price: 1, deluxePrice: 1 }))
+        quantityService = {
+            getAll: vi.fn().mockName("QuantityService.getAll")
+        }
+        quantityService.getAll.mockReturnValue(of([]))
         translateService = {
             get: vi.fn().mockName("TranslateService.get")
         }
@@ -94,6 +102,7 @@ describe('PurchaseBasketComponent', () => {
                 { provide: MatSnackBar, useValue: snackBar },
                 { provide: UserService, useValue: userService },
                 { provide: ProductService, useValue: productService },
+                { provide: QuantityService, useValue: quantityService },
                 { provide: DeluxeGuard, useValue: deluxeGuard },
                 provideHttpClient(withInterceptorsFromDi()),
                 provideHttpClientTesting()
@@ -355,6 +364,33 @@ describe('PurchaseBasketComponent', () => {
             basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 7, quantity: 2 }])
             component.dec(999)
             expect(basketService.updateGuestBasketItemQuantity).not.toHaveBeenCalled()
+        })
+
+        it('should not increase a guest basket item beyond its per-user limit', () => {
+            quantityService.getAll.mockReturnValue(of([{ ProductId: 7, quantity: 10, limitPerUser: 2 }]))
+            basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 7, quantity: 2 }])
+            basketService.getGuestBasketQuantityViolation.mockReturnValue({ type: 'limit', limitPerUser: 2 })
+            component.load()
+            component.inc(7)
+            expect(basketService.updateGuestBasketItemQuantity).not.toHaveBeenCalled()
+        })
+
+        it('should not increase a guest basket item beyond the available stock', () => {
+            quantityService.getAll.mockReturnValue(of([{ ProductId: 7, quantity: 2, limitPerUser: null }]))
+            basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 7, quantity: 2 }])
+            basketService.getGuestBasketQuantityViolation.mockReturnValue({ type: 'stock' })
+            component.load()
+            component.inc(7)
+            expect(basketService.updateGuestBasketItemQuantity).not.toHaveBeenCalled()
+        })
+
+        it('should allow deluxe users to increase a guest basket item beyond its per-user limit', () => {
+            deluxeGuard.isDeluxe.mockReturnValue(true)
+            quantityService.getAll.mockReturnValue(of([{ ProductId: 7, quantity: 10, limitPerUser: 2 }]))
+            basketService.getGuestBasketItems.mockReturnValue([{ ProductId: 7, quantity: 2 }])
+            component.load()
+            component.inc(7)
+            expect(basketService.updateGuestBasketItemQuantity).toHaveBeenCalledWith(7, 3)
         })
     })
 

--- a/frontend/src/app/purchase-basket/purchase-basket.component.ts
+++ b/frontend/src/app/purchase-basket/purchase-basket.component.ts
@@ -4,9 +4,10 @@
  */
 
 import { Component, EventEmitter, Input, type OnInit, Output, inject, ChangeDetectionStrategy } from '@angular/core'
-import { BasketService } from '../Services/basket.service'
+import { BasketService, type GuestBasketQuantityInfo } from '../Services/basket.service'
 import { UserService } from '../Services/user.service'
 import { ProductService } from '../Services/product.service'
+import { QuantityService } from '../Services/quantity.service'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons/'
 import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons'
@@ -33,6 +34,7 @@ export class PurchaseBasketComponent implements OnInit {
   private readonly basketService = inject(BasketService)
   private readonly userService = inject(UserService)
   private readonly productService = inject(ProductService)
+  private readonly quantityService = inject(QuantityService)
   private readonly snackBarHelperService = inject(SnackBarHelperService)
 
   @Input() public allowEdit = false
@@ -45,6 +47,7 @@ export class PurchaseBasketComponent implements OnInit {
   public bonus = 0
   public itemTotal = 0
   public userEmail: string
+  private guestQuantityInfo = new Map<number, GuestBasketQuantityInfo>()
 
   ngOnInit (): void {
     if (this.allowEdit && !this.tableColumns.includes('remove')) {
@@ -110,8 +113,12 @@ export class PurchaseBasketComponent implements OnInit {
       )
     })
 
-    forkJoin(guestProductRequests).subscribe({
-      next: (productResults) => {
+    forkJoin([this.quantityService.getAll().pipe(catchError(() => of([]))), ...guestProductRequests]).subscribe({
+      next: ([quantities, ...productResults]) => {
+        this.guestQuantityInfo = new Map(
+          quantities.map(quantity => [quantity.ProductId, { quantity: quantity.quantity, limitPerUser: quantity.limitPerUser }])
+        )
+
         this.dataSource = productResults
           .filter(result => result != null)
           .map(result => {
@@ -165,7 +172,12 @@ export class PurchaseBasketComponent implements OnInit {
         return
       }
 
-      this.basketService.updateGuestBasketItemQuantity(id, existingGuestItem.quantity + value)
+      const newQuantity = existingGuestItem.quantity + value
+      if (value > 0 && !this.isWithinGuestQuantityLimits(id, newQuantity)) {
+        return
+      }
+
+      this.basketService.updateGuestBasketItemQuantity(id, newQuantity)
       this.load()
       return
     }
@@ -196,5 +208,16 @@ export class PurchaseBasketComponent implements OnInit {
 
   isDeluxe () {
     return this.deluxeGuard.isDeluxe()
+  }
+
+  private isWithinGuestQuantityLimits (productId: number, quantity: number): boolean {
+    const violation = this.basketService.getGuestBasketQuantityViolation(quantity, this.guestQuantityInfo.get(productId), this.isDeluxe())
+
+    if (violation != null) {
+      this.snackBarHelperService.openBasketQuantityViolation(violation)
+      return false
+    }
+
+    return true
   }
 }

--- a/frontend/src/app/search-result/search-result.component.spec.ts
+++ b/frontend/src/app/search-result/search-result.component.spec.ts
@@ -294,7 +294,7 @@ describe('SearchResultComponent', () => {
                 { id: 2, name: 'Orange', price: 2, description: 'd', image: 'i' }
             ]))
             quantityService.getAll.mockReturnValue(of([
-                { ProductId: 1, quantity: 10 },
+                { ProductId: 1, quantity: 10, limitPerUser: 2 },
                 { ProductId: 3, quantity: 5 } // Non-existent product
             ]))
             component.ngAfterViewInit()
@@ -303,7 +303,9 @@ describe('SearchResultComponent', () => {
             const apple = component.dataSource.data.find(p => p.id === 1)
             const orange = component.dataSource.data.find(p => p.id === 2)
             expect(apple?.quantity).toBe(10)
+            expect(apple?.limitPerUser).toBe(2)
             expect(orange?.quantity).toBeUndefined()
+            expect(orange?.limitPerUser).toBeUndefined()
         })
 
         it('should unsubscribe the previous grid data source subscription when filtering twice', () => {

--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -85,6 +85,7 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
             continue
           }
           entry.quantity = quantity.quantity
+          entry.limitPerUser = quantity.limitPerUser
         }
         this.dataSource = new MatTableDataSource<ProductTableEntry>(dataTable)
         this.updatePageSizeOptions()

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -62,6 +62,8 @@
   "TITLE_ALL_PRODUCTS": "All Products",
   "BASKET_ADD_SAME_PRODUCT": "Added another {{product}} to basket.",
   "BASKET_ADD_PRODUCT": "Placed {{product}} into basket.",
+  "BASKET_ADD_PRODUCT_LIMIT": "You can order only up to {{quantity}} items of this product.",
+  "BASKET_ADD_PRODUCT_OUT_OF_STOCK": "We are out of stock! Sorry for the inconvenience.",
   "LABEL_PRODUCT": "Product",
   "LABEL_PRODUCT_ORDERED": "Ordered products",
   "LABEL_EXPECTED_DELIVERY": "Expected Delivery",

--- a/rsn/cache.json
+++ b/rsn/cache.json
@@ -1226,8 +1226,8 @@
 	},
 	"restfulXssChallenge_1_correct.ts": {
 		"added": [
-			42,
-			43
+			43,
+			44
 		],
 		"removed": []
 	},


### PR DESCRIPTION
### Description

On the product list page, anonymous users could add products to their guest basket in unlimited quantities — even when the product was out of stock or limited per user.

**Scenario A — per-user limit (*Juice Shop "Permafrost" 2020 Edition*, `limitPerUser: 1`)**

1. Start Juice Shop and, while logged out, add *Juice Shop "Permafrost" 2020 Edition* to the basket as many times as you like, plus a few other products.
2. Go to checkout and log in with `demo` / `demo`.
3. The *Permafrost* bottles are now **completely gone** from the basket.
4. While logged in, adding the product only allows the expected limit of 1 — making the loss during checkout look even stranger.

**Scenario B — stock limit (*Best Juice Shop Salesman Artwork*, `quantity: 1`, no per-user limit)**

1. While logged out, add *Best Juice Shop Salesman Artwork* to the basket multiple times — the UI lets you add far more than the single copy in stock.
2. Go to checkout and log in with `demo` / `demo`.
3. The artwork is **completely gone** from the basket (the server rejects the over-stock quantity during the merge and it is silently dropped).
4. While logged in, the same add attempt correctly fails with *"We are out of stock! Sorry for the inconvenience."*

**Why it happened**

- Guest basket additions were stored in `sessionStorage` with **no validation at all**.
- On login, the guest basket is merged into the server-side basket via `POST/PUT /api/BasketItems`. The server's `quantityCheck` rejects over-limit/over-stock items with `400`.
- Those rejections were swallowed (`catchError(() => of(null))`) and the whole guest basket was then cleared — so the invalid items **silently disappeared**.

### The fix

Guest basket changes now enforce the same rules the server applies, before anything is stored:

- **Rule evaluation** centralized in `BasketService.getGuestBasketQuantityViolation()` — mirrors `routes/basketItems.ts` `quantityCheck` exactly:
  - per-user limit (`limitPerUser`), bypassed for deluxe users, `0`/`null` = unlimited
  - available stock (`quantity`)
- **Product list** (`ProductComponent.addToBasket`): the guest path validates the new total (existing guest quantity + 1) before adding.
- **Basket steppers** (`PurchaseBasketComponent.addToQuantity`): guest `+` clicks validate the new quantity before updating.
- **Message display** centralized in `SnackBarHelperService.openBasketQuantityViolation()` — shows the same translated error snackbars the logged-in flow shows:
  - `BASKET_ADD_PRODUCT_LIMIT` → *"You can order only up to {{quantity}} items of this product."*
  - `BASKET_ADD_PRODUCT_OUT_OF_STOCK` → *"We are out of stock! Sorry for the inconvenience."*
- `limitPerUser` is propagated from `GET /api/Quantitys` into the product table entries.

### Notable details

- The search-result change touches the `restfulXssChallenge` code snippet → all 4 codefix files updated and the RSN cache re-locked (`npm run rsn` passes).
- New frontend i18n keys added to the Crowdin source `frontend/src/assets/i18n/en.json` only; other languages fall back to English until Crowdin translates.
- Known limitation (unchanged): a guest basket already containing over-limit items from *before* this fix can still be silently dropped at login merge. Validation prevents that state from arising going forward.

### Tests

- `BasketService`: 7 new unit tests covering all rule branches (limit/stock over & within, deluxe bypass, zero-limit, missing info).
- `SnackBarHelperService`: 2 new tests for violation message display.
- `ProductComponent` / `PurchaseBasketComponent`: tests for blocked additions on limit/stock and allowed additions for deluxe users.
- `SearchResultComponent`: asserts `limitPerUser` propagation.
- Full frontend suite: 1325 tests passing; `npm run lint` and `npm run rsn` clean; frontend + server build clean.

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Visual studio chat`
    - LLMs and versions: `DeepSeek V4 Pro`
    - Prompts: `Reported bug: guest users could add products to the anonymous basket beyond available stock/per-user limits, and those items silently disappeared after logging in during checkout (repro: "Juice Shop Permafrost 2020 Edition", "Best Juice Shop Salesman Artwork"). Planned the fix first; requested validation in both the product list and basket steppers with translated error snackbars; requested extraction of the duplicated validation logic into a shared service (BasketService) and the message display into SnackBarHelperService; fixed untranslated messages by adding frontend i18n keys; requested code review and PR description.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
