### PR TITLE
fix: restore exact array assertions in challenge filtering tests

### DIFF
--- a/frontend/src/app/score-board/helpers/challenge-filtering.spec.ts
+++ b/frontend/src/app/score-board/helpers/challenge-filtering.spec.ts
@@ -60,30 +60,18 @@ describe('filterChallenges', () => {
     })
 
     it('should filter challenges based on categories properly', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, categories: ['foobar'] }).map((challenge) => challenge.key)).toHaveLength(2)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, categories: ['foobar'] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-2']))
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, categories: ['barfoo'] }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, categories: ['barfoo'] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-3']))
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, categories: ['foobar'] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-2'].sort())
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, categories: ['barfoo'] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-3'].sort())
     })
 
     it('should filter challenges based on difficulties properly', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, difficulties: [1, 6] }).map((challenge) => challenge.key)).toHaveLength(2)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, difficulties: [1, 6] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-3']))
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, difficulties: [3] }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, difficulties: [3] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-2']))
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, difficulties: [1, 6] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-3'].sort())
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, difficulties: [3] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-2'].sort())
     })
 
     it('should filter challenges based on tags properly', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, tags: ['easy'] }).map((challenge) => challenge.key)).toHaveLength(2)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, tags: ['easy'] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-2']))
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, tags: ['hard'] }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, tags: ['hard'] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-3']))
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, tags: ['easy'] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-2'].sort())
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, tags: ['hard'] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-3'].sort())
     })
 
     it('should filter challenges with "External Dependency" tag matching any "Requires ..." tag', () => {
@@ -101,11 +89,7 @@ describe('filterChallenges', () => {
             ...CHALLENGE_3,
             tagList: ['hard']
         } as EnrichedChallenge
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-
-        expect(filterChallenges([challengeWithRequires, challengeWithOtherRequires, challengeWithoutRequires], { ...DEFAULT_FILTER_SETTING, tags: [EXTERNAL_DEPENDENCY_TAG] }).map((challenge) => challenge.key)).toHaveLength(2)
-
-        expect(filterChallenges([challengeWithRequires, challengeWithOtherRequires, challengeWithoutRequires], { ...DEFAULT_FILTER_SETTING, tags: [EXTERNAL_DEPENDENCY_TAG] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-requires', 'challenge-requires-2']))
+        expect(filterChallenges([challengeWithRequires, challengeWithOtherRequires, challengeWithoutRequires], { ...DEFAULT_FILTER_SETTING, tags: [EXTERNAL_DEPENDENCY_TAG] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-requires', 'challenge-requires-2'].sort())
     })
 
     it('should allow combining "External Dependency" with other tags', () => {
@@ -124,64 +108,38 @@ describe('filterChallenges', () => {
             key: 'challenge-easy',
             tagList: ['easy']
         } as EnrichedChallenge
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-
-        expect(filterChallenges([challengeWithRequires, challengeWithHardTag, challengeWithEasyTag], { ...DEFAULT_FILTER_SETTING, tags: [EXTERNAL_DEPENDENCY_TAG, 'hard'] }).map((challenge) => challenge.key)).toHaveLength(2)
-
-        expect(filterChallenges([challengeWithRequires, challengeWithHardTag, challengeWithEasyTag], { ...DEFAULT_FILTER_SETTING, tags: [EXTERNAL_DEPENDENCY_TAG, 'hard'] }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-requires', 'challenge-hard']))
+       expect(filterChallenges([challengeWithRequires, challengeWithHardTag, challengeWithEasyTag], { ...DEFAULT_FILTER_SETTING, tags: [EXTERNAL_DEPENDENCY_TAG, 'hard'] }).map((challenge) => challenge.key).sort()).toEqual(['challenge-requires', 'challenge-hard'].sort())
     })
 
     it('should filter challenges based on status properly', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'solved' }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'solved' }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-2']))
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'unsolved' }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'unsolved' }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1']))
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'partially-solved' }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'partially-solved' }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-3']))
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'solved' }).map((challenge) => challenge.key).sort()).toEqual(['challenge-2'].sort())
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'unsolved' }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1'].sort())
+       expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, status: 'partially-solved' }).map((challenge) => challenge.key).sort()).toEqual(['challenge-3'].sort())
     })
 
     it('should filter challenges based on searchQuery properly', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, searchQuery: 'lorem' }).map((challenge) => challenge.key)).toHaveLength(3)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, searchQuery: 'lorem' }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-2', 'challenge-3']))
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, searchQuery: 'challenge three' }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, searchQuery: 'challenge three' }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-3']))
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, searchQuery: 'lorem' }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-2', 'challenge-3'].sort())
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, searchQuery: 'challenge three' }).map((challenge) => challenge.key).sort()).toEqual(['challenge-3'].sort())
     })
 
     it('should filter challenges based on disabled setting properly', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, showDisabledChallenges: true }).map((challenge) => challenge.key)).toHaveLength(3)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, showDisabledChallenges: true }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-2', 'challenge-3']))
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, showDisabledChallenges: false }).map((challenge) => challenge.key)).toHaveLength(2)
-        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, showDisabledChallenges: false }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-2']))
+       expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, showDisabledChallenges: true }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-2', 'challenge-3'].sort())
+        expect(filterChallenges([CHALLENGE_1, CHALLENGE_2, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, showDisabledChallenges: false }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-2'].sort())
     })
 
     it('should only show unsolved tutorial of first difficulty if no challenges are solved', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, { ...CHALLENGE_2, solved: false }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, { ...CHALLENGE_2, solved: false }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1']))
+       expect(filterChallenges([CHALLENGE_1, { ...CHALLENGE_2, solved: false }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1'].sort())
     })
 
     it('should only show tutorial challenges when restrictToTutorialChallengesFirst is set', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([CHALLENGE_1, { ...CHALLENGE_2, solved: false, difficulty: 1, tutorialOrder: null }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toHaveLength(1)
-        expect(filterChallenges([CHALLENGE_1, { ...CHALLENGE_2, solved: false, difficulty: 1, tutorialOrder: null }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1']))
+        expect(filterChallenges([CHALLENGE_1, { ...CHALLENGE_2, solved: false, difficulty: 1, tutorialOrder: null }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1'].sort())
     })
 
     it('should only show unsolved tutorial of first difficulty and solved ones of easier difficulties', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([{ ...CHALLENGE_1, solved: true }, { ...CHALLENGE_2, solved: false }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toHaveLength(2)
-        expect(filterChallenges([{ ...CHALLENGE_1, solved: true }, { ...CHALLENGE_2, solved: false }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-2']))
+        expect(filterChallenges([{ ...CHALLENGE_1, solved: true }, { ...CHALLENGE_2, solved: false }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-2'].sort())
     })
 
     it('should only show ignore tutorial mode when all tutorial challenges are solved', () => {
-        // TODO: vitest-migration: Verify this matches strict array content (multiset equality). Vitest's arrayContaining is a subset check.
-        expect(filterChallenges([{ ...CHALLENGE_1, solved: true }, { ...CHALLENGE_2, solved: true }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toHaveLength(3)
-        expect(filterChallenges([{ ...CHALLENGE_1, solved: true }, { ...CHALLENGE_2, solved: true }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key)).toEqual(expect.arrayContaining(['challenge-1', 'challenge-2', 'challenge-3']))
+        expect(filterChallenges([{ ...CHALLENGE_1, solved: true }, { ...CHALLENGE_2, solved: true }, CHALLENGE_3], { ...DEFAULT_FILTER_SETTING, restrictToTutorialChallengesFirst: true }).map((challenge) => challenge.key).sort()).toEqual(['challenge-1', 'challenge-2', 'challenge-3'].sort())
     })
 })


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a ban from inter-
acting with the project and the entire underlying GitHub organization. You can find
more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

Restore the exact-content semantics of challenge filtering assertions after the Vitest migration.

While reviewing `frontend/src/app/score-board/helpers/challenge-filtering.spec.ts`, I found several assertions using `expect.arrayContaining()` together with `toHaveLength()`. The original Jasmine tests used `jasmine.arrayWithExactContents()`, so I investigated whether the migrated assertions were semantically equivalent.

I first tested the difference with a temporary Vitest experiment. In particular, I tested the case where:

- Actual: `[challenge-1, challenge-2]`
- Expected: `[challenge-1, challenge-1]`

A subset-style `arrayContaining()` assertion can pass in this case because it does not enforce the number of occurrences of each expected value, while an exact multiset comparison must fail because the occurrence counts differ.

The experiment confirmed that `arrayContaining()` does not enforce the same duplicate-count semantics as `arrayWithExactContents()`.

I then replaced the affected assertions with sorted challenge-key arrays compared using `toEqual()`. Sorting keeps the comparison order-independent, while `toEqual()` enforces exact contents and duplicate counts. The existing `map()` already creates a new array, so sorting the mapped keys does not mutate the original challenge collection.

All affected assertions in the file were updated, and the temporary experiment was removed.

#### Testing

- `npx ng test --watch=false --include="src/app/score-board/helpers/challenge-filtering.spec.ts"` — 13/13 tests passed
- `npm run lint` — passed
- `git diff --check` — passed

Resolved or fixed issue: `none`

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `ChatGPT`
    - LLMs and versions: `GPT-5.6 Luna`
    - Prompts: `Used for code investigation, reasoning about the semantic difference between Jasmine and Vitest array matchers, validating the test approach, and reviewing the contribution workflow. AI assistance was used during the investigation and implementation process; the resulting changes and tests were manually reviewed and verified in the repository.`

### Affirmation

- [x] My code follows the https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md guidelines