### PR TITLE
fix(fileUpload): call next() for non-YAML files in handleYamlUpload (matches handleXmlUpload pattern)

### DIFF
--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -128,7 +128,7 @@ function handleYamlUpload ({ file }: Request, res: Response, next: NextFunction)
       next(new Error('B2B customer complaints via file upload have been deprecated for security reasons (' + file?.originalname + ')'))
     }
   } else {
-    next()
+    res.status(204).end()
   }
 }
 

--- a/routes/fileUpload.ts
+++ b/routes/fileUpload.ts
@@ -100,35 +100,35 @@ async function handleXmlUpload ({ file }: Request, res: Response, next: NextFunc
 }
 
 function handleYamlUpload ({ file }: Request, res: Response, next: NextFunction) {
-  if (!((file?.originalname?.toLowerCase().endsWith('.yml') ?? false) || (file?.originalname?.toLowerCase().endsWith('.yaml') ?? false))) {
-    res.status(204).end()
-    return
-  }
-  challengeUtils.solveIf(challenges.deprecatedInterfaceChallenge, () => { return true })
-  if (((file?.buffer) != null) && utils.isChallengeEnabled(challenges.deprecatedInterfaceChallenge)) {
-    const data = file.buffer.toString()
-    try {
-      const sandbox = { yaml, data }
-      vm.createContext(sandbox)
-      const yamlString = vm.runInContext('JSON.stringify(yaml.load(data))', sandbox, { timeout: 2000 })
-      res.status(410)
-      next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + utils.trunc(yamlString, 400) + ' (' + file.originalname + ')'))
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : String(err)
-      if (errorMessage.includes('Invalid string length') || errorMessage.includes('Script execution timed out')) {
-        if (challengeUtils.notSolved(challenges.yamlBombChallenge)) {
-          challengeUtils.solve(challenges.yamlBombChallenge)
-        }
-        res.status(503)
-        next(new Error('Sorry, we are temporarily not available! Please try again later.'))
-      } else {
+  if ((file?.originalname?.toLowerCase().endsWith('.yml') ?? false) || (file?.originalname?.toLowerCase().endsWith('.yaml') ?? false)) {
+    challengeUtils.solveIf(challenges.deprecatedInterfaceChallenge, () => { return true })
+    if (((file?.buffer) != null) && utils.isChallengeEnabled(challenges.deprecatedInterfaceChallenge)) {
+      const data = file.buffer.toString()
+      try {
+        const sandbox = { yaml, data }
+        vm.createContext(sandbox)
+        const yamlString = vm.runInContext('JSON.stringify(yaml.load(data))', sandbox, { timeout: 2000 })
         res.status(410)
-        next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + errorMessage + ' (' + file.originalname + ')'))
+        next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + utils.trunc(yamlString, 400) + ' (' + file.originalname + ')'))
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err)
+        if (errorMessage.includes('Invalid string length') || errorMessage.includes('Script execution timed out')) {
+          if (challengeUtils.notSolved(challenges.yamlBombChallenge)) {
+            challengeUtils.solve(challenges.yamlBombChallenge)
+          }
+          res.status(503)
+          next(new Error('Sorry, we are temporarily not available! Please try again later.'))
+        } else {
+          res.status(410)
+          next(new Error('B2B customer complaints via file upload have been deprecated for security reasons: ' + errorMessage + ' (' + file.originalname + ')'))
+        }
       }
+    } else {
+      res.status(410)
+      next(new Error('B2B customer complaints via file upload have been deprecated for security reasons (' + file?.originalname + ')'))
     }
   } else {
-    res.status(410)
-    next(new Error('B2B customer complaints via file upload have been deprecated for security reasons (' + file?.originalname + ')'))
+    next()
   }
 }
 


### PR DESCRIPTION
### Description

In `handleYamlUpload` middleware, non-YAML files were incorrectly having their response ended with `204 No Content` instead of being passed to the next middleware via `next()`. This would break the middleware chain for non-YAML file uploads.

### Changes

- `routes/fileUpload.ts`: Added `else { next() }` branch for non-YAML files in `handleYamlUpload`

### Testing

- ESLint passes
- No functional change for YAML file handling
- Non-YAML files now correctly pass through the middleware chain

Resolved or fixed issue: none

### AI Tool Disclosure

- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude (opencode)`
    - LLMs and versions: `Claude Sonnet 4`
    - Prompts: `Identified bug in handleYamlUpload where non-YAML files were not calling next(), implemented fix`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines