### PR TITLE
chore: replacing archived get-tag action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: "Get tag name"
-        id: tag
-        uses: dawidd6/action-get-tag@727a6f0a561be04e09013531e73a3983a65e3479 #v1.1.0 TODO Action is archived and should be replaced eventually
       - name: "Set labels for ${{ github.ref }}"
         run: |
           echo "VCS_REF=`git rev-parse --short HEAD`" >> $GITHUB_ENV
@@ -101,7 +98,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            bkimminich/juice-shop:${{ steps.tag.outputs.tag }}
+            bkimminich/juice-shop:${{ github.ref_name }}
           build-args: |
             VCS_REF=${{ env.VCS_REF }}
             BUILD_DATE=${{ env.BUILD_DATE }}


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a ban from inter-
acting with the project and the entire underlying GitHub organization. You can find
more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

While inspecting the GitHub Actions workflows, I noticed that the release workflow was using `dawidd6/action-get-tag`, which is an archived action. The workflow also contained a TODO noting that the action should eventually be replaced.

I first inspected how the release workflow is triggered and then checked the current Juice Shop release/tag convention to confirm what value the action was providing and how that value was being used. The action was only being used to obtain the tag name for the Docker image.

GitHub Actions already provides the tag name through the built-in `github.ref_name` context. Replacing the archived action with `github.ref_name` therefore removes an unmaintained third-party dependency while preserving the existing Docker image tag format and release behavior.

Scope: one workflow (`.github/workflows/release.yml`)
Reason: remove an archived dependency from the CI/CD infrastructure
Behavior: preserve the existing Docker image tag name
Validation: workflow configuration reviewed and the branch CI was checked

This also addresses the TODO left in the workflow regarding replacement of the archived action.

Resolved or fixed issue: none

### AI Tool Disclosure

- [] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
AI Tools: ChatGPT
LLMs and versions: GPT-5.6 Luna
Prompts: Used ChatGPT to investigate the repository, identify the archived GitHub Action, verify the appropriate GitHub Actions replacement, and assist in the contribution workflow.

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
