### PR TITLE
Migrate login page to Angular Signals and align layout with registration page

### DIFF
--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -9,30 +9,30 @@
 
       <h1 class="mat-headline-medium">Login</h1>
 
-      @if (error) {
-      <div class="error">{{error}}</div>
+      @if (error()) {
+      <div class="error">{{error()}}</div>
       }
 
       <form class="form-container" id="login-form" (ngSubmit)="login()">
 
         <mat-form-field color="tertiary" appearance="outline">
           <mat-label translate>LABEL_EMAIL</mat-label>
-          <input id="email" #email name="email"
-            [formControl]="emailControl"
-            (focus)="this.error=null"
+          <input id="email"
+            [formField]="loginForm.email"
+            (focus)="error.set(null)"
             matInput placeholder=""
             aria-label="Text field for the login email"
           >
-          @if (emailControl.invalid) {
+          @if (loginForm.email().getError('required')) {
           <mat-error translate>MANDATORY_EMAIL</mat-error>
           }
         </mat-form-field>
 
         <mat-form-field color="tertiary" appearance="outline">
           <mat-label translate>LABEL_PASSWORD</mat-label>
-          <input id="password" #password name="password"
-            [formControl]="passwordControl"
-            (focus)="this.error=null"
+          <input id="password"
+            [formField]="loginForm.password"
+            (focus)="error.set(null)"
             matInput placeholder="" [type]="hide ? 'password' : 'text'"
             aria-label="Text field for the login password"
           >
@@ -47,7 +47,7 @@
             <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
           </button>
           }
-          @if (passwordControl.invalid) {
+          @if (loginForm.password().getError('required')) {
           <mat-error translate>MANDATORY_PASSWORD</mat-error>
           }
         </mat-form-field>
@@ -57,7 +57,7 @@
         <button
           type="submit"
           id="loginButton"
-          [disabled]="!emailControl.value||!passwordControl.value"
+          [disabled]="!loginForm.email().value() || !loginForm.password().value()"
           mat-raised-button
           color="primary"
           aria-label="Login"
@@ -68,7 +68,7 @@
           {{'BTN_LOGIN' | translate}}
         </button>
 
-        <mat-checkbox [formControl]="rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
+        <mat-checkbox [formField]="loginForm.rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
           {{'REMEMBER_ME' | translate}}
         </mat-checkbox>
 

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -5,7 +5,7 @@
 
 <main class="center-container">
   <mat-card appearance="outlined" class="mat-elevation-z6 mdc-card">
-    <h1 class="mat-headline-medium">Login</h1>
+    <h1 class="mat-headline-medium" translate>TITLE_LOGIN</h1>
 
     @if (error()) {
     <div class="error">{{error()}}</div>

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -37,12 +37,12 @@
             aria-label="Text field for the login password"
           >
           @if (hide) {
-          <button type="button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to display the password"
+          <button type="button" class="password-toggle-button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to display the password"
             matTooltip="{{ 'SHOW_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
             <i class="fas fa-eye" aria-label="Eye"></i>
           </button>
           } @else {
-          <button type="button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password"
+          <button type="button" class="password-toggle-button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password"
             matTooltip="{{ 'HIDE_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
             <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
           </button>

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -3,102 +3,99 @@
   ~ SPDX-License-Identifier: MIT
 -->
 
-<div class="center-container">
-  <mat-card appearance="outlined" class="mat-elevation-z6">
-    <div class="mdc-card">
+<main class="center-container">
+  <mat-card appearance="outlined" class="mat-elevation-z6 mdc-card">
+    <h1 class="mat-headline-medium">Login</h1>
 
-      <h1 class="mat-headline-medium">Login</h1>
+    @if (error()) {
+    <div class="error">{{error()}}</div>
+    }
 
-      @if (error()) {
-      <div class="error">{{error()}}</div>
+    <form class="form-container" id="login-form" (ngSubmit)="login()">
+
+      <mat-form-field color="tertiary" appearance="outline">
+        <mat-label translate>LABEL_EMAIL</mat-label>
+        <input id="email"
+          [formField]="loginForm.email"
+          (focus)="error.set(null)"
+          matInput placeholder=""
+          aria-label="Text field for the login email"
+        >
+        @if (loginForm.email().getError('required')) {
+        <mat-error translate>MANDATORY_EMAIL</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field color="tertiary" appearance="outline">
+        <mat-label translate>LABEL_PASSWORD</mat-label>
+        <input id="password"
+          [formField]="loginForm.password"
+          (focus)="error.set(null)"
+          matInput placeholder="" [type]="hide ? 'password' : 'text'"
+          aria-label="Text field for the login password"
+        >
+        @if (hide) {
+        <button type="button" class="password-toggle-button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to display the password"
+          matTooltip="{{ 'SHOW_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
+          <i class="fas fa-eye" aria-label="Eye"></i>
+        </button>
+        } @else {
+        <button type="button" class="password-toggle-button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password"
+          matTooltip="{{ 'HIDE_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
+          <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
+        </button>
+        }
+        @if (loginForm.password().getError('required')) {
+        <mat-error translate>MANDATORY_PASSWORD</mat-error>
+        }
+      </mat-form-field>
+
+      <a class="primary-link forgot-pw" routerLink="/forgot-password" translate>FORGOT_PASSWORD</a>
+
+      <button
+        type="submit"
+        id="loginButton"
+        [disabled]="!loginForm.email().value() || !loginForm.password().value()"
+        mat-raised-button
+        color="primary"
+        aria-label="Login"
+      >
+        <mat-icon>
+          exit_to_app
+        </mat-icon>
+        {{'BTN_LOGIN' | translate}}
+      </button>
+
+      <mat-checkbox [formField]="loginForm.rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
+        {{'REMEMBER_ME' | translate}}
+      </mat-checkbox>
+
+      @if (!oauthUnavailable) {
+      <div class="breakLine">
+        <div class="line">
+          <div></div>
+        </div>
+        <div class="textOnLine" translate>LABEL_OR</div>
+        <div class="line">
+          <div></div>
+        </div>
+      </div>
       }
 
-      <form class="form-container" id="login-form" (ngSubmit)="login()">
+      @if (!oauthUnavailable) {
+      <button type="button" id="loginButtonGoogle"
+        mat-raised-button color="tertiary"
+        (click)="googleLogin()"
+        aria-label="Login with Google"
+        class="google-button"
+      >
+        <i class="fab fa-google fa-lg"></i> {{'BTN_GOOGLE_LOGIN' | translate}}
+      </button>
+      }
 
-        <mat-form-field color="tertiary" appearance="outline">
-          <mat-label translate>LABEL_EMAIL</mat-label>
-          <input id="email"
-            [formField]="loginForm.email"
-            (focus)="error.set(null)"
-            matInput placeholder=""
-            aria-label="Text field for the login email"
-          >
-          @if (loginForm.email().getError('required')) {
-          <mat-error translate>MANDATORY_EMAIL</mat-error>
-          }
-        </mat-form-field>
-
-        <mat-form-field color="tertiary" appearance="outline">
-          <mat-label translate>LABEL_PASSWORD</mat-label>
-          <input id="password"
-            [formField]="loginForm.password"
-            (focus)="error.set(null)"
-            matInput placeholder="" [type]="hide ? 'password' : 'text'"
-            aria-label="Text field for the login password"
-          >
-          @if (hide) {
-          <button type="button" class="password-toggle-button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to display the password"
-            matTooltip="{{ 'SHOW_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
-            <i class="fas fa-eye" aria-label="Eye"></i>
-          </button>
-          } @else {
-          <button type="button" class="password-toggle-button" mat-icon-button matSuffix (click)="hide = !hide" aria-label="Button to hide the password"
-            matTooltip="{{ 'HIDE_PWD_TOOLTIP' | translate  }}" matTooltipPosition=right>
-            <i class="fas fa-eye-slash" aria-label="Eye Slash"></i>
-          </button>
-          }
-          @if (loginForm.password().getError('required')) {
-          <mat-error translate>MANDATORY_PASSWORD</mat-error>
-          }
-        </mat-form-field>
-
-        <a class="primary-link forgot-pw" routerLink="/forgot-password" translate>FORGOT_PASSWORD</a>
-
-        <button
-          type="submit"
-          id="loginButton"
-          [disabled]="!loginForm.email().value() || !loginForm.password().value()"
-          mat-raised-button
-          color="primary"
-          aria-label="Login"
-        >
-          <mat-icon>
-            exit_to_app
-          </mat-icon>
-          {{'BTN_LOGIN' | translate}}
-        </button>
-
-        <mat-checkbox [formField]="loginForm.rememberMe" id="rememberMe" aria-label="Checkbox to stay logged in or not logged in">
-          {{'REMEMBER_ME' | translate}}
-        </mat-checkbox>
-
-        @if (!oauthUnavailable) {
-        <div class="breakLine">
-          <div class="line">
-            <div></div>
-          </div>
-          <div class="textOnLine" translate>LABEL_OR</div>
-          <div class="line">
-            <div></div>
-          </div>
-        </div>
-        }
-
-        @if (!oauthUnavailable) {
-        <button type="button" id="loginButtonGoogle"
-          mat-raised-button color="tertiary"
-          (click)="googleLogin()"
-          aria-label="Login with Google"
-          class="google-button"
-        >
-          <i class="fab fa-google fa-lg"></i> {{'BTN_GOOGLE_LOGIN' | translate}}
-        </button>
-        }
-
-        <div id="newCustomerLink">
-          <a class="primary-link" routerLink="/register" translate>NO_CUSTOMER</a>
-        </div>
-      </form>
-    </div>
+      <div id="newCustomerLink">
+        <a class="primary-link" routerLink="/register" translate>NO_CUSTOMER</a>
+      </div>
+    </form>
   </mat-card>
-</div>
+</main>

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -8,7 +8,7 @@
     <h1 class="mat-headline-medium" translate>TITLE_LOGIN</h1>
 
     @if (error()) {
-    <div class="error">{{error()}}</div>
+    <div class="error" role="alert">{{error()}}</div>
     }
 
     <form class="form-container" id="login-form" (ngSubmit)="login()">

--- a/frontend/src/app/login/login.component.scss
+++ b/frontend/src/app/login/login.component.scss
@@ -39,6 +39,10 @@ mat-form-field:nth-child(2) {
   padding-bottom: $space-ml;
 }
 
+.password-toggle-button {
+  margin-right: $space-s;
+}
+
 #loginButton,
 #loginButtonGoogle {
   margin-left: 20%;

--- a/frontend/src/app/login/login.component.scss
+++ b/frontend/src/app/login/login.component.scss
@@ -24,6 +24,10 @@ mat-card {
   }
 }
 
+.error {
+  margin-bottom: $space-m;
+}
+
 .form-container {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/login/login.component.scss
+++ b/frontend/src/app/login/login.component.scss
@@ -9,7 +9,7 @@ $break-line: #c0c0c0;
 
 mat-card {
   height: auto;
-  min-width: 400px;
+  min-width: 410px;
   width: 25%;
   padding: $space-l $space-xl;
 }

--- a/frontend/src/app/login/login.component.scss
+++ b/frontend/src/app/login/login.component.scss
@@ -22,7 +22,6 @@ mat-card {
 
 .forgot-pw {
   font-size: 11px;
-  margin-top: -$space-m;
 }
 
 mat-checkbox {
@@ -32,11 +31,7 @@ mat-checkbox {
 }
 
 mat-form-field {
-  padding-top: $space-s;
-}
-
-mat-form-field:nth-child(2) {
-  padding-bottom: $space-ml;
+  margin-bottom: $space-m;
 }
 
 .password-toggle-button {

--- a/frontend/src/app/login/login.component.scss
+++ b/frontend/src/app/login/login.component.scss
@@ -9,8 +9,19 @@ $break-line: #c0c0c0;
 
 mat-card {
   height: auto;
-  min-width: 320px;
+  min-width: 400px;
   width: 25%;
+  padding: $space-l $space-xl;
+}
+
+@media (max-width: 599.98px) {
+  mat-card {
+    width: 100%;
+    min-width: auto;
+    margin-bottom: $space-l;
+    margin-left: $space-m;
+    margin-right: $space-m;
+  }
 }
 
 .form-container {

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -256,6 +256,7 @@ describe('LoginComponent', () => {
             fixture.detectChanges()
             const errorEl = (fixture.nativeElement as HTMLElement).querySelector('.error')
             expect(errorEl?.textContent).toContain('Invalid credentials')
+            expect(errorEl?.getAttribute('role')).toBe('alert')
         })
 
         it('should clear the error when the email input receives focus', () => {

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -210,7 +210,7 @@ describe('LoginComponent', () => {
     describe('template rendering', () => {
         it('should render the login heading, email and password inputs and the login button', () => {
             const compiled: HTMLElement = fixture.nativeElement
-            expect(compiled.querySelector('h1')?.textContent).toContain('Login')
+            expect(compiled.querySelector('h1')).toBeTruthy()
             expect(compiled.querySelector('input#email')).toBeTruthy()
             expect(compiled.querySelector('input#password')).toBeTruthy()
             expect(compiled.querySelector('button#loginButton')).toBeTruthy()

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -207,6 +207,14 @@ describe('LoginComponent', () => {
         expect(localStorage.getItem('email')).toBe('horst@juice-sh.op')
     })
 
+    it('removes the remembered email on login with remember-me checkbox unticked', async () => {
+        localStorage.setItem('email', 'horst@juice-sh.op')
+        userService.login.mockReturnValue(of({}))
+        component.loginModel.update((model) => ({ ...model, email: 'horst@juice-sh.op', password: 'p', rememberMe: false }))
+        await component.login()
+        expect(localStorage.getItem('email')).toBeNull()
+    })
+
     describe('template rendering', () => {
         it('should render the login heading, email and password inputs and the login button', () => {
             const compiled: HTMLElement = fixture.nativeElement

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -140,6 +140,12 @@ describe('LoginComponent', () => {
         expect(component.oauthUnavailable).toBe(true)
     })
 
+    it('should not attempt login while the form is invalid', async () => {
+        userService.login.mockReturnValue(of({}))
+        await component.login()
+        expect(userService.login).not.toHaveBeenCalled()
+    })
+
     it('forwards to main page after successful login', async () => {
         component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
         userService.login.mockReturnValue(of({}))
@@ -222,11 +228,41 @@ describe('LoginComponent', () => {
             expect(compiled.querySelector('#newCustomerLink a')).toBeTruthy()
         })
 
+        it('should enable the login button once email and password are provided', () => {
+            component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
+            fixture.detectChanges()
+            const loginButton = (fixture.nativeElement as HTMLElement).querySelector('#loginButton') as HTMLButtonElement
+            expect(loginButton.disabled).toBe(false)
+        })
+
+        it('should check the remember-me checkbox when a remembered email exists', () => {
+            localStorage.setItem('email', 'a@a')
+            component.ngOnInit()
+            fixture.detectChanges()
+            const checkbox = (fixture.nativeElement as HTMLElement).querySelector('#rememberMe input') as HTMLInputElement
+            expect(checkbox.checked).toBe(true)
+        })
+
+        it('should update the login model when the remember-me checkbox is toggled', () => {
+            const checkbox = (fixture.nativeElement as HTMLElement).querySelector('#rememberMe') as HTMLElement
+            checkbox.click()
+            fixture.detectChanges()
+            expect(component.loginModel().rememberMe).toBe(true)
+        })
+
         it('should show the error message banner when an error is set', () => {
             component.error.set('Invalid credentials')
             fixture.detectChanges()
             const errorEl = (fixture.nativeElement as HTMLElement).querySelector('.error')
             expect(errorEl?.textContent).toContain('Invalid credentials')
+        })
+
+        it('should clear the error when the email input receives focus', () => {
+            component.error.set('Invalid credentials')
+            fixture.detectChanges()
+            const emailInput = (fixture.nativeElement as HTMLElement).querySelector('#email') as HTMLInputElement
+            emailInput.dispatchEvent(new Event('focus'))
+            expect(component.error()).toBeNull()
         })
 
         it('should hide the OAuth login section when oauthUnavailable is true', () => {
@@ -235,6 +271,15 @@ describe('LoginComponent', () => {
             const compiled: HTMLElement = fixture.nativeElement
             expect(compiled.querySelector('#loginButtonGoogle')).toBeNull()
             expect(compiled.querySelector('.breakLine')).toBeNull()
+        })
+
+        it('should invoke googleLogin when the Google button is clicked', () => {
+            component.oauthUnavailable = false
+            fixture.detectChanges()
+            const googleSpy = vi.spyOn(component, 'googleLogin')
+            const googleButton = (fixture.nativeElement as HTMLElement).querySelector('#loginButtonGoogle') as HTMLButtonElement
+            googleButton.click()
+            expect(googleSpy).toHaveBeenCalled()
         })
 
         it('should show the OAuth login section and toggle password visibility', () => {
@@ -253,7 +298,13 @@ describe('LoginComponent', () => {
 
             expect(component.hide).toBe(false)
             expect(password.type).toBe('text')
-            expect(compiled.querySelector('[aria-label="Button to hide the password"]')).toBeTruthy()
+            const hideToggle = compiled.querySelector('[aria-label="Button to hide the password"]') as HTMLButtonElement
+            expect(hideToggle).toBeTruthy()
+            hideToggle.click()
+            fixture.detectChanges()
+
+            expect(component.hide).toBe(true)
+            expect(password.type).toBe('password')
         })
 
         it('should submit the form when email and password are provided', () => {

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -244,8 +244,8 @@ describe('LoginComponent', () => {
         })
 
         it('should update the login model when the remember-me checkbox is toggled', () => {
-            const checkbox = (fixture.nativeElement as HTMLElement).querySelector('#rememberMe') as HTMLElement
-            checkbox.click()
+            const checkboxInput = (fixture.nativeElement as HTMLElement).querySelector('#rememberMe input') as HTMLInputElement
+            checkboxInput.click()
             fixture.detectChanges()
             expect(component.loginModel().rememberMe).toBe(true)
         })

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -9,7 +9,8 @@ import { provideHttpClientTesting } from '@angular/common/http/testing'
 import { UserService } from '../Services/user.service'
 import { type ComponentFixture, TestBed } from '@angular/core/testing'
 import { LoginComponent } from './login.component'
-import { RouterTestingModule } from '@angular/router/testing'
+import { provideRouter } from '@angular/router'
+import { provideLocationMocks } from '@angular/common/testing'
 
 import { MatIconModule } from '@angular/material/icon'
 import { MatCheckboxModule } from '@angular/material/checkbox'
@@ -66,9 +67,7 @@ describe('LoginComponent', () => {
         }
 
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([
-                    { path: 'search', component: SearchResultComponent }
-                ]),
+            imports: [
                 CookieModule.forRoot(),
                 TranslateModule.forRoot(),
                 MatCheckboxModule,
@@ -84,6 +83,8 @@ describe('LoginComponent', () => {
                 MatTooltipModule,
                 LoginComponent, SearchResultComponent],
             providers: [
+                provideRouter([{ path: 'search', component: SearchResultComponent }]),
+                provideLocationMocks(),
                 { provide: UserService, useValue: userService },
                 { provide: ConfigurationService, useValue: configurationService },
                 { provide: BasketService, useValue: basketService },

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -10,7 +10,6 @@ import { UserService } from '../Services/user.service'
 import { type ComponentFixture, TestBed } from '@angular/core/testing'
 import { LoginComponent } from './login.component'
 import { RouterTestingModule } from '@angular/router/testing'
-import { ReactiveFormsModule } from '@angular/forms'
 
 import { MatIconModule } from '@angular/material/icon'
 import { MatCheckboxModule } from '@angular/material/checkbox'
@@ -70,7 +69,6 @@ describe('LoginComponent', () => {
             imports: [RouterTestingModule.withRoutes([
                     { path: 'search', component: SearchResultComponent }
                 ]),
-                ReactiveFormsModule,
                 CookieModule.forRoot(),
                 TranslateModule.forRoot(),
                 MatCheckboxModule,
@@ -114,28 +112,28 @@ describe('LoginComponent', () => {
     })
 
     it('should have email as compulsory', () => {
-        component.emailControl.setValue('')
-        expect(component.emailControl.valid).toBeFalsy()
-        component.emailControl.setValue('Value')
-        expect(component.emailControl.valid).toBe(true)
+        component.loginModel.update((model) => ({ ...model, email: '' }))
+        expect(component.loginForm.email().valid()).toBeFalsy()
+        component.loginModel.update((model) => ({ ...model, email: 'Value' }))
+        expect(component.loginForm.email().valid()).toBe(true)
     })
 
     it('should have password as compulsory', () => {
-        component.passwordControl.setValue('')
-        expect(component.passwordControl.valid).toBeFalsy()
-        component.passwordControl.setValue('Value')
-        expect(component.passwordControl.valid).toBe(true)
+        component.loginModel.update((model) => ({ ...model, password: '' }))
+        expect(component.loginForm.password().valid()).toBeFalsy()
+        component.loginModel.update((model) => ({ ...model, password: 'Value' }))
+        expect(component.loginForm.password().valid()).toBe(true)
     })
 
     it('should have remember-me checked if email token is present as in localStorage', () => {
         localStorage.setItem('email', 'a@a')
         component.ngOnInit()
-        expect(component.rememberMe.value).toBe(true)
+        expect(component.loginModel().rememberMe).toBe(true)
     })
 
     it('should have remember-me unchecked if email token is not present in localStorage', () => {
         component.ngOnInit()
-        expect(component.rememberMe.value).toBeFalsy()
+        expect(component.loginModel().rememberMe).toBeFalsy()
     })
 
     it('should flag OAuth as disabled if server is running on unauthorized redirect URI', () => {
@@ -143,57 +141,62 @@ describe('LoginComponent', () => {
     })
 
     it('forwards to main page after successful login', async () => {
+        component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
         userService.login.mockReturnValue(of({}))
-        component.login()
-        await fixture.whenStable()
+        await component.login()
         expect(location.path()).toBe('/search')
     })
 
-    it('stores the returned authentication token in localStorage', () => {
+    it('stores the returned authentication token in localStorage', async () => {
+        component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
         userService.login.mockReturnValue(of({ token: 'token' }))
-        component.login()
+        await component.login()
         expect(localStorage.getItem('token')).toBe('token')
     })
 
-    it('puts the returned basket id into browser session storage', () => {
+    it('puts the returned basket id into browser session storage', async () => {
+        component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
         userService.login.mockReturnValue(of({ bid: 4711 }))
-        component.login()
+        await component.login()
         expect(sessionStorage.getItem('bid')).toBe('4711')
     })
 
-    it('removes authentication token and basket id on failed login attempt', () => {
+    it('removes authentication token and basket id on failed login attempt', async () => {
+        component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
         userService.login.mockReturnValue(throwError({ error: 'Error' }))
-        component.login()
+        await component.login()
         expect(localStorage.getItem('token')).toBeNull()
         expect(sessionStorage.getItem('bid')).toBeNull()
     })
 
-    it('returns error message from server to client on failed login attempt', () => {
+    it('returns error message from server to client on failed login attempt', async () => {
+        component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
         userService.login.mockReturnValue(throwError({ error: 'Error' }))
-        component.login()
-        expect(component.error).toBeTruthy()
+        await component.login()
+        expect(component.error()).toBeTruthy()
     })
 
-    it('sets form to pristine on failed login attempt', () => {
+    it('resets touched state on failed login attempt', async () => {
+        component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
+        component.loginForm.email().markAsTouched()
+        component.loginForm.password().markAsTouched()
         userService.login.mockReturnValue(throwError({ error: 'Error' }))
-        component.login()
-        expect(component.emailControl.pristine).toBe(true)
-        expect(component.passwordControl.pristine).toBe(true)
+        await component.login()
+        expect(component.loginForm.email().touched()).toBe(false)
+        expect(component.loginForm.password().touched()).toBe(false)
     })
 
-    it('puts current email into "email" cookie on successful login with remember-me checkbox ticked', () => {
+    it('puts current email into "email" cookie on successful login with remember-me checkbox ticked', async () => {
         userService.login.mockReturnValue(of({}))
-        component.emailControl.setValue('horst@juice-sh.op')
-        component.rememberMe.setValue(true)
-        component.login()
+        component.loginModel.update((model) => ({ ...model, email: 'horst@juice-sh.op', password: 'p', rememberMe: true }))
+        await component.login()
         expect(localStorage.getItem('email')).toBe('horst@juice-sh.op')
     })
 
-    it('puts current email into "email" cookie on failed login with remember-me checkbox ticked', () => {
+    it('puts current email into "email" cookie on failed login with remember-me checkbox ticked', async () => {
         userService.login.mockReturnValue(throwError({ error: 'Error' }))
-        component.emailControl.setValue('horst@juice-sh.op')
-        component.rememberMe.setValue(true)
-        component.login()
+        component.loginModel.update((model) => ({ ...model, email: 'horst@juice-sh.op', password: 'p', rememberMe: true }))
+        await component.login()
         expect(localStorage.getItem('email')).toBe('horst@juice-sh.op')
     })
 
@@ -219,8 +222,8 @@ describe('LoginComponent', () => {
             expect(compiled.querySelector('#newCustomerLink a')).toBeTruthy()
         })
 
-        it('should show the error message banner when component.error is set', () => {
-            component.error = 'Invalid credentials'
+        it('should show the error message banner when an error is set', () => {
+            component.error.set('Invalid credentials')
             fixture.detectChanges()
             const errorEl = (fixture.nativeElement as HTMLElement).querySelector('.error')
             expect(errorEl?.textContent).toContain('Invalid credentials')
@@ -255,8 +258,7 @@ describe('LoginComponent', () => {
 
         it('should submit the form when email and password are provided', () => {
             const loginSpy = vi.spyOn(component, 'login')
-            component.emailControl.setValue('user@example.com')
-            component.passwordControl.setValue('password')
+            component.loginModel.update((model) => ({ ...model, email: 'user@example.com', password: 'password' }))
             fixture.detectChanges()
 
             const form = (fixture.nativeElement as HTMLElement).querySelector('#login-form') as HTMLFormElement
@@ -329,18 +331,18 @@ describe('LoginComponent', () => {
             const router = (component as any).router
             const navSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true as any)
             ;(component as any).route = { snapshot: { queryParamMap: { get: () => '/profile' } } }
+            component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
             userService.login.mockReturnValue(of({ token: 't', bid: 1 }))
-            component.login()
-            await fixture.whenStable()
+            await component.login()
             expect(navSpy).toHaveBeenCalledWith('/profile')
         })
 
         it('should log and continue when merging guest basket fails', async () => {
             console.log = vi.fn()
             basketService.mergeGuestBasketIntoUserBasket.mockReturnValue(throwError('mergeErr'))
+            component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
             userService.login.mockReturnValue(of({ token: 't', bid: 1 }))
-            component.login()
-            await fixture.whenStable()
+            await component.login()
             expect(console.log).toHaveBeenCalledWith('mergeErr')
             expect(basketService.updateNumberOfCartItems).toHaveBeenCalled()
         })
@@ -348,11 +350,11 @@ describe('LoginComponent', () => {
         it('should redirect to 2FA page when login requires a TOTP token', async () => {
             const router = (component as any).router
             const navSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true as any)
+            component.loginModel.update((model) => ({ ...model, email: 'a@a', password: 'p' }))
             userService.login.mockReturnValue(throwError({
                 error: { status: 'totp_token_required', data: { tmpToken: 'tmp' } }
             }))
-            component.login()
-            await fixture.whenStable()
+            await component.login()
             expect(localStorage.getItem('totp_tmp_token')).toBe('tmp')
             expect(navSpy).toHaveBeenCalledWith(['/2fa/enter'])
             localStorage.removeItem('totp_tmp_token')

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -6,8 +6,9 @@
 import { CookieService } from 'ngy-cookie'
 import { WindowRefService } from '../Services/window-ref.service'
 import { ActivatedRoute, Router, RouterLink } from '@angular/router'
-import { Component, NgZone, type OnInit, inject, ChangeDetectionStrategy } from '@angular/core'
-import { UntypedFormControl, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms'
+import { Component, type OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core'
+import { FormsModule } from '@angular/forms'
+import { FormField, form, minLength, required, submit } from '@angular/forms/signals'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { UserService } from '../Services/user.service'
 import { faEye, faEyeSlash, faKey } from '@fortawesome/free-solid-svg-icons'
@@ -21,7 +22,7 @@ import { MatIconButton, MatButtonModule } from '@angular/material/button'
 import { MatInputModule } from '@angular/material/input'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatFormFieldModule, MatLabel, MatError, MatSuffix } from '@angular/material/form-field'
-import { of } from 'rxjs'
+import { firstValueFrom, of } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 
 import { MatCardModule } from '@angular/material/card'
@@ -35,7 +36,7 @@ const oauthProviderUrl = 'https://accounts.google.com/o/oauth2/v2/auth'
   selector: 'app-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
-  imports: [MatCardModule, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, ReactiveFormsModule, MatError, MatIconButton, MatSuffix, MatTooltip, RouterLink, MatButtonModule, MatIconModule, MatCheckbox]
+  imports: [MatCardModule, MatFormFieldModule, MatLabel, TranslateModule, MatInputModule, FormsModule, FormField, MatError, MatIconButton, MatSuffix, MatTooltip, RouterLink, MatButtonModule, MatIconModule, MatCheckbox]
 })
 
 export class LoginComponent implements OnInit {
@@ -46,16 +47,21 @@ export class LoginComponent implements OnInit {
   private readonly router = inject(Router)
   private readonly route = inject(ActivatedRoute)
   private readonly basketService = inject(BasketService)
-  private readonly ngZone = inject(NgZone)
 
-  public emailControl = new UntypedFormControl('', [Validators.required])
+  public readonly loginModel = signal({
+    email: '',
+    password: '',
+    rememberMe: false
+  })
 
-  public passwordControl = new UntypedFormControl('', [Validators.required, Validators.minLength(1)])
+  public readonly loginForm = form(this.loginModel, (s) => {
+    required(s.email)
+    required(s.password)
+    minLength(s.password, 1)
+  })
 
   public hide = true
-  public user: any
-  public rememberMe: UntypedFormControl = new UntypedFormControl(false)
-  public error: any
+  public error = signal<any>(null)
   public clientId = '1005568560502-6hm16lef8oh46hr2d98vf2ohlnj4nfhq.apps.googleusercontent.com'
   public oauthUnavailable = true
   public redirectUri = ''
@@ -64,14 +70,7 @@ export class LoginComponent implements OnInit {
 
   ngOnInit (): void {
     const email = localStorage.getItem('email')
-    if (email) {
-      this.user = {}
-      this.user.email = email
-      this.rememberMe.setValue(true)
-    } else {
-      this.rememberMe.setValue(false)
-    }
-
+    this.loginModel.update((model) => ({ ...model, rememberMe: !!email }))
 
     this.redirectUri = `${this.windowRefService.nativeWindow.location.protocol}//${this.windowRefService.nativeWindow.location.host}`
     this.configurationService.getApplicationConfiguration().subscribe({
@@ -93,11 +92,20 @@ export class LoginComponent implements OnInit {
   }
 
   login () {
-    this.user = {}
-    this.user.email = this.emailControl.value
-    this.user.password = this.passwordControl.value
-    this.userService.login(this.user).subscribe({
-      next: (authentication: any) => {
+    return submit(this.loginForm, async () => {
+      const user = {
+        email: this.loginModel().email,
+        password: this.loginModel().password
+      }
+
+      if (this.loginModel().rememberMe) {
+        localStorage.setItem('email', user.email)
+      } else {
+        localStorage.removeItem('email')
+      }
+
+      try {
+        const authentication: any = await firstValueFrom(this.userService.login(user))
         const redirectUrl = this.route.snapshot.queryParamMap.get('redirectUrl') ?? '/search'
         localStorage.setItem('token', authentication.token)
         const expires = new Date()
@@ -105,44 +113,36 @@ export class LoginComponent implements OnInit {
         this.cookieService.put('token', authentication.token, { expires })
         sessionStorage.setItem('bid', authentication.bid)
 
-        this.basketService.mergeGuestBasketIntoUserBasket(authentication.bid)
+        await firstValueFrom(this.basketService.mergeGuestBasketIntoUserBasket(authentication.bid)
           .pipe(
             catchError((err) => {
               console.log(err)
               return of(void 0)
             })
-          )
-          .subscribe(() => {
-            this.completeLogin(redirectUrl)
-          })
-      },
-      error: ({ error }) => {
-        if (error.status && error.data && error.status === 'totp_token_required') {
+          ))
+        await this.completeLogin(redirectUrl)
+      } catch (err: any) {
+        const error = err?.error
+        if (error?.status && error?.data && error.status === 'totp_token_required') {
           localStorage.setItem('totp_tmp_token', error.data.tmpToken)
-          this.ngZone.run(async () => await this.router.navigate(['/2fa/enter']))
+          await this.router.navigate(['/2fa/enter'])
           return
         }
         localStorage.removeItem('token')
         this.cookieService.remove('token')
         sessionStorage.removeItem('bid')
-        this.error = error
+        this.error.set(error)
         this.userService.isLoggedIn.next(false)
-        this.emailControl.markAsPristine()
-        this.passwordControl.markAsPristine()
+        this.loginForm.email().reset()
+        this.loginForm.password().reset()
       }
     })
-
-    if (this.rememberMe.value) {
-      localStorage.setItem('email', this.user.email)
-    } else {
-      localStorage.removeItem('email')
-    }
   }
 
-  private completeLogin (redirectUrl: string): void {
+  private completeLogin (redirectUrl: string): Promise<boolean> {
     this.basketService.updateNumberOfCartItems()
     this.userService.isLoggedIn.next(true)
-    this.ngZone.run(async () => await this.router.navigateByUrl(redirectUrl))
+    return this.router.navigateByUrl(redirectUrl)
   }
 
   googleLogin () {

--- a/frontend/src/app/register/register.component.html
+++ b/frontend/src/app/register/register.component.html
@@ -7,7 +7,7 @@
   <mat-card appearance="outlined" class="mat-elevation-z6 mdc-card">
     <h1 class="mat-headline-medium" translate>TITLE_REGISTRATION</h1>
 
-    <div class="error">{{ error() }}</div>
+    <div class="error" role="alert">{{ error() }}</div>
 
     <form class="form-container" id="registration-form" (ngSubmit)="save()">
 

--- a/frontend/src/app/register/register.component.scss
+++ b/frontend/src/app/register/register.component.scss
@@ -35,6 +35,10 @@ mat-slide-toggle {
   margin-bottom: $space-xs;
 }
 
+.error {
+  margin-bottom: $space-m;
+}
+
 .form-container {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/register/register.component.spec.ts
+++ b/frontend/src/app/register/register.component.spec.ts
@@ -10,7 +10,8 @@ import { SecurityQuestionService } from '../Services/security-question.service'
 import { provideHttpClientTesting } from '@angular/common/http/testing'
 import { type ComponentFixture, TestBed } from '@angular/core/testing'
 import { RegisterComponent } from './register.component'
-import { RouterTestingModule } from '@angular/router/testing'
+import { provideRouter } from '@angular/router'
+import { provideLocationMocks } from '@angular/common/testing'
 import { Location } from '@angular/common'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatButtonModule } from '@angular/material/button'
@@ -48,9 +49,7 @@ describe('RegisterComponent', () => {
         }
         userService.save.mockReturnValue(of({}))
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([
-                    { path: 'login', component: LoginComponent }
-                ]),
+            imports: [
                 TranslateModule.forRoot(),
                 MatCardModule,
                 MatFormFieldModule,
@@ -65,6 +64,8 @@ describe('RegisterComponent', () => {
                 MatSlideToggleModule,
                 RegisterComponent, LoginComponent],
             providers: [
+                provideRouter([{ path: 'login', component: LoginComponent }]),
+                provideLocationMocks(),
                 { provide: SecurityAnswerService, useValue: securityAnswerService },
                 { provide: SecurityQuestionService, useValue: securityQuestionService },
                 { provide: UserService, useValue: userService },

--- a/frontend/src/app/register/register.component.spec.ts
+++ b/frontend/src/app/register/register.component.spec.ts
@@ -232,5 +232,13 @@ describe('RegisterComponent', () => {
             const link = compiled.querySelector('#alreadyACustomerLink a')
             expect(link).toBeTruthy()
         })
+
+        it('should show the error message banner as an alert when an error is set', () => {
+            component.error.set('Invalid registration data')
+            fixture.detectChanges()
+            const errorEl = (fixture.nativeElement as HTMLElement).querySelector('.error')
+            expect(errorEl?.textContent).toContain('Invalid registration data')
+            expect(errorEl?.getAttribute('role')).toBe('alert')
+        })
     })
 })


### PR DESCRIPTION
### Description

This PR migrates the login page from the legacy Reactive Forms approach to the modern Angular Signal Forms API, and aligns its layout, spacing and structure with the registration page that was migrated in #3589. It also fixes the Google login button
wrapping by increasing the minimum card width, and improves error announcements for screen-reader users.

Resolved or fixed issue: none

### Changes

- Signal Forms migration (`login.component.ts`, `login.component.html`)
  - Replaced `UntypedFormControl`/`Validators` with a `signal`-based model and `form()` from `@angular/forms/signals`
  - Switched template bindings from `[formControl]` to `[formField]` and dropped `ReactiveFormsModule`
  - Moved validation into the form schema (`required` for email/password, `minLength` for password)
  - Converted component state (`error`) to a signal
  - Reworked `login()` to use `submit()` with an async action; removed the now-unnecessary `NgZone` wrapper around navigation
  - Replaced the nested `subscribe()` chain with `firstValueFrom` for login and guest-basket merge
  - Reset form state via `loginForm.email().reset()` / `loginForm.password().reset()` instead of `markAsPristine()`
  - Simplified the "remember me" handling: `localStorage.email` is now written/removed directly in `login()`
- Template cleanup (`login.component.html`)
  - Replaced the wrapper `div` with `main` for semantic structure (adds a main landmark)
  - Merged the nested `.mdc-card` wrapper into the `mat-card` class
  - Made the heading translatable (`TITLE_LOGIN`)
  - Removed unused template reference variables (`#email`, `#password`) and the redundant `name` attributes; all `id` attributes used by the tutorial (hacking instructor) and Cypress specs are unchanged
  - Aligned markup structure and indentation with the registration page
- Layout / style fixes (`login.component.scss`)
  - Increased `mat-card` `min-width` from 320px to 410px so the Google login button text no longer wraps
  - Matched the registration card padding (`$space-l $space-xl`) and kept the 25% width on larger screens
  - Added a responsive `@media (max-width: 599.98px)` rule so the card becomes full-width with `$space-m` side margins on small screens
  - Replaced the `nth-child`/negative-margin spacing hacks with a consistent `margin-bottom: $space-m` on `mat-form-field`, a `margin-right` on `.password-toggle-button`, and a `$space-m` bottom margin on the error banner
- Accessibility
  - Added `role="alert"` to the login error banner so failed login attempts are announced by screen readers (WCAG 4.1.3 Status Messages)
  - Mirrored the same `role="alert"` and error-banner spacing on the register page for consistency
- Tests
  - Updated `login.component.spec.ts` to the new signal API (`provideRouter`, `provideLocationMocks`) and expanded coverage of validation and login flows
  - Added assertions for the `role="alert"` error banner on both the login and register pages
  -  Added coverage for the remember-me path where an existing remembered email is cleared from `localStorage` when the checkbox is unticked
  - Added missing error-banner test coverage for the register page
  - Updated `register.component.spec.ts` to use `provideRouter`/`provideLocationMocks` instead of `RouterTestingModule`

Verified with `npm run lint` (ESLint + Stylelint clean) and `npm run test:frontend` (122 files / 1343 tests passing).

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `GitHub Copilot (VS Code Chat)`
    - LLMs and versions: `DeepSeek V4.1 Flash`
    - Prompts: `Migrate the login page to Angular Signals (Signal Forms from @angular/forms/signals); update the template bindings ([formField]) and form validation, rework login() to use submit() and drop the NgZone wrapper, update the component tests, and align the login page styles/structure with the registration page (card padding, form-field spacing, responsiveness, and a wider mat-card so the Google login button does not wrap). Add role="alert" and a uniform bottom margin to the login and register error banners for screen readers and consistent spacing, with regression tests.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines