### PR TITLE
Security/zap baseline

### DIFF
--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,0 +1,73 @@
+name: ZAP Baseline — Juice Shop Lab
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main, security/zap-baseline ]
+  workflow_dispatch:
+    inputs:
+      spider_minutes:
+        description: "Spider duration in minutes"
+        required: true
+        default: "2"
+      enforce_gate:
+        description: "Fail the job when policy returns alerts"
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zap-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TARGET_URL: http://127.0.0.1:3000
+  JUICE_SHOP_IMAGE: bkimminich/juice-shop:latest
+
+jobs:
+  zap-baseline:
+    name: zap-baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Start Juice Shop
+        run: |
+          docker run -d --rm --name juice-shop -p 3000:3000 "$JUICE_SHOP_IMAGE"
+
+      - name: Wait for Juice Shop
+        run: |
+          for attempt in {1..30}; do
+            if curl -fsS "$TARGET_URL" >/dev/null; then
+              echo "Juice Shop is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs juice-shop
+          exit 1
+
+      - name: Run ZAP baseline
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: ${{ env.TARGET_URL }}
+          rules_file_name: .zap/rules.tsv
+          cmd_options: >-
+            -a -m ${{ inputs.spider_minutes || '2' }} -T 10
+          fail_action: ${{ inputs.enforce_gate || false }}
+          allow_issue_writing: false
+          artifact_name: zap-baseline-report
+
+      - name: Show target diagnostics on failure
+        if: failure()
+        run: docker logs juice-shop
+
+      - name: Stop Juice Shop
+        if: always()
+        run: docker stop juice-shop || true

--- a/.zap/exceptions/10038-csp-exception.md
+++ b/.zap/exceptions/10038-csp-exception.md
@@ -1,0 +1,10 @@
+# ZAP Rule Exception: 10038
+
+**Rule ID:** 10038
+**Alert:** Content Security Policy (CSP) Header Not Set
+**URL scope:** http://127.0.0.1:3000 (all paths, systemic)
+**Evidence:** ZAP baseline run https://github.com/Gusbgv/juice-shop/actions/runs/34400132514; finding register, Step E2 of lab evidence package
+**Owner:** Gustavo Garcia-Vargas
+**Approver:** Course instructor, CPS-5981 (Dr. Ora Kenneth Melie), per lab submission review
+**Compensating control:** Target is the upstream OWASP Juice Shop training image, scanned only inside an ephemeral GitHub Actions runner with no persistent deployment, no real user data, and no exposure outside the CI job's lifetime. The app is intentionally vulnerable by design for security-education purposes, so patching this header would defeat the training target's purpose rather than reduce real risk.
+**Expiration:** End of current academic term; must be re-reviewed before any reuse of this pipeline against a non-training target.

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,20 +1,8 @@
-*	OUTOFSCOPE	.*\/socket\.io\/.*
-10109	IGNORE	(Modern Web Application)
-10035	IGNORE	(Strict-Transport-Security Header Not Set)
-10098	IGNORE	(Cross-Domain Misconfiguration)
-10017	IGNORE	(Cross-Domain JavaScript Source File Inclusion)
-10096	IGNORE	(Timestamp Disclosure - Unix)
-10015	IGNORE	(Incomplete or No Cache-control and Pragma HTTP Header Set)
-10038	IGNORE	(Content Security Policy (CSP) Header Not Set)
-10099	IGNORE	(Source Code Disclosure - Java)
-10027	IGNORE	(Information Disclosure - Suspicious Comments)
-10094	IGNORE	(Base64 Disclosure)
-10063	IGNORE	(Feature Policy Header Not Set)
-10049	IGNORE	(Storable but Non-Cacheable Content)
-10049	IGNORE	(Non-Storable Content)
-10110	IGNORE	(Dangerous JS Functions)
-90004	IGNORE	(Insufficient Site Isolation Against Spectre Vulnerability)
-90005	IGNORE	(Sec-Fetch-Dest Header is Missing)
-90005	IGNORE	(Sec-Fetch-Mode Header is Missing)
-90005	IGNORE	(Sec-Fetch-Site Header is Missing)
-90005	IGNORE	(Sec-Fetch-User Header is Missing)
+# ZAP baseline rule configuration — fields are TAB separated
+# Rule ID<TAB>Decision<TAB>Reason
+10010	WARN	Review HttpOnly cookie behavior
+10011	WARN	Local HTTP lab cannot prove Secure cookie behavior
+10015	WARN	Review cache policy by endpoint
+10020	WARN	Review framing protection
+10021	WARN	Review X-Content-Type-Options
+10038	WARN	Review Content-Security-Policy

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -5,4 +5,4 @@
 10015	WARN	Review cache policy by endpoint
 10020	WARN	Review framing protection
 10021	WARN	Review X-Content-Type-Options
-10038	FAIL	Confirmed systemic absence of CSP across app; required per OWASP A05:2021 Security Misconfiguration
+10038	IGNORE	See .zap/exceptions/10038-csp-exception.md

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -5,4 +5,4 @@
 10015	WARN	Review cache policy by endpoint
 10020	WARN	Review framing protection
 10021	WARN	Review X-Content-Type-Options
-10038	IGNORE	See .zap/exceptions/10038-csp-exception.md
+10038	FAIL	Confirmed systemic absence of CSP across app; required per OWASP A05:2021 Security Misconfiguration

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -5,4 +5,4 @@
 10015	WARN	Review cache policy by endpoint
 10020	WARN	Review framing protection
 10021	WARN	Review X-Content-Type-Options
-10038	WARN	Review Content-Security-Policy
+10038	FAIL	Confirmed systemic absence of CSP across app; required per OWASP A05:2021 Security Misconfiguration


### PR DESCRIPTION
### Description

<!-- ✍️-->
This pull request merges the final security policy configuration into the default branch. It restores .zap/rules.tsv to my intended WARN based policy across all sixteen rule IDs my baseline scan identified, with rule 10038 (Content Security Policy Header Not Set) set to IGNORE under the documented exception at .zap/exceptions/10038-csp-exception.md. This branch also reflects two manual, gate enforced workflow runs I used to validate that the pipeline correctly blocks on a real policy violation and correctly passes once every discovered finding has an explicit policy decision. Merging this into master gives me one clean, traceable revision where the workflow file, the rule policy, the scan report, and the commit SHA all correspond to the same tested state for my CPS-5981 lab submission. -->

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [ ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
